### PR TITLE
Handle None case of spdxId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,12 @@ and this project adheres to
   `/pitloom:enrich` to generate and enrich SBOMs directly from Claude
   Code ([#82])
 
+### Fixed
+
+- Handle None case of spdxId ([#83])
+
 [#82]: https://github.com/bact/pitloom/pull/82
+[#83]: https://github.com/bact/pitloom/pull/83
 
 ## [0.8.0] - 2026-05-29
 

--- a/src/pitloom/assemble/spdx3/ai.py
+++ b/src/pitloom/assemble/spdx3/ai.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from spdx_python_model import v3_0_1 as spdx3
+from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.assemble.spdx3.dataset import add_datasets_for_model
 from pitloom.assemble.spdx3.deps import build_license_elements

--- a/src/pitloom/assemble/spdx3/ai.py
+++ b/src/pitloom/assemble/spdx3/ai.py
@@ -15,7 +15,7 @@ from pitloom.assemble.spdx3.dataset import add_datasets_for_model
 from pitloom.assemble.spdx3.deps import build_license_elements
 from pitloom.core.ai_metadata import AiModelMetadata
 from pitloom.core.models import generate_spdx_id
-from pitloom.export.spdx3_json import Spdx3JsonExporter
+from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 
 # Valid SPDX 3 ai_safetyRiskAssessmentType enum values (lowercase).
 _SAFETY_RISK_VALUES = {"high", "medium", "low", "serious"}
@@ -200,7 +200,7 @@ def add_ai_models(
 
         if ai_model.datasets:
             add_datasets_for_model(
-                ai_package_spdx_id=ai_pkg.spdxId,
+                ai_package_spdx_id=require_spdx_id(ai_pkg),
                 datasets=ai_model.datasets,
                 creation_info=creation_info,
                 doc_name=doc_name,
@@ -211,7 +211,7 @@ def add_ai_models(
         if ai_model.license:
             rel_declared, rel_concluded = build_license_elements(
                 license_id=ai_model.license,
-                package_spdx_id=ai_pkg.spdxId,
+                package_spdx_id=require_spdx_id(ai_pkg),
                 license_provenance=ai_model.provenance.get(
                     "license",
                     "Source: model file / Hugging Face Hub",
@@ -231,7 +231,7 @@ def add_ai_models(
                 doc_uuid=doc_uuid,
             ),
             from_=main_package_spdx_id,
-            to=[ai_pkg.spdxId],
+            to=[require_spdx_id(ai_pkg)],
             relationshipType=spdx3.RelationshipType.contains,
             creationInfo=creation_info,
         )

--- a/src/pitloom/assemble/spdx3/dataset.py
+++ b/src/pitloom/assemble/spdx3/dataset.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from spdx_python_model import v3_0_1 as spdx3
+from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.core.dataset_metadata import DatasetMetadata, DatasetReference
 from pitloom.core.models import generate_spdx_id

--- a/src/pitloom/assemble/spdx3/dataset.py
+++ b/src/pitloom/assemble/spdx3/dataset.py
@@ -10,25 +10,27 @@ from spdx_python_model import v3_0_1 as spdx3
 
 from pitloom.core.dataset_metadata import DatasetMetadata, DatasetReference
 from pitloom.core.models import generate_spdx_id
-from pitloom.export.spdx3_json import Spdx3JsonExporter
+from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 
 # Mapping from DatasetReference.role strings to SPDX 3.0.1 RelationshipType.
 # finetunedOn, validatedOn, pretrainedOn do not exist in SPDX 3.0.1;
 # they fall back to RelationshipType.other with a comment (see _role_to_rel).
-_ROLE_TO_RELATIONSHIP: dict[str, spdx3.RelationshipType] = {
+# RelationshipType members are plain str NamedIndividual IRIs, not an enum type.
+_ROLE_TO_RELATIONSHIP: dict[str, str] = {
     "trainedOn": spdx3.RelationshipType.trainedOn,
     "testedOn": spdx3.RelationshipType.testedOn,
 }
 
 # PresenceType mapping for has_sensitive_personal_information.
-_PRESENCE_MAP: dict[str, spdx3.PresenceType] = {
+# PresenceType members are plain str NamedIndividual IRIs, not an enum type.
+_PRESENCE_MAP: dict[str, str] = {
     "yes": spdx3.PresenceType.yes,
     "no": spdx3.PresenceType.no,
     "noAssertion": spdx3.PresenceType.noAssertion,
 }
 
 
-def _role_to_rel(role: str) -> tuple[spdx3.RelationshipType, str | None]:
+def _role_to_rel(role: str) -> tuple[str, str | None]:
     """Return the SPDX RelationshipType and optional fallback comment for *role*.
 
     Returns:
@@ -112,7 +114,8 @@ def _build_dataset_package(
     # dataset_datasetType is required by the SPDX model; always set it.
     # Map known string names to enum values, skip unknowns silently.
     # Fall back to [noAssertion] when no type information is available.
-    type_values: list[spdx3.dataset_DatasetType] = []
+    # dataset_DatasetType members are plain str NamedIndividual IRIs.
+    type_values: list[str] = []
     for type_name in meta.dataset_types:
         enum_val = getattr(spdx3.dataset_DatasetType, type_name, None)
         if enum_val is not None:
@@ -210,7 +213,7 @@ def add_datasets_for_model(
             ),
             creationInfo=creation_info,
             from_=ai_package_spdx_id,
-            to=[dataset_pkg.spdxId],
+            to=[require_spdx_id(dataset_pkg)],
             relationshipType=rel_type,
         )
         if fallback_comment:

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -10,7 +10,7 @@ from importlib.metadata import PackageMetadata, PackageNotFoundError
 from importlib.metadata import metadata as get_pkg_metadata
 from importlib.metadata import version as get_package_version
 
-from spdx_python_model import v3_0_1 as spdx3
+from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.core.models import build_pypi_purl, generate_spdx_id
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -13,7 +13,7 @@ from importlib.metadata import version as get_package_version
 from spdx_python_model import v3_0_1 as spdx3
 
 from pitloom.core.models import build_pypi_purl, generate_spdx_id
-from pitloom.export.spdx3_json import Spdx3JsonExporter
+from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 
 # Operators used in PEP 508 dependency specifiers, ordered longest-first to
 # avoid splitting on a prefix of a multi-character operator (e.g. "==" before "=").
@@ -147,7 +147,7 @@ def _enrich_from_installed(
     if license_id and license_id != "UNKNOWN":
         rel_declared, _ = build_license_elements(
             license_id=license_id,
-            package_spdx_id=dep_package.spdxId,
+            package_spdx_id=require_spdx_id(dep_package),
             license_provenance=provenance_source,
             creation_info=creation_info,
             doc_name=doc_name,
@@ -208,7 +208,7 @@ def build_license_elements(
         license_text.simplelicensing_licenseText = license_id
         license_text.comment = f"Metadata provenance: license: {license_provenance}"
         exporter.add_license(license_text)
-        license_spdx_id = license_text.spdxId
+        license_spdx_id = require_spdx_id(license_text)
 
     # The license actually found in the Software Artifact.
     rel_has_declared_license = spdx3.Relationship(
@@ -303,7 +303,7 @@ def add_dependencies(
                 "Relationship", doc_name=doc_name, doc_uuid=doc_uuid
             ),
             from_=main_package_spdx_id,
-            to=[dep_package.spdxId],
+            to=[require_spdx_id(dep_package)],
             relationshipType=spdx3.RelationshipType.dependsOn,
             creationInfo=creation_info,
         )

--- a/src/pitloom/assemble/spdx3/document.py
+++ b/src/pitloom/assemble/spdx3/document.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from pathlib import Path
 
-from spdx_python_model import v3_0_1 as spdx3
+from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.assemble.spdx3.ai import _build_ai_package, add_ai_models
 from pitloom.assemble.spdx3.dataset import add_datasets_for_model

--- a/src/pitloom/assemble/spdx3/document.py
+++ b/src/pitloom/assemble/spdx3/document.py
@@ -23,7 +23,7 @@ from pitloom.core.models import (
     compute_doc_uuid,
     generate_spdx_id,
 )
-from pitloom.export.spdx3_json import Spdx3JsonExporter
+from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 
 
 def _parse_iso_datetime(value: str) -> datetime:
@@ -87,9 +87,9 @@ def _build_creation_bundle(
             creationInfo=spdx_ci,
         )
 
-    spdx_ci.createdBy = [creator.spdxId]
+    spdx_ci.createdBy = [require_spdx_id(creator)]
     if tool is not None:
-        spdx_ci.createdUsing = [tool.spdxId]
+        spdx_ci.createdUsing = [require_spdx_id(tool)]
     return spdx_ci, creator, tool
 
 
@@ -179,7 +179,7 @@ def _add_package_files(
             )
             directory_file.software_fileKind = spdx3.software_FileKindType.directory
             exporter.add_file(directory_file)
-            dir_spdx_ids[directory_name] = directory_file.spdxId
+            dir_spdx_ids[directory_name] = require_spdx_id(directory_file)
 
             parent_id = (
                 main_package.spdxId
@@ -192,7 +192,7 @@ def _add_package_files(
                         "Relationship", doc_name=metadata.name, doc_uuid=doc_uuid
                     ),
                     from_=parent_id,
-                    to=[directory_file.spdxId],
+                    to=[require_spdx_id(directory_file)],
                     relationshipType=spdx3.RelationshipType.contains,
                     creationInfo=spdx_ci,
                 )
@@ -211,7 +211,7 @@ def _add_package_files(
             )
         ]
         exporter.add_file(package_entry)
-        file_spdx_ids[package_file.distribution_path] = package_entry.spdxId
+        file_spdx_ids[package_file.distribution_path] = require_spdx_id(package_entry)
 
         parent_id = (
             dir_spdx_ids[parent_paths[-1].as_posix()]
@@ -224,7 +224,7 @@ def _add_package_files(
                     "Relationship", doc_name=metadata.name, doc_uuid=doc_uuid
                 ),
                 from_=parent_id,
-                to=[package_entry.spdxId],
+                to=[require_spdx_id(package_entry)],
                 relationshipType=spdx3.RelationshipType.contains,
                 creationInfo=spdx_ci,
             )
@@ -303,7 +303,7 @@ def build(doc: DocumentModel, merkle_root: str | None = None) -> Spdx3JsonExport
     if metadata.license_name:
         rel_declared, rel_concluded = build_license_elements(
             license_id=metadata.license_name,
-            package_spdx_id=main_package.spdxId,
+            package_spdx_id=require_spdx_id(main_package),
             license_provenance=metadata.provenance.get(
                 "license", "Source: pyproject.toml | Field: project.license"
             ),
@@ -320,7 +320,7 @@ def build(doc: DocumentModel, merkle_root: str | None = None) -> Spdx3JsonExport
     add_dependencies(
         dependencies=metadata.dependencies,
         dep_provenance=metadata.provenance.get("dependencies", "Unknown source"),
-        main_package_spdx_id=main_package.spdxId,
+        main_package_spdx_id=require_spdx_id(main_package),
         creation_info=spdx_ci,
         doc_name=metadata.name,
         doc_uuid=doc_uuid,
@@ -345,7 +345,7 @@ def build(doc: DocumentModel, merkle_root: str | None = None) -> Spdx3JsonExport
             )
         add_ai_models(
             ai_models=doc.ai_models,
-            main_package_spdx_id=main_package.spdxId,
+            main_package_spdx_id=require_spdx_id(main_package),
             file_spdx_ids=file_spdx_ids,
             creation_info=spdx_ci,
             doc_name=metadata.name,
@@ -418,9 +418,9 @@ def build_model(
             creationInfo=spdx_ci,
         )
 
-    spdx_ci.createdBy = [creator.spdxId]
+    spdx_ci.createdBy = [require_spdx_id(creator)]
     if tool is not None:
-        spdx_ci.createdUsing = [tool.spdxId]
+        spdx_ci.createdUsing = [require_spdx_id(tool)]
 
     exporter.add_creation_info(spdx_ci)
     exporter.add_person(creator)
@@ -433,7 +433,7 @@ def build_model(
     if model.license:
         rel_declared, rel_concluded = build_license_elements(
             license_id=model.license,
-            package_spdx_id=ai_pkg.spdxId,
+            package_spdx_id=require_spdx_id(ai_pkg),
             license_provenance=model.provenance.get(
                 "license",
                 "Source: model file / Hugging Face Hub",
@@ -448,7 +448,7 @@ def build_model(
 
     if model.datasets:
         add_datasets_for_model(
-            ai_package_spdx_id=ai_pkg.spdxId,
+            ai_package_spdx_id=require_spdx_id(ai_pkg),
             datasets=model.datasets,
             creation_info=spdx_ci,
             doc_name=doc_name,

--- a/src/pitloom/assemble/spdx3/fragments.py
+++ b/src/pitloom/assemble/spdx3/fragments.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from spdx_python_model import v3_0_1 as spdx3
+from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.export.spdx3_json import Spdx3JsonExporter
 

--- a/src/pitloom/export/spdx3_json.py
+++ b/src/pitloom/export/spdx3_json.py
@@ -28,6 +28,25 @@ _GRAPH_TYPE_PRIORITY: dict[str, int] = {
 }
 
 
+def require_spdx_id(element: spdx3.Element) -> str:
+    """Return *element*'s ``spdxId``, narrowing away the ``None`` case.
+
+    ``spdxId`` is typed ``str | None`` upstream because the SHACL model
+    allows an Element to be constructed without one, but every element
+    pitloom builds is always given an explicit ``spdxId`` at construction
+    time (see :func:`pitloom.core.models.generate_spdx_id`). This helper
+    exists only to satisfy mypy at the many call sites that pass an
+    element's ``spdxId`` on to APIs expecting a plain ``str``.
+
+    Raises:
+        ValueError: If *element* has no ``spdxId`` assigned, which would
+            indicate a bug in how the element was constructed.
+    """
+    if element.spdxId is None:
+        raise ValueError(f"{element!r} has no spdxId assigned")
+    return element.spdxId
+
+
 def _graph_sort_key(element: dict[str, Any]) -> tuple[int, str, str]:
     """Return a deterministic sort key for a @graph element.
 
@@ -252,7 +271,7 @@ class Spdx3JsonExporter:
         self.object_set.add(simple_licensing_text)
         license_id: str | None = simple_licensing_text.simplelicensing_licenseText
         if license_id:
-            self._license_index[license_id] = simple_licensing_text.spdxId
+            self._license_index[license_id] = require_spdx_id(simple_licensing_text)
 
     def add_relationship(self, relationship: spdx3.Relationship) -> None:
         """Add a relationship to the document.

--- a/src/pitloom/export/spdx3_json.py
+++ b/src/pitloom/export/spdx3_json.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from typing import Any
 
 import rfc8785
-from spdx_python_model import v3_0_1 as spdx3
+from spdx_python_model.bindings import v3_0_1 as spdx3
 
 # Lower value = earlier in @graph. Types not listed here get priority 4.
 # Order rationale:

--- a/src/pitloom/loom.py
+++ b/src/pitloom/loom.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 from spdx_python_model import v3_0_1 as spdx3
 
 from pitloom.core.models import generate_spdx_id
-from pitloom.export.spdx3_json import Spdx3JsonExporter
+from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 
 
 def _get_caller_info() -> str:
@@ -62,7 +62,7 @@ class _ActiveRun:
             name="Pitloom SDK (Automated Run)",
             creationInfo=self.creation_info,
         )
-        self.creation_info.createdBy = [person.spdxId]
+        self.creation_info.createdBy = [require_spdx_id(person)]
 
         self.exporter = Spdx3JsonExporter()
         self.exporter.add_person(person)
@@ -238,7 +238,7 @@ class _ActiveRun:
                         self.doc_uuid,
                     ),
                     from_=self.model.spdxId,
-                    to=[dataset.spdxId],
+                    to=[require_spdx_id(dataset)],
                     relationshipType=spdx3.RelationshipType.trainedOn,
                     creationInfo=self.creation_info,
                 )
@@ -254,7 +254,7 @@ class _ActiveRun:
                         self.doc_uuid,
                     ),
                     from_=self.model.spdxId,
-                    to=[dataset.spdxId],
+                    to=[require_spdx_id(dataset)],
                     relationshipType=spdx3.RelationshipType.testedOn,
                     creationInfo=self.creation_info,
                 )
@@ -262,7 +262,7 @@ class _ActiveRun:
 
         # output_dataset hasInput input_datasets (dataset lineage / preprocessing)
         if self.output_datasets and self.input_datasets:
-            input_ids = [ds.spdxId for ds in self.input_datasets]
+            input_ids = [require_spdx_id(ds) for ds in self.input_datasets]
             for output_ds in self.output_datasets:
                 rel = spdx3.Relationship(
                     spdxId=generate_spdx_id(

--- a/src/pitloom/loom.py
+++ b/src/pitloom/loom.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
 
-from spdx_python_model import v3_0_1 as spdx3
+from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.core.models import generate_spdx_id
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from spdx_python_model import v3_0_1 as spdx3
+from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.assemble import generate_sbom
 from pitloom.assemble.spdx3.document import build, build_model

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -20,7 +20,7 @@ from pitloom.core.creation import CreationMetadata
 from pitloom.core.document import DocumentModel
 from pitloom.core.models import generate_spdx_id
 from pitloom.core.project import ProjectFile, ProjectMetadata
-from pitloom.export.spdx3_json import Spdx3JsonExporter
+from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 from pitloom.extract.ai_model import read_ai_model
 
 
@@ -361,7 +361,7 @@ files = ["fragment1.json", "fragment2.json"]
             name="Author 1",
             creationInfo=ci1,
         )
-        ci1.createdBy = [person1.spdxId]
+        ci1.createdBy = [require_spdx_id(person1)]
         ai_pkg = spdx3.ai_AIPackage(
             spdxId=generate_spdx_id("AIPackage", "test-ai-model", doc_uuid_1),
             name="cool-ai-model",
@@ -382,7 +382,7 @@ files = ["fragment1.json", "fragment2.json"]
             name="Author 2",
             creationInfo=ci2,
         )
-        ci2.createdBy = [person2.spdxId]
+        ci2.createdBy = [require_spdx_id(person2)]
         dataset_pkg = spdx3.dataset_DatasetPackage(
             spdxId=generate_spdx_id("DatasetPackage", "test-dataset", doc_uuid_2),
             name="cool-dataset",

--- a/tests/test_hatch_hook.py
+++ b/tests/test_hatch_hook.py
@@ -32,7 +32,10 @@ from hatchling.plugin.manager import PluginManager  # noqa: E402
 from spdx_python_model import v3_0_1 as spdx3  # noqa: E402
 
 from pitloom.core.models import compute_doc_uuid, generate_spdx_id  # noqa: E402
-from pitloom.export.spdx3_json import Spdx3JsonExporter  # noqa: E402
+from pitloom.export.spdx3_json import (  # noqa: E402
+    Spdx3JsonExporter,
+    require_spdx_id,
+)
 from pitloom.extract.hatchling import metadata_from_hatchling  # noqa: E402
 from pitloom.extract.pyproject import read_pyproject  # noqa: E402
 from pitloom.plugins.hatch import (  # noqa: E402
@@ -357,7 +360,7 @@ def test_hook_with_pitloom_fragments() -> None:
             name="Frag Author",
             creationInfo=ci,
         )
-        ci.createdBy = [person.spdxId]
+        ci.createdBy = [require_spdx_id(person)]
         pkg = spdx3.software_Package(
             spdxId=generate_spdx_id("Package", "fragment-lib", doc_uuid),
             name="fragment-lib",

--- a/tests/test_hatch_hook.py
+++ b/tests/test_hatch_hook.py
@@ -29,7 +29,7 @@ pytest.importorskip("hatchling", reason="hatchling is required for hook tests")
 # pylint: disable=wrong-import-position
 import hatchling.metadata.core as hatchling_metadata_core  # noqa: E402
 from hatchling.plugin.manager import PluginManager  # noqa: E402
-from spdx_python_model import v3_0_1 as spdx3  # noqa: E402
+from spdx_python_model.bindings import v3_0_1 as spdx3  # noqa: E402
 
 from pitloom.core.models import compute_doc_uuid, generate_spdx_id  # noqa: E402
 from pitloom.export.spdx3_json import (  # noqa: E402

--- a/tests/test_spdx3_compliance.py
+++ b/tests/test_spdx3_compliance.py
@@ -10,7 +10,7 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from spdx_python_model import v3_0_1 as spdx3
+from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.assemble import generate_sbom
 from pitloom.core.creation import CreationMetadata

--- a/tests/test_spdx3_dataset.py
+++ b/tests/test_spdx3_dataset.py
@@ -24,7 +24,7 @@ from pitloom.core.dataset_metadata import DatasetMetadata, DatasetReference
 from pitloom.core.document import DocumentModel
 from pitloom.core.models import _clear_doc_counters, compute_doc_uuid, generate_spdx_id
 from pitloom.core.project import ProjectMetadata
-from pitloom.export.spdx3_json import Spdx3JsonExporter
+from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 
 _DOC_NAME = "testproject"
 _DOC_UUID = compute_doc_uuid("testproject", "1.0", [])
@@ -41,7 +41,7 @@ def _make_ci() -> spdx3.CreationInfo:
         name="Test",
         creationInfo=ci,
     )
-    ci.createdBy = [person.spdxId]
+    ci.createdBy = [require_spdx_id(person)]
     return ci
 
 
@@ -97,7 +97,6 @@ def test_build_dataset_package_dataset_types() -> None:
     pkg = _build_dataset_package(
         _make_meta(dataset_types=["text", "numeric"]), _make_ci(), _DOC_NAME, _DOC_UUID
     )
-    assert pkg.dataset_datasetType is not None
     assert len(pkg.dataset_datasetType) == 2
 
 
@@ -229,9 +228,9 @@ def test_build_dataset_package_croissant_url_as_external_ref() -> None:
     pkg = _build_dataset_package(
         _make_meta(croissant_url=url), _make_ci(), _DOC_NAME, _DOC_UUID
     )
-    assert pkg.externalRef is not None
     assert len(pkg.externalRef) == 1
     ref = pkg.externalRef[0]
+    assert isinstance(ref, spdx3.ExternalRef)
     assert url in ref.locator
     assert ref.externalRefType == spdx3.ExternalRefType.other
     assert ref.comment == "Croissant metadata"

--- a/tests/test_spdx3_dataset.py
+++ b/tests/test_spdx3_dataset.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 
-from spdx_python_model import v3_0_1 as spdx3
+from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.assemble.spdx3.dataset import (
     _build_dataset_package,


### PR DESCRIPTION
This issue arose after upgrading spdx-python-model from 0.0.4 to 0.0.6.

Per spec, the generated `Element` should always have `spdxId` (as a string), so we will defensively check for that.

Also fix pylint issue with `v3_0_1` import.
Use `from spdx_python_model.bindings import v3_0_1` instead of `from spdx_python_model import v3_0_1` to allow pylint to see the dynamically generated `v3_0_1`.