### PR TITLE
Fix pyproject.toml extraction when [project] is not exist

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
+exclude = tests/fixtures
 extend-ignore = E203
 max-line-length = 88

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,12 +47,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        include:
-          - os: windows-latest
-            python-version: "3.10"
-          - os: macos-latest
-            python-version: "3.10"
+        python-version: ["3.10", "3.14"]
+        # python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # include:
+        #   - os: windows-latest
+        #     python-version: "3.10"
+        #   - os: macos-latest
+        #     python-version: "3.10"
       fail-fast: true
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.14"]
       fail-fast: true
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,15 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Full release notes: <https://github.com/bact/pitloom/releases>
-- Commit history: <https://github.com/bact/pitloom/compare/v0.4.1...v0.5.0>
+- Commit history: <https://github.com/bact/pitloom/compare/v0.5.0...v0.5.1>
+
+## [0.5.1] - 2026-04-29
+
+### Changed
+
+- Fallback gracefully if `[project]` is not found in `pyproject.toml` ([#63])
+
+[#63]: https://github.com/bact/pitloom/pull/63
 
 ## [0.5.0] - 2026-04-29
 
@@ -109,6 +117,7 @@ release because "Loom" and "Pyloom" were unavailable on PyPI.
 
 ---
 
+[0.5.1]: https://github.com/bact/pitloom/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/bact/pitloom/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/bact/pitloom/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/bact/pitloom/compare/v0.3.0...v0.4.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ abstract: Automated transparency, woven from the ground up. SBOM generation for 
 repository-code: "https://github.com/bact/pitloom"
 type: software
 doi: 10.5281/zenodo.19243681
-version: 0.5.0
+version: 0.5.1
 license-url: "https://spdx.org/licenses/Apache-2.0"
 keywords:
   - sbom
@@ -21,4 +21,4 @@ keywords:
   - gguf
   - onnx
   - safetensors
-date-released: 2026-04-29
+date-released: 2026-05-06

--- a/README.md
+++ b/README.md
@@ -65,11 +65,16 @@ uv sync --group dev
 Install extras to enable metadata extraction from model files:
 
 ```bash
+pip install -e ".[aimodel]"       # all supported AI model formats
+```
+
+or choose individually:
+
+```bash
 pip install -e ".[fasttext]"      # fastText models
 pip install -e ".[gguf]"          # GGUF models
 pip install -e ".[onnx]"          # ONNX models
 pip install -e ".[safetensors]"   # Safetensors models
-pip install -e ".[aimodel]"       # all of the above
 ```
 
 ## Usage

--- a/codemeta.json
+++ b/codemeta.json
@@ -18,8 +18,8 @@
     "codeRepository": "https://github.com/bact/pitloom",
     "copyrightYear": 2026,
     "dateCreated": "2026-03-27",
-    "dateModified": "2026-04-29",
-    "datePublished": "2026-04-29",
+    "dateModified": "2026-05-06",
+    "datePublished": "2026-05-06",
     "description": "Automated transparency, woven from the ground up. SBOM generation for Python & AI projects. Extract metadata from GGUF, ONNX, PyTorch, and Safetensors models with native Hatchling build-hook support.",
     "developmentStatus": "active",
     "downloadUrl": "https://github.com/bact/pitloom/releases",
@@ -54,5 +54,5 @@
     "programmingLanguage": "Python 3",
     "readme": "https://github.com/bact/pitloom/blob/main/README.md",
     "url": "https://github.com/bact/pitloom",
-    "version": "0.5.0"
+    "version": "0.5.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ pretty = true
 # creation-datetime = "2026-04-01T00:00:00"  # Fixed for reproducibility
 
 [tool.mypy]
+exclude = ["tests/fixtures/"]
 pretty = true
 python_version = "3.10"
 mypy_path = ["src"]
@@ -165,6 +166,7 @@ ignore_missing_imports = true
 module = "spdx_python_model.*"
 
 [tool.pylint.main]
+ignore-paths = ["^tests/fixtures/.*$"]
 init-hook = "import sys; sys.path.insert(0, 'src')" # for IDE's Pylint
 source-roots = ["src"]
 
@@ -196,10 +198,14 @@ pythonpath = ["src"]
 testpaths = ["tests"]
 
 [tool.ruff]
-target-version = "py310"
+exclude = ["tests/fixtures"]
 line-length = 88
+target-version = "py310"
 
 [tool.ruff.lint]
+ignore = [
+    "E501", # line too long, handled by formatter
+]
 select = [
     "E",  # pycodestyle errors
     "W",  # pycodestyle warnings
@@ -208,9 +214,6 @@ select = [
     "B",  # flake8-bugbear
     "C4", # flake8-comprehensions
     "UP", # pyupgrade
-]
-ignore = [
-    "E501", # line too long, handled by formatter
 ]
 
 [tool.ruff.lint.isort]

--- a/src/pitloom/__about__.py
+++ b/src/pitloom/__about__.py
@@ -4,4 +4,4 @@
 
 """Package information for Pitloom."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/src/pitloom/extract/_license.py
+++ b/src/pitloom/extract/_license.py
@@ -23,10 +23,11 @@ from pathlib import Path
 
 _logger = logging.getLogger(__name__)
 
+_AggregatedLicenseMatcher: type | None = None
 try:
     from licenseid import AggregatedLicenseMatcher as _AggregatedLicenseMatcher
 except ImportError:
-    _AggregatedLicenseMatcher = None
+    pass
 
 # Heuristic: single-token SPDX License IDs and expressions like "GPL-3.0-or-later"
 _SPDX_LICENSE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9.\-+]*$")

--- a/src/pitloom/extract/_license.py
+++ b/src/pitloom/extract/_license.py
@@ -23,12 +23,6 @@ from pathlib import Path
 
 _logger = logging.getLogger(__name__)
 
-_AggregatedLicenseMatcher: type | None = None
-try:
-    from licenseid import AggregatedLicenseMatcher as _AggregatedLicenseMatcher
-except ImportError:
-    pass
-
 # Heuristic: single-token SPDX License IDs and expressions like "GPL-3.0-or-later"
 _SPDX_LICENSE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9.\-+]*$")
 # Detects compound SPDX expressions: "MIT OR Apache-2.0", "GPL-2.0 WITH ..."
@@ -85,11 +79,14 @@ def detect_license_from_text(text: str, threshold: float = 0.85) -> str | None:
             db_path,
         )
         return None
-    if _AggregatedLicenseMatcher is None:
+    try:
+        # pylint: disable=import-outside-toplevel
+        from licenseid import AggregatedLicenseMatcher
+    except ImportError:
         _logger.debug("licenseid not installed; skipping license text detection")
         return None
     try:
-        matcher = _AggregatedLicenseMatcher(str(db_path))
+        matcher = AggregatedLicenseMatcher(str(db_path))
         results = matcher.match(text)
         filtered = [r for r in results if r["score"] >= threshold]
         return filtered[0]["license_id"] if filtered else None

--- a/src/pitloom/extract/pyproject.py
+++ b/src/pitloom/extract/pyproject.py
@@ -46,7 +46,7 @@ def read_pyproject(pyproject_path: Path) -> tuple[ProjectMetadata, PitloomConfig
 
     Raises:
         FileNotFoundError: If the file does not exist.
-        ValueError: If the ``[project]`` section is missing or ``name`` is absent.
+        ValueError: If ``pyproject-metadata`` cannot parse the ``[project]`` section.
     """
     if not pyproject_path.exists():
         raise FileNotFoundError(f"pyproject.toml not found at {pyproject_path}")
@@ -55,10 +55,21 @@ def read_pyproject(pyproject_path: Path) -> tuple[ProjectMetadata, PitloomConfig
         data: dict[str, Any] = tomllib.load(f)
 
     project_data: dict[str, Any] = data.get("project", {})
-    if not project_data:
-        raise ValueError("No [project] section found in pyproject.toml")
-    if not project_data.get("name"):
-        raise ValueError("Project name is required in pyproject.toml")
+    pitloom_config = _read_pitloom_config(data)
+
+    name: str = (project_data.get("name") or "").strip()
+
+    if not project_data or not name:
+        license_name, license_prov = detect_license_for_project(pyproject_path.parent)
+        prov: dict[str, str] = {}
+        if name:
+            prov["name"] = "Source: pyproject.toml | Field: project.name"
+        if license_prov:
+            prov["license"] = license_prov
+        return (
+            ProjectMetadata(name=name, license_name=license_name, provenance=prov),
+            pitloom_config,
+        )
 
     dynamic_fields: list[str] = list(project_data.get("dynamic", []))
     version_source: str | None = None
@@ -77,7 +88,6 @@ def read_pyproject(pyproject_path: Path) -> tuple[ProjectMetadata, PitloomConfig
             dynamic_fields = [f for f in dynamic_fields if f != "version"]
 
     data, readme_override = _strip_missing_readme(project_data, pyproject_path, data)
-    pitloom_config = _read_pitloom_config(data)
 
     try:
         std = StandardMetadata.from_pyproject(

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -83,12 +83,12 @@ line-length = 88
         pyproject_path = tmppath / "pyproject.toml"
         pyproject_path.write_text(pyproject_content)
 
-        metadata, config = read_pyproject(pyproject_path)
+        metadata, _ = read_pyproject(pyproject_path)
         assert metadata.name == ""
         assert metadata.version is None
         assert metadata.description is None
-        assert metadata.keywords == []
-        assert metadata.dependencies == []
+        assert not metadata.keywords
+        assert not metadata.dependencies
 
 
 def test_extract_metadata_missing_name() -> None:
@@ -104,7 +104,7 @@ description = "A test package"
         pyproject_path = tmppath / "pyproject.toml"
         pyproject_path.write_text(pyproject_content)
 
-        metadata, config = read_pyproject(pyproject_path)
+        metadata, _ = read_pyproject(pyproject_path)
         assert metadata.name == ""
         assert metadata.version is None
         assert metadata.description is None

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -68,11 +68,14 @@ def test_extract_metadata_missing_file() -> None:
 
 
 def test_extract_metadata_missing_project_section() -> None:
-    """Test extraction with missing [project] section."""
+    """Test graceful fallback when [project] section is absent."""
     pyproject_content = """
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.black]
+line-length = 88
 """
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -80,12 +83,16 @@ build-backend = "hatchling.build"
         pyproject_path = tmppath / "pyproject.toml"
         pyproject_path.write_text(pyproject_content)
 
-        with pytest.raises(ValueError, match="No \\[project\\] section found"):
-            read_pyproject(pyproject_path)
+        metadata, config = read_pyproject(pyproject_path)
+        assert metadata.name == ""
+        assert metadata.version is None
+        assert metadata.description is None
+        assert metadata.keywords == []
+        assert metadata.dependencies == []
 
 
 def test_extract_metadata_missing_name() -> None:
-    """Test extraction with missing project name."""
+    """Test graceful fallback when project name is absent from [project] section."""
     pyproject_content = """
 [project]
 version = "1.0.0"
@@ -97,8 +104,31 @@ description = "A test package"
         pyproject_path = tmppath / "pyproject.toml"
         pyproject_path.write_text(pyproject_content)
 
-        with pytest.raises(ValueError, match="Project name is required"):
-            read_pyproject(pyproject_path)
+        metadata, config = read_pyproject(pyproject_path)
+        assert metadata.name == ""
+        assert metadata.version is None
+        assert metadata.description is None
+
+
+def test_extract_metadata_no_project_section_reads_pitloom_config() -> None:
+    """[tool.pitloom] config is still read even when [project] section is absent."""
+    pyproject_content = """
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.pitloom]
+pretty = true
+"""
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        metadata, config = read_pyproject(pyproject_path)
+        assert metadata.name == ""
+        assert config.pretty is True
 
 
 def test_extract_metadata_dynamic_version() -> None:


### PR DESCRIPTION
The extraction should not throw ValueError but fallback to default values instead if there is no `[project]` section in `pyproject.toml` file.

Some projects, like Mistral in #62, do not have `[project]`. Have to deal with that.
