### PR TITLE
Command-line option to generate SBOM of standalone AI model

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install . --group test
+          pip install ".[onnx,safetensors]" --group test
 
       - name: Run tests
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ and this project adheres to
 ### Added
 
 - `-m` / `--aimodel` command-line option to generate an SBOM for standalone
-  AI model (may not be part of a Python project)
+  AI model (may not be part of a Python project) ([#69])
+
+[#69]: https://github.com/bact/pitloom/pull/69
 
 ## [0.6.0] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,14 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Full release notes: <https://github.com/bact/pitloom/releases>
-- Commit history: <https://github.com/bact/pitloom/compare/v0.5.1...v0.6.0>
+- Commit history: <https://github.com/bact/pitloom/compare/v0.6.0...v0.6.1>
+
+## [0.6.1] - 2026-05-07
+
+### Added
+
+- `-m` / `--aimodel` command-line option to generate an SBOM for standalone
+  AI model (may not be part of a Python project)
 
 ## [0.6.0] - 2026-05-07
 
@@ -132,6 +139,7 @@ release because "Loom" and "Pyloom" were unavailable on PyPI.
 
 ---
 
+[0.6.1]: https://github.com/bact/pitloom/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/bact/pitloom/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/bact/pitloom/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/bact/pitloom/compare/v0.4.1...v0.5.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ abstract: Automated transparency, woven from the ground up. SBOM generation for 
 repository-code: "https://github.com/bact/pitloom"
 type: software
 doi: 10.5281/zenodo.19243681
-version: 0.6.0
+version: 0.6.1
 license-url: "https://spdx.org/licenses/Apache-2.0"
 keywords:
   - sbom

--- a/codemeta.json
+++ b/codemeta.json
@@ -54,5 +54,5 @@
     "programmingLanguage": "Python 3",
     "readme": "https://github.com/bact/pitloom/blob/main/README.md",
     "url": "https://github.com/bact/pitloom",
-    "version": "0.6.0"
+    "version": "0.6.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,10 +62,11 @@ aimodel = [
     "onnx>=1.14.1",
     "safetensors[numpy]>=0.4.0",
 ]
+license = ["licenseid>=0.2.2"]
+
 fasttext = ["fasttext>=0.9.3"] # or fasttext-community>=0.11.7
 gguf = ["gguf>=0.10.0"]
 hdf5 = ["h5py>=3.0.0"]
-license = ["licenseid>=0.2.2"]
 numpy = ["numpy>=1.24.0"]
 onnx = ["onnx>=1.14.1"]
 pytorch = ["fickling>=0.1.10"]

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from pitloom.__about__ import __version__
-from pitloom.assemble import generate_sbom
+from pitloom.assemble import generate_ai_model_sbom, generate_sbom
 from pitloom.core.creation import CreationMetadata
 
 _SPDX3_JSON_EXT = ".spdx3.json"
@@ -74,9 +74,27 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "project_dir",
         type=Path,
+        nargs="?",
+        default=None,
         help=(
             "Path to the project directory "
-            "(containing pyproject.toml, setup.cfg, or setup.py)"
+            "(containing pyproject.toml, setup.cfg, or setup.py). "
+            "Required unless -m/--aimodel is used."
+        ),
+    )
+    parser.add_argument(
+        "-m",
+        "--aimodel",
+        dest="aimodel",
+        type=Path,
+        default=None,
+        metavar="MODEL_FILE",
+        help=(
+            "Path to an AI model file. "
+            "Generate a standalone SBOM for the model as an AIPackage, "
+            "without requiring a project directory. "
+            "Supported formats: GGUF, ONNX, Safetensors, PyTorch, "
+            "Keras, HDF5, NumPy, fastText."
         ),
     )
     parser.add_argument(
@@ -492,6 +510,19 @@ def _resolve_output_path(explicit: Path | None, project_dir: Path) -> Path:
         return Path(f"sbom{_SPDX3_JSON_EXT}")
 
 
+def _resolve_model_output_path(explicit: Path | None, model_path: Path) -> Path:
+    """Return the SBOM output path for a standalone model SBOM.
+
+    Uses the explicit ``-o`` path when given; otherwise derives the name from
+    the model file stem (e.g. ``llama-7b.gguf`` → ``llama-7b.spdx3.json``).
+    """
+    if explicit is not None:
+        return explicit
+    return model_path.with_suffix("").with_suffix("").parent / (
+        model_path.stem + _SPDX3_JSON_EXT
+    )
+
+
 def main() -> int:
     """Main entry point for the Pitloom CLI.
 
@@ -501,6 +532,64 @@ def main() -> int:
     parser = _build_parser()
     args = parser.parse_args()
 
+    if args.aimodel is not None:
+        return _run_model_mode(args)
+
+    if args.project_dir is None:
+        print(
+            "Error: project_dir is required unless -m/--aimodel is used.",
+            file=sys.stderr,
+        )
+        return 1
+
+    return _run_project_mode(args)
+
+
+def _run_model_mode(args: argparse.Namespace) -> int:
+    """Generate a standalone SBOM for a single AI model file."""
+    try:
+        model_path: Path = args.aimodel.resolve()
+        if not model_path.exists():
+            print(f"Error: Model file not found: {model_path}", file=sys.stderr)
+            return 1
+
+        from pitloom.core.config import (
+            PitloomConfig,  # pylint: disable=import-outside-toplevel
+        )
+
+        pitloom_config = PitloomConfig()
+        creation = _resolve_creation_metadata(args, pitloom_config)
+        effective_pretty = args.pretty if args.pretty is not None else False
+        effective_describe = (
+            bool(args.describe_relationship)
+            if args.describe_relationship is not None
+            else False
+        )
+
+        output_path = _resolve_model_output_path(args.output, model_path)
+
+        if args.verbose:
+            print(f"Pitloom version: {__version__}")
+            print(f"Model file      : {model_path}")
+            print(f"Output path     : {output_path}")
+
+        generate_ai_model_sbom(
+            model_path,
+            output_path=output_path,
+            creation_info=creation.to_creation_metadata(),
+            pretty=effective_pretty,
+            describe_relationship=effective_describe,
+        )
+        return 0
+
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print(f"Error generating model SBOM: {e}", file=sys.stderr)
+        traceback.print_exc()
+        return 1
+
+
+def _run_project_mode(args: argparse.Namespace) -> int:
+    """Generate a full project SBOM from a project directory."""
     try:
         project_dir, _ = _resolve_project_paths(args)
         if project_dir is None:

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -15,7 +15,10 @@ from typing import Any
 
 from pitloom.__about__ import __version__
 from pitloom.assemble import generate_ai_model_sbom, generate_sbom
+from pitloom.core.config import PitloomConfig
 from pitloom.core.creation import CreationMetadata
+from pitloom.extract.pyproject import read_pyproject
+from pitloom.extract.setuptools import read_setuptools
 
 _SPDX3_JSON_EXT = ".spdx3.json"
 _PROJECT_PYPROJECT_SOURCE = "pyproject.toml"
@@ -260,14 +263,9 @@ def _load_project_config(project_dir: Path) -> tuple[Any, Path | None]:
     Tries ``pyproject.toml`` first, then ``setup.cfg``/``setup.py``.
     Returns a 2-tuple of ``(PitloomConfig, config_file_path)``.
     """
-    # pylint: disable=import-outside-toplevel
-    from pitloom.core.config import PitloomConfig
-
     pyproject_path = project_dir / "pyproject.toml"
     if pyproject_path.exists():
         try:
-            from pitloom.extract.pyproject import read_pyproject
-
             _, config = read_pyproject(pyproject_path)
             return config, pyproject_path
         except Exception:  # pylint: disable=broad-exception-caught
@@ -277,8 +275,6 @@ def _load_project_config(project_dir: Path) -> tuple[Any, Path | None]:
     setup_py = project_dir / "setup.py"
     if setup_cfg.exists() or setup_py.exists():
         try:
-            from pitloom.extract.setuptools import read_setuptools
-
             _, config = read_setuptools(project_dir)
             config_path = setup_cfg if setup_cfg.exists() else setup_py
             return config, config_path
@@ -487,15 +483,10 @@ def _resolve_output_path(explicit: Path | None, project_dir: Path) -> Path:
         return explicit
 
     try:
-        # pylint: disable=import-outside-toplevel
         pyproject_path = project_dir / "pyproject.toml"
         if pyproject_path.exists():
-            from pitloom.extract.pyproject import read_pyproject
-
             metadata, pitloom_config = read_pyproject(pyproject_path)
         else:
-            from pitloom.extract.setuptools import read_setuptools
-
             metadata, pitloom_config = read_setuptools(project_dir)
 
         if pitloom_config.sbom_basename:
@@ -552,10 +543,6 @@ def _run_model_mode(args: argparse.Namespace) -> int:
         if not model_path.exists():
             print(f"Error: Model file not found: {model_path}", file=sys.stderr)
             return 1
-
-        from pitloom.core.config import (
-            PitloomConfig,  # pylint: disable=import-outside-toplevel
-        )
 
         pitloom_config = PitloomConfig()
         creation = _resolve_creation_metadata(args, pitloom_config)

--- a/src/pitloom/assemble/__init__.py
+++ b/src/pitloom/assemble/__init__.py
@@ -8,11 +8,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pitloom.assemble.spdx3.document import build
+from pitloom.assemble.spdx3.document import build, build_model
 from pitloom.assemble.spdx3.fragments import merge_fragments
 from pitloom.core.creation import CreationMetadata
 from pitloom.core.document import DocumentModel
 from pitloom.core.models import get_wheel_files
+from pitloom.extract.ai_model import read_ai_model
 from pitloom.extract.pyproject import read_pyproject
 from pitloom.extract.scanner import scan_project_for_ai_models
 
@@ -83,4 +84,45 @@ def generate_sbom(
     return sbom_json
 
 
-__all__ = ["generate_sbom"]
+def generate_ai_model_sbom(
+    model_path: Path,
+    output_path: Path | None = None,
+    creation_info: CreationMetadata | None = None,
+    pretty: bool = False,
+    describe_relationship: bool = False,
+) -> str:
+    """Generate a standalone SPDX 3 SBOM for a single AI model file.
+
+    The model is treated as an ``ai_AIPackage`` root element — no surrounding
+    Python project is required.
+
+    Args:
+        model_path: Path to the AI model file (GGUF, ONNX, Safetensors, etc.).
+        output_path: If given, the JSON-LD output is also written to this path.
+        creation_info: Creator and timestamp metadata.  Defaults to a
+            ``CreationMetadata`` with creator ``"Pitloom"`` and current UTC time.
+        pretty: Indent JSON output with 2 spaces when ``True``.
+        describe_relationship: Add human-readable text to SPDX relationships.
+
+    Returns:
+        JSON-LD string of the generated SPDX 3 SBOM.
+
+    Raises:
+        FileNotFoundError: If *model_path* does not exist.
+        ValueError: If the model format is unsupported or cannot be parsed.
+    """
+    model = read_ai_model(model_path)
+    exporter = build_model(model, creation_info or CreationMetadata())
+
+    sbom_json = exporter.to_json(
+        pretty=pretty,
+        describe_relationship=describe_relationship,
+    )
+
+    if output_path is not None:
+        output_path.write_text(sbom_json, encoding="utf-8")
+
+    return sbom_json
+
+
+__all__ = ["generate_ai_model_sbom", "generate_sbom"]

--- a/src/pitloom/assemble/spdx3/document.py
+++ b/src/pitloom/assemble/spdx3/document.py
@@ -11,8 +11,11 @@ from pathlib import Path
 
 from spdx_python_model import v3_0_1 as spdx3
 
-from pitloom.assemble.spdx3.ai import add_ai_models
+from pitloom.assemble.spdx3.ai import _build_ai_package, add_ai_models
+from pitloom.assemble.spdx3.dataset import add_datasets_for_model
 from pitloom.assemble.spdx3.deps import add_dependencies, build_license_elements
+from pitloom.core.ai_metadata import AiModelMetadata
+from pitloom.core.creation import CreationMetadata
 from pitloom.core.document import DocumentModel
 from pitloom.core.models import _clear_doc_counters, compute_doc_uuid, generate_spdx_id
 from pitloom.export.spdx3_json import Spdx3JsonExporter
@@ -323,5 +326,115 @@ def build(doc: DocumentModel, merkle_root: str | None = None) -> Spdx3JsonExport
             doc_uuid=doc_uuid,
             exporter=exporter,
         )
+
+    return exporter
+
+
+def build_model(
+    model: AiModelMetadata,
+    creation: CreationMetadata,
+) -> Spdx3JsonExporter:
+    """Assemble a standalone SPDX 3 SBOM for a single AI model file.
+
+    Produces a minimal document containing only the ``ai_AIPackage`` element
+    derived from *model*.  There is no parent Python package — the AI package
+    is itself the root element of the ``software_Sbom``.
+
+    Args:
+        model: Extracted AI model metadata.
+        creation: Creator and timestamp metadata for the SBOM document.
+
+    Returns:
+        A populated :class:`~pitloom.export.spdx3_json.Spdx3JsonExporter`.
+    """
+    doc_name: str = model.name or model.format_info.file_name or "model"
+
+    created_at = (
+        _to_spdx3_datetime(_parse_iso_datetime(creation.creation_datetime))
+        if creation.creation_datetime
+        else _spdx3_utc_now()
+    )
+
+    exporter = Spdx3JsonExporter()
+    doc_uuid = compute_doc_uuid(
+        name=doc_name,
+        version=model.version or "unknown",
+        dependencies=[],
+        merkle_root=None,
+    )
+    _clear_doc_counters(doc_uuid)
+
+    spdx_ci = spdx3.CreationInfo(
+        specVersion="3.0.1",
+        created=created_at,
+    )
+    if creation.creation_comment:
+        spdx_ci.comment = creation.creation_comment
+
+    creator = spdx3.Person(
+        spdxId=generate_spdx_id("Person", doc_name=doc_name, doc_uuid=doc_uuid),
+        name=creation.creator_name,
+        creationInfo=spdx_ci,
+    )
+    if creation.creator_email:
+        creator.externalIdentifier = [
+            spdx3.ExternalIdentifier(
+                externalIdentifierType=spdx3.ExternalIdentifierType.email,
+                identifier=creation.creator_email,
+            )
+        ]
+
+    tool: spdx3.Tool | None = None
+    if creation.creation_tool:
+        tool = spdx3.Tool(
+            spdxId=generate_spdx_id("Tool", doc_name=doc_name, doc_uuid=doc_uuid),
+            name=creation.creation_tool,
+            creationInfo=spdx_ci,
+        )
+
+    spdx_ci.createdBy = [creator.spdxId]
+    if tool is not None:
+        spdx_ci.createdUsing = [tool.spdxId]
+
+    exporter.add_creation_info(spdx_ci)
+    exporter.add_person(creator)
+    if tool is not None:
+        exporter.object_set.add(tool)
+
+    ai_pkg = _build_ai_package(model, spdx_ci, doc_name, doc_uuid)
+    exporter.add_package(ai_pkg)
+
+    if model.datasets:
+        add_datasets_for_model(
+            ai_package_spdx_id=ai_pkg.spdxId,
+            datasets=model.datasets,
+            creation_info=spdx_ci,
+            doc_name=doc_name,
+            doc_uuid=doc_uuid,
+            exporter=exporter,
+        )
+
+    sbom = spdx3.software_Sbom(
+        spdxId=generate_spdx_id("Sbom", doc_name=doc_name, doc_uuid=doc_uuid),
+        creationInfo=spdx_ci,
+        rootElement=[ai_pkg.spdxId],
+    )
+    sbom.software_sbomType = [spdx3.software_SbomType.build]
+
+    spdx_doc = spdx3.SpdxDocument(
+        spdxId=generate_spdx_id("SpdxDocument", doc_name=doc_name, doc_uuid=doc_uuid),
+        creationInfo=spdx_ci,
+        rootElement=[sbom.spdxId],
+    )
+    spdx_doc.profileConformance = [
+        spdx3.ProfileIdentifierType.core,
+        spdx3.ProfileIdentifierType.software,
+        spdx3.ProfileIdentifierType.ai,
+    ]
+    if model.datasets:
+        spdx_doc.profileConformance.append(spdx3.ProfileIdentifierType.dataset)
+
+    exporter.add_document(spdx_doc)
+    exporter.add_sbom(sbom)
 
     return exporter

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -252,6 +252,7 @@ def test_model_mode_no_project_dir_required(
         pretty: bool = False,
         describe_relationship: bool = False,
     ) -> str:
+        _ = (creation_info, pretty, describe_relationship)
         captured["model_path"] = model_path
         captured["output_path"] = output_path
         return "{}"
@@ -277,6 +278,7 @@ def test_model_mode_explicit_output_path(
         pretty: bool = False,
         describe_relationship: bool = False,
     ) -> str:
+        _ = (model_path, creation_info, pretty, describe_relationship)
         captured["output_path"] = output_path
         return "{}"
 
@@ -301,6 +303,7 @@ def test_model_mode_default_output_path_uses_stem(
         pretty: bool = False,
         describe_relationship: bool = False,
     ) -> str:
+        _ = (model_path, creation_info, pretty, describe_relationship)
         captured["output_path"] = output_path
         return "{}"
 
@@ -325,6 +328,7 @@ def test_model_mode_passes_pretty_flag(
         pretty: bool = False,
         describe_relationship: bool = False,
     ) -> str:
+        _ = (model_path, output_path, creation_info, describe_relationship)
         captured["pretty"] = pretty
         return "{}"
 
@@ -347,6 +351,7 @@ def test_model_mode_passes_creation_info(
         pretty: bool = False,
         describe_relationship: bool = False,
     ) -> str:
+        _ = (model_path, output_path, pretty, describe_relationship)
         captured["creation_info"] = creation_info
         return "{}"
 
@@ -393,6 +398,7 @@ def test_model_mode_verbose_shows_model_path(
         pretty: bool = False,
         describe_relationship: bool = False,
     ) -> str:
+        _ = (model_path, output_path, creation_info, pretty, describe_relationship)
         return "{}"
 
     monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -13,6 +14,10 @@ import pytest
 
 from pitloom import __main__
 from pitloom.core.creation import CreationMetadata
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+SAFETENSORS_FIXTURE = FIXTURE_DIR / "safetensors" / "whisper-tiny-random.safetensors"
+ONNX_FIXTURE = FIXTURE_DIR / "onnx" / "squeezenet1.1-7.onnx"
 
 
 def test_main_uses_pretty_from_pyproject(
@@ -228,3 +233,258 @@ version = "0.1.0"
     assert "Config file" in captured.out
     assert "creation_datetime     : None" in captured.out
     assert "creation_comment      : None" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# -m / --aimodel: model-mode tests
+# ---------------------------------------------------------------------------
+
+
+def test_model_mode_no_project_dir_required(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_generate_model_sbom(
+        model_path: Path,
+        output_path: Path | None = None,
+        creation_info: object | None = None,
+        pretty: bool = False,
+        describe_relationship: bool = False,
+    ) -> str:
+        captured["model_path"] = model_path
+        captured["output_path"] = output_path
+        return "{}"
+
+    monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
+    monkeypatch.setattr(sys, "argv", ["loom", "-m", str(SAFETENSORS_FIXTURE)])
+
+    assert __main__.main() == 0
+    assert captured["model_path"] == SAFETENSORS_FIXTURE.resolve()
+
+
+def test_model_mode_explicit_output_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    explicit_out = tmp_path / "my-model.spdx3.json"
+    captured: dict[str, object] = {}
+
+    def _fake_generate_model_sbom(
+        model_path: Path,
+        output_path: Path | None = None,
+        creation_info: object | None = None,
+        pretty: bool = False,
+        describe_relationship: bool = False,
+    ) -> str:
+        captured["output_path"] = output_path
+        return "{}"
+
+    monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
+    monkeypatch.setattr(
+        sys, "argv", ["loom", "-m", str(ONNX_FIXTURE), "-o", str(explicit_out)]
+    )
+
+    assert __main__.main() == 0
+    assert captured["output_path"] == explicit_out
+
+
+def test_model_mode_default_output_path_uses_stem(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_generate_model_sbom(
+        model_path: Path,
+        output_path: Path | None = None,
+        creation_info: object | None = None,
+        pretty: bool = False,
+        describe_relationship: bool = False,
+    ) -> str:
+        captured["output_path"] = output_path
+        return "{}"
+
+    monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
+    monkeypatch.setattr(sys, "argv", ["loom", "-m", str(SAFETENSORS_FIXTURE)])
+
+    assert __main__.main() == 0
+    out = captured["output_path"]
+    assert isinstance(out, Path)
+    assert out.name == "whisper-tiny-random.spdx3.json"
+
+
+def test_model_mode_passes_pretty_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_generate_model_sbom(
+        model_path: Path,
+        output_path: Path | None = None,
+        creation_info: object | None = None,
+        pretty: bool = False,
+        describe_relationship: bool = False,
+    ) -> str:
+        captured["pretty"] = pretty
+        return "{}"
+
+    monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
+    monkeypatch.setattr(sys, "argv", ["loom", "-m", str(ONNX_FIXTURE), "--pretty"])
+
+    assert __main__.main() == 0
+    assert captured["pretty"] is True
+
+
+def test_model_mode_passes_creation_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_generate_model_sbom(
+        model_path: Path,
+        output_path: Path | None = None,
+        creation_info: object | None = None,
+        pretty: bool = False,
+        describe_relationship: bool = False,
+    ) -> str:
+        captured["creation_info"] = creation_info
+        return "{}"
+
+    monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["loom", "-m", str(SAFETENSORS_FIXTURE), "--creator-name", "TestBot"],
+    )
+
+    assert __main__.main() == 0
+    ci = captured["creation_info"]
+    assert isinstance(ci, CreationMetadata)
+    assert ci.creator_name == "TestBot"
+
+
+def test_model_mode_nonexistent_file_returns_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        sys, "argv", ["loom", "-m", str(tmp_path / "no-such-model.safetensors")]
+    )
+    assert __main__.main() == 1
+
+
+def test_no_args_returns_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["loom"])
+    assert __main__.main() == 1
+    assert "project_dir" in capsys.readouterr().err
+
+
+def test_model_mode_verbose_shows_model_path(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def _fake_generate_model_sbom(
+        model_path: Path,
+        output_path: Path | None = None,
+        creation_info: object | None = None,
+        pretty: bool = False,
+        describe_relationship: bool = False,
+    ) -> str:
+        return "{}"
+
+    monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
+    monkeypatch.setattr(sys, "argv", ["loom", "-m", str(ONNX_FIXTURE), "-v"])
+
+    assert __main__.main() == 0
+    out = capsys.readouterr().out
+    assert str(ONNX_FIXTURE.resolve()) in out
+    assert "Pitloom version" in out
+
+
+# ---------------------------------------------------------------------------
+# -m / --aimodel: integration tests with real model fixtures
+# ---------------------------------------------------------------------------
+
+
+def test_model_mode_safetensors_produces_ai_package(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "whisper.spdx3.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["loom", "-m", str(SAFETENSORS_FIXTURE), "-o", str(out)],
+    )
+
+    assert __main__.main() == 0
+    assert out.exists()
+
+    doc = json.loads(out.read_text())
+    graph = doc.get("@graph", [])
+    types = [node.get("type") for node in graph]
+    assert "ai_AIPackage" in types
+
+
+def test_model_mode_onnx_produces_ai_package(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "squeezenet.spdx3.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["loom", "-m", str(ONNX_FIXTURE), "-o", str(out)],
+    )
+
+    assert __main__.main() == 0
+    assert out.exists()
+
+    doc = json.loads(out.read_text())
+    graph = doc.get("@graph", [])
+    types = [node.get("type") for node in graph]
+    assert "ai_AIPackage" in types
+
+
+def test_model_mode_safetensors_no_software_package(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "whisper.spdx3.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["loom", "-m", str(SAFETENSORS_FIXTURE), "-o", str(out)],
+    )
+
+    assert __main__.main() == 0
+
+    doc = json.loads(out.read_text())
+    graph = doc.get("@graph", [])
+    types = [node.get("type") for node in graph]
+    assert "software_Package" not in types
+
+
+def test_model_mode_onnx_sbom_root_is_ai_package(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    out = tmp_path / "squeezenet.spdx3.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["loom", "-m", str(ONNX_FIXTURE), "-o", str(out)],
+    )
+
+    assert __main__.main() == 0
+
+    doc = json.loads(out.read_text())
+    graph = doc.get("@graph", [])
+    sbom = next((n for n in graph if n.get("type") == "software_Sbom"), None)
+    assert sbom is not None
+    ai_pkg = next((n for n in graph if n.get("type") == "ai_AIPackage"), None)
+    assert ai_pkg is not None
+    assert ai_pkg["spdxId"] in sbom.get("rootElement", [])


### PR DESCRIPTION
The functionality to extract metadata from an AI model exists and can be used programmatically, but does not yet exposed to the command-line interface.

This PR introduces `-m` and `--aimodel` option to use that.

```sh
loom -m <ai_model_file>
```

The model does not need to be in any Python project.