### PR TITLE
Add license relationship

### DIFF
--- a/src/pitloom/assemble/spdx3/assembler.py
+++ b/src/pitloom/assemble/spdx3/assembler.py
@@ -17,6 +17,77 @@ from pitloom.core.models import generate_spdx_id
 from pitloom.export.spdx3_json import Spdx3JsonExporter
 
 
+def _build_license_elements(
+    license_id: str,
+    package_spdx_id: str,
+    license_provenance: str,
+    creation_info: spdx3.CreationInfo,
+    doc_name: str,
+    doc_uuid: str,
+) -> tuple[
+    spdx3.simplelicensing_SimpleLicensingText,
+    spdx3.Relationship,
+    spdx3.Relationship,
+]:
+    """Build a SimpleLicensingText element and its hasDeclaredLicense /
+    hasConcludedLicense relationships for a given package.
+
+    Args:
+        license_id: SPDX license identifier string (e.g. ``"Apache-2.0"``)
+                    (the "to" in a relationship).
+        package_spdx_id: SPDX ID of the package the license applies to
+                         (the "from" in a relationship).
+        license_provenance: Human-readable provenance note for the comment field.
+        creation_info: Shared CreationInfo for all new elements.
+        doc_name: Document name used in SPDX ID generation.
+        doc_uuid: Document UUID used in SPDX ID generation.
+
+    Returns:
+        A 3-tuple of ``(SimpleLicensingText, hasDeclaredLicense Relationship,
+        hasConcludedLicense Relationship)``.
+    """
+    license_text = spdx3.simplelicensing_SimpleLicensingText(
+        spdxId=generate_spdx_id("License", doc_name=doc_name, doc_uuid=doc_uuid),
+        creationInfo=creation_info,
+    )
+    license_text.name = license_id
+    license_text.simplelicensing_licenseText = license_id
+    license_text.comment = f"Metadata provenance: license: {license_provenance}"
+
+    # The license actually found in the Software Artifact.
+    rel_has_declared_license = spdx3.Relationship(
+        spdxId=generate_spdx_id(
+            "Relationship", doc_name=f"{doc_name}-declared-license", doc_uuid=doc_uuid
+        ),
+        creationInfo=creation_info,
+        from_=package_spdx_id,
+        relationshipType=spdx3.RelationshipType.hasDeclaredLicense,
+        to=[license_text.spdxId],
+    )
+
+    # The license identified by the SPDX data creator.
+    # This can be more complicated.
+    # For example, if there are mulitple declared licenses,
+    # or if there is no declared licenes but a license
+    # can be concluded from other evidence.
+    # See https://spdx.github.io/spdx-spec/v3.0/model/Licensing/Licensing/
+    # Sort this out in future versions.
+    # Eventually we may need to create the relationships separately,
+    # as hasDeclaredLicense and hasConcludedLicense can be different and
+    # the value of having this helper function will be less clear.
+    rel_has_concluded_license = spdx3.Relationship(
+        spdxId=generate_spdx_id(
+            "Relationship", doc_name=f"{doc_name}-concluded-license", doc_uuid=doc_uuid
+        ),
+        creationInfo=creation_info,
+        from_=package_spdx_id,
+        relationshipType=spdx3.RelationshipType.hasConcludedLicense,
+        to=[license_text.spdxId],
+    )
+
+    return license_text, rel_has_declared_license, rel_has_concluded_license
+
+
 def build(doc: DocumentModel) -> Spdx3JsonExporter:
     """Assemble SPDX 3 elements from a :class:`~pitloom.core.document.DocumentModel`.
 
@@ -134,6 +205,24 @@ def build(doc: DocumentModel) -> Spdx3JsonExporter:
     exporter.add_document(spdx_doc)
     exporter.add_sbom(sbom)
     exporter.add_package(main_package)
+
+    # --- License ---
+    if metadata.license_name:
+        license_elements = _build_license_elements(
+            license_id=metadata.license_name,
+            package_spdx_id=main_package.spdxId,
+            license_provenance=metadata.provenance.get(
+                "license", "Source: pyproject.toml | Field: project.license"
+            ),
+            creation_info=spdx_ci,
+            doc_name=metadata.name,
+            doc_uuid=doc_uuid,
+        )
+        license_text, rel_declared, rel_concluded = license_elements
+        exporter.add_license(license_text)
+        exporter.add_relationship(rel_declared)
+        exporter.add_relationship(rel_concluded)
+        spdx_doc.profileConformance.append(spdx3.ProfileIdentifierType.simpleLicensing)
 
     # --- Dependencies ---
     add_dependencies(

--- a/src/pitloom/export/spdx3_json.py
+++ b/src/pitloom/export/spdx3_json.py
@@ -42,6 +42,16 @@ class Spdx3JsonExporter:
         """
         self.object_set.add(package)
 
+    def add_license(
+        self, license_text: spdx3.simplelicensing_SimpleLicensingText
+    ) -> None:
+        """Add a SimpleLicensingText element to the document.
+
+        Args:
+            license_text: The simplelicensing_SimpleLicensingText object
+        """
+        self.object_set.add(license_text)
+
     def add_relationship(self, relationship: spdx3.Relationship) -> None:
         """Add a relationship to the document.
 


### PR DESCRIPTION
Simple license relationship.

It assumes that the declared license and the concluded license are the same (not always true).