### PR TITLE
Allow multiple SBOM creators/tools in CreationMetadata

### DIFF
--- a/.github/workflows/hatch-integration.yml
+++ b/.github/workflows/hatch-integration.yml
@@ -111,6 +111,65 @@ jobs:
               sys.exit(1)
 
           print(f"SBOM packages: {pkg_names}")
+
+          # Resolve spdxId/@id references to the actual graph elements, the
+          # same way a real SPDX 3 consumer would.
+          elements_by_id = {}
+          for element in graph:
+              element_id = element.get("spdxId", element.get("@id"))
+              if element_id is not None:
+                  elements_by_id[element_id] = element
+
+          creation_infos = [e for e in graph if e.get("type") == "CreationInfo"]
+          if len(creation_infos) != 1:
+              print(
+                  f"ERROR: Expected exactly 1 CreationInfo element, found "
+                  f"{len(creation_infos)}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          creation_info = creation_infos[0]
+
+          created_by_ids = creation_info.get("createdBy", [])
+          created_by = [elements_by_id[i] for i in created_by_ids]
+          if len(created_by) != 2:
+              print(
+                  f"ERROR: Expected 2 createdBy agents, found {len(created_by)}: "
+                  f"{created_by}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
+          persons = [a for a in created_by if a.get("type") == "Person"]
+          orgs = [a for a in created_by if a.get("type") == "Organization"]
+          if len(persons) != 1 or persons[0].get("name") != "Pitloom CI":
+              print(
+                  f"ERROR: Expected 1 Person named 'Pitloom CI' in createdBy, "
+                  f"found: {persons}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          if len(orgs) != 1 or orgs[0].get("name") != "Sample Project Org":
+              print(
+                  f"ERROR: Expected 1 Organization named 'Sample Project Org' in "
+                  f"createdBy, found: {orgs}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
+          created_using_ids = creation_info.get("createdUsing", [])
+          created_using = [elements_by_id[i] for i in created_using_ids]
+          tool_names = sorted(t.get("name") for t in created_using)
+          if len(created_using) != 2 or tool_names != ["CI Wrapper", "Pitloom"]:
+              print(
+                  f"ERROR: Expected createdUsing tools ['CI Wrapper', 'Pitloom'], "
+                  f"found: {tool_names}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
+          print(f"createdBy: {[a.get('name') for a in created_by]}")
+          print(f"createdUsing: {tool_names}")
           print("SBOM presence check passed.")
           EOF
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ and this project adheres to
 - BREAKING CHANGE:
   Renamed the `creation_info` parameter to `creation_metadata` in
   `generate_sbom()` and related APIs ([#84])
+- BREAKING CHANGE:
+  `CreationInfo` now supports multiple creators and multiple creation
+  tools. `CreationMetadata.creator_name`/`creator_email`/`creator_type`/
+  `creation_tool` (scalar) are replaced by `creators: list[Creator]` and
+  `tools: list[ToolInfo] | None`. CLI `--creator-name`/`--creation-tool`
+  are now repeatable; config gains `[[tool.pitloom.creator]]` /
+  `[[tool.pitloom.creation-tool]]` array-of-tables (replacing the old
+  `[tool.pitloom.creation]` `creator-name`/`creator-email`/`creator-type`/
+  `creation-tool` keys, which now raise a moved-key error). `setup.cfg`
+  keeps single-creator/-tool support only.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -94,29 +94,41 @@ loom -m Qwen/Qwen3-235B-A22B   # bare model ID also works
 ### Creation metadata
 
 These flags apply to project, AI model, and Hugging Face SBOM generation
-alike. `--creator-name`/`--creator-type` (`person` default, `organization`,
-`software-agent`, `agent`)/`--creator-email` name *who* initiated the run;
-`--creation-tool` records *what* produced it (default `"Pitloom"`,
-`--no-creation-tool` to omit); `--creation-comment`/`--creation-datetime`
-set free-text provenance and an ISO 8601 timestamp:
+alike. `--creator-name` is repeatable -- each occurrence starts a new
+creator, in order; `--creator-type` (`person` default, `organization`,
+`software-agent`, `agent`) and `--creator-email` set the type/email of the
+*most recently named* creator. `--creation-tool` records *what* produced
+it (default `"Pitloom"`, also repeatable; `--no-creation-tool` to omit);
+`--creation-comment`/`--creation-datetime` set free-text provenance and an
+ISO 8601 timestamp:
 
 ```bash
 loom . --creator-name "Alice" --creator-email "alice@example.com"
 loom . --creator-name "Acme Corp" --creator-type organization
+loom . --creator-name "Acme Corp" --creator-type organization --creator-name Alice
 loom . --creation-datetime "2026-01-15T10:00:00Z" --creation-comment "CI run #123"
 ```
 
-The same fields can be set in `pyproject.toml` under `[tool.pitloom.creation]`
-(CLI flags take precedence):
+The same fields can be set in `pyproject.toml` under
+`[[tool.pitloom.creator]]` / `[[tool.pitloom.creation-tool]]` (CLI flags
+take precedence, replacing the whole list rather than merging):
 
 ```toml
+[[tool.pitloom.creator]]
+name = "Alice"
+email = "alice@example.com"
+type = "person"       # or "organization", "software-agent", "agent"
+
+[[tool.pitloom.creator]]
+name = "Acme Corp"
+type = "organization"
+
+[[tool.pitloom.creation-tool]]
+name = "MyCompany SBOM Wrapper"
+
 [tool.pitloom.creation]
-creator-name = "Alice"
-creator-email = "alice@example.com"
-creator-type = "person"       # or "organization", "software-agent", "agent"
 creation-datetime = "2026-01-15T10:00:00Z"
 creation-comment = "Generated in CI pipeline #123"
-creation-tool = "MyCompany SBOM Wrapper"
 ```
 
 See [Creation metadata](docs/creation-metadata.md) for what these fields
@@ -129,13 +141,13 @@ The SBOM generator can be used programmatically:
 
 ```python
 from pathlib import Path
-from pitloom.core.creation import CreationMetadata
+from pitloom.core.creation import CreationMetadata, Creator
 from pitloom.assemble import generate_sbom
 
 generate_sbom(
     project_dir=Path("/path/to/project"),
     output_path=Path("sbom.spdx3.json"),
-    creation_metadata=CreationMetadata(creator_name="Your Name"),
+    creation_metadata=CreationMetadata(creators=[Creator(name="Your Name")]),
 )
 ```
 
@@ -163,7 +175,8 @@ enabled = true    # set to false to skip SBOM generation
 That's all -- `hatch build`/`python -m build` now embeds the SBOM, always
 as compact canonical JSON. Basename and fragments are configured under
 `[tool.pitloom]`; creator/tool metadata uses the same
-`[tool.pitloom.creation]` table the CLI reads (see
+`[[tool.pitloom.creator]]` / `[[tool.pitloom.creation-tool]]` /
+`[tool.pitloom.creation]` tables the CLI reads (see
 [Creation metadata](#creation-metadata) above):
 
 ```toml

--- a/docs/creation-metadata.md
+++ b/docs/creation-metadata.md
@@ -38,50 +38,55 @@ generation events contributed to it -- correct provenance to keep, since
 each part genuinely was created separately, at a different time, possibly
 by a different creator.
 
-This means `[tool.pitloom.creation]` in `pyproject.toml` only shapes the
-record for whatever the CLI or Hatchling build hook itself generates (the
-main document) -- it does not reach into fragment files that were already
+This means `[[tool.pitloom.creator]]` / `[[tool.pitloom.creation-tool]]` /
+`[tool.pitloom.creation]` in `pyproject.toml` only shape the record for
+whatever the CLI or Hatchling build hook itself generates (the main
+document) -- they do not reach into fragment files that were already
 generated earlier by `pitloom.loom.run`. A fragment's record is fixed at
-the moment `loom.run` produced it; give it the same creator by passing an
+the moment `loom.run` produced it; give it the same creator(s) by passing an
 explicit `creation_metadata=CreationMetadata(...)` to that call.
 
 | Field (SPDX 3 name) | Meaning | What Pitloom puts there |
 | :--- | :--- | :--- |
-| `createdBy` (**≥1**) | *Who* created it | The **creator**: a person, organization, software agent, or generic agent when you name one (`--creator-type`); otherwise Pitloom itself, acting unattended (see below). |
-| `createdUsing` (0+) | *What* tool produced it | **Pitloom**, with a version summary. Suppress with `--no-creation-tool`. |
+| `createdBy` (**≥1**) | *Who* created it | One or more **creators**: a person, organization, software agent, or generic agent for each one you name (`--creator-name`, repeatable); otherwise Pitloom itself, acting unattended (see below). |
+| `createdUsing` (0+) | *What* tool produced it | **Pitloom** by default, with a version summary; repeat `--creation-tool` for more than one. Suppress with `--no-creation-tool`. |
 | `created` (1) | *When* | `--creation-datetime` if set, else the current UTC time. |
 | `comment` (0-1) | *How* it was invoked | A short static note per channel (`Generated via Pitloom CLI`, `... Hatchling build hook`, `... loom SDK`), or your `--creation-comment`. |
 
-> Note: The `≥1`/`0+` cardinalities above are what SPDX 3 *allows* -- not
-something Pitloom currently exercises.
-> Each SPDX 3's `CreationInfo` record Pitloom writes holds exactly one creator
-> Agent and at most one Tool.
-
 Pitloom's design distinguishes *who acted* from *what tool was used* --
 naming a creator never means naming Pitloom, and Pitloom itself is always
-recorded as the tool, never as the creator. In SPDX 3 terms this is the
+recorded as a tool, never as a creator. In SPDX 3 terms this is the
 `Agent`/`Tool` split: an `Agent` (`Person` / `Organization` / `SoftwareAgent`
 / the generic `Agent`) is who acts; a `Tool` is the instrument used. Pitloom
 is the instrument, so it belongs in `createdUsing` as a `Tool` -- **not** in
 `createdBy`.
 
-- **You name a creator** (`--creator-name`, or `[tool.pitloom.creation]`):
-  it becomes a person (default), organization, software agent, or generic
-  agent as the creator (via `--creator-type`), and the main package's
-  supplier. The software-agent/agent types are for naming an automated
-  creator that isn't Pitloom itself -- e.g. a CI bot that invoked Pitloom on
-  someone's behalf.
+- **You name one or more creators** (repeatable `--creator-name`, or
+  `[[tool.pitloom.creator]]`): each becomes a person (default), organization,
+  software agent, or generic agent (via `--creator-type`/`type`, bound to the
+  most recently named creator). The software-agent/agent types are for
+  naming an automated creator that isn't Pitloom itself -- e.g. a CI bot
+  that invoked Pitloom on someone's behalf. `suppliedBy` on the main package
+  -- single-valued in SPDX 3 -- is set to the *first* named creator when two
+  or more are given.
 - **You name no creator** (zero-config): rather than invent a fake person,
   Pitloom records itself as the creator too, but as a software agent, not a
   person or organization -- honestly "an unattended Pitloom run made this" --
-  and omits a supplier for the main package. Pitloom is still recorded as
-  the tool regardless, so the same Pitloom shows up twice in this case: once
+  and omits a supplier for the main package. Pitloom is still recorded as a
+  tool regardless, so the same Pitloom shows up twice in this case: once
   as the (software agent) creator, once as the tool.
 
 This applies uniformly to the CLI, the Hatchling build hook, and
 `pitloom.loom` fragments -- all three accept the same creator/tool/timestamp
 overrides and fall back to the same `SoftwareAgent` default.
 
+`setup.cfg` (INI) is a documented exception: `configparser` cannot express
+TOML array-of-tables, so `[tool:pitloom]` / `[tool:pitloom:creation]` only
+support a single `creator-name`/`creator-email`/`creator-type` and a single
+`creation-tool`. Projects that need more than one creator or tool should use
+`pyproject.toml` or the library API.
+
 See the [README](https://github.com/bact/pitloom#readme) for the
-`--creator-*` / `--creation-*` CLI flags and the `[tool.pitloom.creation]`
-`pyproject.toml` table used to set these fields.
+`--creator-*` / `--creation-*` CLI flags and the `[[tool.pitloom.creator]]` /
+`[[tool.pitloom.creation-tool]]` / `[tool.pitloom.creation]`
+`pyproject.toml` tables used to set these fields.

--- a/docs/creation-metadata.md
+++ b/docs/creation-metadata.md
@@ -54,12 +54,14 @@ explicit `creation_metadata=CreationMetadata(...)` to that call.
 | `comment` (0-1) | *How* it was invoked | A short static note per channel (`Generated via Pitloom CLI`, `... Hatchling build hook`, `... loom SDK`), or your `--creation-comment`. |
 
 Pitloom's design distinguishes *who acted* from *what tool was used* --
-naming a creator never means naming Pitloom, and Pitloom itself is always
-recorded as a tool, never as a creator. In SPDX 3 terms this is the
-`Agent`/`Tool` split: an `Agent` (`Person` / `Organization` / `SoftwareAgent`
-/ the generic `Agent`) is who acts; a `Tool` is the instrument used. Pitloom
-is the instrument, so it belongs in `createdUsing` as a `Tool` -- **not** in
-`createdBy`.
+naming a creator (`--creator-name`) never names Pitloom itself as a
+`Person` or `Organization`. Pitloom is recorded as the tool in
+`createdUsing` by default (suppress with `--no-creation-tool`). In SPDX 3
+terms this is the `Agent`/`Tool` split: an `Agent` (`Person` /
+`Organization` / `SoftwareAgent` / the generic `Agent`) is who acts; a
+`Tool` is the instrument used. With no creator named, Pitloom stands in as
+the `SoftwareAgent` creator too (see below) -- but never pretending a
+human did the work.
 
 - **You name one or more creators** (repeatable `--creator-name`, or
   `[[tool.pitloom.creator]]`): each becomes a person (default), organization,
@@ -72,9 +74,10 @@ is the instrument, so it belongs in `createdUsing` as a `Tool` -- **not** in
 - **You name no creator** (zero-config): rather than invent a fake person,
   Pitloom records itself as the creator too, but as a software agent, not a
   person or organization -- honestly "an unattended Pitloom run made this" --
-  and omits a supplier for the main package. Pitloom is still recorded as a
-  tool regardless, so the same Pitloom shows up twice in this case: once
-  as the (software agent) creator, once as the tool.
+  and omits a supplier for the main package. Pitloom is also recorded as
+  the tool by default (unless suppressed with `--no-creation-tool`), so
+  the same Pitloom can show up twice in this case: once as the (software
+  agent) creator, once as the tool.
 
 This applies uniformly to the CLI, the Hatchling build hook, and
 `pitloom.loom` fragments -- all three accept the same creator/tool/timestamp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,10 +197,10 @@ module = "tests.test_extract_huggingface"
 pretty = true
 sbom-basename = "sbom"
 
-[tool.pitloom.creation]
-creator-name = "Arthit Suriyawongkul"
-creator-email = "suriyawa@tcd.ie"
-creator-type = "person"
+[[tool.pitloom.creator]]
+name = "Arthit Suriyawongkul"
+email = "suriyawa@tcd.ie"
+type = "person"
 
 [tool.pylint.main]
 ignore-paths = ["^tests/fixtures/.*$"]

--- a/skills/sbom/SKILL.md
+++ b/skills/sbom/SKILL.md
@@ -87,8 +87,8 @@ pitloom`).
   `--creator-type`/`--creator-email` bind to the most recently named one
   (e.g. `--creator-name "Acme Corp" --creator-type organization
   --creator-name Alice`). Without a named creator, Pitloom records itself
-  as an unattended `software-agent` creator. Pitloom is always recorded as
-  the generating tool regardless.
+  as an unattended `software-agent` creator. Pitloom is recorded as the
+  generating tool by default too (suppress with `--no-creation-tool`).
 
 ## What Pitloom produces
 

--- a/skills/sbom/SKILL.md
+++ b/skills/sbom/SKILL.md
@@ -82,9 +82,13 @@ pitloom`).
 - `-v` / `--verbose` -- print effective options and where each came from.
 - `--creator-name NAME`, `--creator-email EMAIL` -- name who created the
   SBOM (person by default); `--creator-type` selects `person`,
-  `organization`, `software-agent`, or `agent`. Without a named creator,
-  Pitloom records itself as an unattended `software-agent` creator.
-  Pitloom is always recorded as the generating tool regardless.
+  `organization`, `software-agent`, or `agent`. `--creator-name` is
+  repeatable -- each occurrence starts a new creator, in order;
+  `--creator-type`/`--creator-email` bind to the most recently named one
+  (e.g. `--creator-name "Acme Corp" --creator-type organization
+  --creator-name Alice`). Without a named creator, Pitloom records itself
+  as an unattended `software-agent` creator. Pitloom is always recorded as
+  the generating tool regardless.
 
 ## What Pitloom produces
 

--- a/skills/sbom/references/examples.md
+++ b/skills/sbom/references/examples.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-07-05
-Last-Modified: 2026-07-06
+Last-Modified: 2026-07-08
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -35,6 +35,14 @@ uvx --from 'pitloom[aimodel]' pitloom -m model.safetensors -o model.spdx3.json
 ```bash
 uvx --from 'pitloom[huggingface]' pitloom -m mistralai/Mistral-7B-v0.1 \
   -o mistral.spdx3.json --pretty
+```
+
+## Project SBOM, multiple creators
+
+```bash
+loom . --creator-name "Acme Corp" --creator-type organization \
+       --creator-name "Alice" --creator-email alice@example.com \
+       -o sbom.spdx3.json
 ```
 
 ## Verify the result

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -391,26 +391,22 @@ def _resolve_creation_metadata(
 def _load_project_config(project_dir: Path) -> tuple[Any, Path | None]:
     """Load :class:`~pitloom.core.config.PitloomConfig` from the project.
 
-    Tries ``pyproject.toml`` first, then ``setup.cfg``/``setup.py``.
+    Tries ``pyproject.toml`` first, then ``setup.cfg``/``setup.py``. A
+    parse or validation error from either propagates -- it is a genuine
+    config mistake, not a signal to silently try the next source.
     Returns a 2-tuple of ``(PitloomConfig, config_file_path)``.
     """
     pyproject_path = project_dir / "pyproject.toml"
     if pyproject_path.exists():
-        try:
-            _, config = read_pyproject(pyproject_path)
-            return config, pyproject_path
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass
+        _, config = read_pyproject(pyproject_path)
+        return config, pyproject_path
 
     setup_cfg = project_dir / "setup.cfg"
     setup_py = project_dir / "setup.py"
     if setup_cfg.exists() or setup_py.exists():
-        try:
-            _, config = read_setuptools(project_dir)
-            config_path = setup_cfg if setup_cfg.exists() else setup_py
-            return config, config_path
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass
+        _, config = read_setuptools(project_dir)
+        config_path = setup_cfg if setup_cfg.exists() else setup_py
+        return config, config_path
 
     return PitloomConfig(), None
 
@@ -634,23 +630,19 @@ def _resolve_output_path(explicit: Path | None, project_dir: Path) -> Path:
     if explicit is not None:
         return explicit
 
-    try:
-        pyproject_path = project_dir / "pyproject.toml"
-        if pyproject_path.exists():
-            metadata, pitloom_config = read_pyproject(pyproject_path)
-        else:
-            metadata, pitloom_config = read_setuptools(project_dir)
+    pyproject_path = project_dir / "pyproject.toml"
+    if pyproject_path.exists():
+        metadata, pitloom_config = read_pyproject(pyproject_path)
+    else:
+        metadata, pitloom_config = read_setuptools(project_dir)
 
-        if pitloom_config.sbom_basename:
-            return Path(f"{pitloom_config.sbom_basename}{_SPDX3_JSON_EXT}")
+    if pitloom_config.sbom_basename:
+        return Path(f"{pitloom_config.sbom_basename}{_SPDX3_JSON_EXT}")
 
-        parts = [metadata.name] if metadata.name else ["sbom"]
-        if metadata.version:
-            parts.append(metadata.version)
-        return Path("-".join(parts) + _SPDX3_JSON_EXT)
-
-    except Exception:  # pylint: disable=broad-exception-caught
-        return Path(f"sbom{_SPDX3_JSON_EXT}")
+    parts = [metadata.name] if metadata.name else ["sbom"]
+    if metadata.version:
+        parts.append(metadata.version)
+    return Path("-".join(parts) + _SPDX3_JSON_EXT)
 
 
 def _resolve_model_output_path(explicit: Path | None, model_path: Path) -> Path:

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -19,9 +19,13 @@ from pitloom.assemble import (
     generate_huggingface_sbom,
     generate_sbom,
 )
-from pitloom.assemble.spdx3.creation_info import CREATOR_TYPES
 from pitloom.core.config import PitloomConfig
-from pitloom.core.creation import CreationMetadata
+from pitloom.core.creation import (
+    VALID_CREATOR_TYPES,
+    CreationMetadata,
+    Creator,
+    ToolInfo,
+)
 from pitloom.extract._huggingface import is_huggingface_source, parse_hf_model_id
 from pitloom.extract.pyproject import read_pyproject
 from pitloom.extract.setuptools import read_setuptools
@@ -41,30 +45,93 @@ class _ResolvedValue:
 
 
 @dataclass(frozen=True)
+class _ResolvedCreators:
+    """Resolved creator list paired with its source label."""
+
+    value: list[Creator]
+    source: str
+
+
+@dataclass(frozen=True)
+class _ResolvedTools:
+    """Resolved tool list paired with its source label.
+
+    ``value`` mirrors :attr:`CreationMetadata.tools`: ``None`` means the
+    default single ``Tool`` ``"Pitloom"``; ``[]`` suppresses ``createdUsing``.
+    """
+
+    value: list[ToolInfo] | None
+    source: str
+
+
+@dataclass(frozen=True)
 class _ResolvedCreationMetadata:
     """Resolved creation metadata values and their source labels."""
 
-    creator_name: _ResolvedValue
-    creator_email: _ResolvedValue
-    creator_type: _ResolvedValue
+    creators: _ResolvedCreators
+    tools: _ResolvedTools
     creation_datetime: _ResolvedValue
-    creation_tool: _ResolvedValue
     creation_comment: _ResolvedValue
 
     def to_creation_metadata(self) -> CreationMetadata:
         """Convert resolved values to :class:`CreationMetadata`.
 
-        ``creator_name`` may be ``None`` (no named creator) -- the assembler
-        then emits the default ``SoftwareAgent`` ``"Pitloom"``.
+        ``creators`` may be empty (no named creator) -- the assembler then
+        emits the default ``SoftwareAgent`` ``"Pitloom"``.
         """
         return CreationMetadata(
-            creator_name=self.creator_name.value,
-            creator_email=self.creator_email.value,
-            creator_type=self.creator_type.value or "person",
+            creators=self.creators.value,
+            tools=self.tools.value,
             creation_datetime=self.creation_datetime.value,
-            creation_tool=self.creation_tool.value,
             creation_comment=self.creation_comment.value,
         )
+
+
+class _CreatorNameAction(argparse.Action):
+    """``--creator-name`` starts a new :class:`Creator`, appended in order."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Any,
+        option_string: str | None = None,
+    ) -> None:
+        creators: list[Creator] = getattr(namespace, self.dest) or []
+        creators.append(Creator(name=values))
+        setattr(namespace, self.dest, creators)
+
+
+class _CreatorTypeAction(argparse.Action):
+    """``--creator-type`` sets the type of the most recently named creator."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Any,
+        option_string: str | None = None,
+    ) -> None:
+        creators: list[Creator] | None = getattr(namespace, self.dest)
+        if not creators:
+            parser.error(f"{option_string} must come after a --creator-name")
+        creators[-1].type = values
+
+
+class _CreatorEmailAction(argparse.Action):
+    """``--creator-email`` sets the email of the most recently named creator."""
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Any,
+        option_string: str | None = None,
+    ) -> None:
+        creators: list[Creator] | None = getattr(namespace, self.dest)
+        if not creators:
+            parser.error(f"{option_string} must come after a --creator-name")
+        creators[-1].email = values
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -128,29 +195,35 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--creator-name",
-        dest="creation_creator_name",
-        type=str,
+        dest="creators",
+        action=_CreatorNameAction,
+        default=None,
+        metavar="NAME",
         help=(
-            "Name of the SBOM creator (see --creator-type for the Agent "
-            "subclass). When omitted, the SoftwareAgent 'Pitloom' is "
-            "recorded as the automated creator."
+            "Name of an SBOM creator (see --creator-type/--creator-email to "
+            "set that creator's type/email). Repeatable: each occurrence "
+            "starts a new creator, in order. When omitted, the "
+            "SoftwareAgent 'Pitloom' is recorded as the automated creator."
         ),
     )
     parser.add_argument(
         "--creator-email",
-        dest="creation_creator_email",
-        type=str,
-        help="Email of the SBOM creator",
+        dest="creators",
+        action=_CreatorEmailAction,
+        default=None,
+        metavar="EMAIL",
+        help="Email of the most recently named --creator-name.",
     )
     parser.add_argument(
         "--creator-type",
-        dest="creation_creator_type",
-        type=str,
-        choices=sorted(CREATOR_TYPES),
+        dest="creators",
+        action=_CreatorTypeAction,
+        default=None,
+        choices=sorted(VALID_CREATOR_TYPES),
+        metavar="TYPE",
         help=(
-            "Agent subclass for --creator-name: person (default), "
-            "organization, software-agent, or agent. "
-            "Ignored when no creator name is given."
+            "Agent subclass for the most recently named --creator-name: "
+            "person (default), organization, software-agent, or agent."
         ),
     )
     parser.add_argument(
@@ -164,13 +237,17 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--creation-tool",
+        dest="creation_tools",
+        action="append",
         type=str,
-        help="Name of the tool that created the SBOM (default: Pitloom)",
+        metavar="NAME",
+        help="Name of a tool that created the SBOM (default: Pitloom). "
+        "Repeatable to record more than one tool.",
     )
     parser.add_argument(
         "--no-creation-tool",
         action="store_true",
-        help="Omit the creation tool from the SBOM. "
+        help="Omit the creation tool(s) from the SBOM. "
         "Overrides --creation-tool and pyproject.toml.",
     )
     parser.add_argument(
@@ -241,15 +318,44 @@ def _resolve_creation_field(
     return _ResolvedValue(value=default_value, source="default")
 
 
-def _resolve_creation_tool(
+def _resolve_creators(
     args: argparse.Namespace,
-    config_value: str | None,
-    default_value: str | None,
-) -> _ResolvedValue:
-    """Resolve the creation tool, supporting explicit omission via CLI."""
+    config_creators: list[Creator],
+) -> _ResolvedCreators:
+    """Resolve the creator list with precedence CLI > pyproject > default.
+
+    A whole-list replacement: if the CLI supplies any ``--creator-name``,
+    it replaces the config's creators entirely rather than merging.
+    """
+    cli_creators: list[Creator] | None = args.creators
+    if cli_creators:
+        return _ResolvedCreators(value=cli_creators, source="command-line")
+    if config_creators:
+        return _ResolvedCreators(
+            value=config_creators, source=_PROJECT_PYPROJECT_SOURCE
+        )
+    return _ResolvedCreators(value=[], source="default")
+
+
+def _resolve_tools(
+    args: argparse.Namespace,
+    config_tools: list[ToolInfo] | None,
+) -> _ResolvedTools:
+    """Resolve the tool list, supporting explicit omission via CLI.
+
+    A whole-list replacement, same as :func:`_resolve_creators`.
+    """
     if args.no_creation_tool:
-        return _ResolvedValue(value=None, source="command-line")
-    return _resolve_creation_field(args.creation_tool, config_value, default_value)
+        return _ResolvedTools(value=[], source="command-line")
+    cli_tools: list[str] | None = args.creation_tools
+    if cli_tools:
+        return _ResolvedTools(
+            value=[ToolInfo(name=name) for name in cli_tools],
+            source="command-line",
+        )
+    if config_tools is not None:
+        return _ResolvedTools(value=config_tools, source=_PROJECT_PYPROJECT_SOURCE)
+    return _ResolvedTools(value=None, source="default")
 
 
 def _resolve_creation_metadata(
@@ -259,30 +365,12 @@ def _resolve_creation_metadata(
     """Resolve creation metadata in CreationMetadata field order."""
     default_creation = CreationMetadata()
     return _ResolvedCreationMetadata(
-        creator_name=_resolve_creation_field(
-            args.creation_creator_name,
-            pitloom_config.creation_creator_name,
-            default_creation.creator_name,
-        ),
-        creator_email=_resolve_creation_field(
-            args.creation_creator_email,
-            pitloom_config.creation_creator_email,
-            default_creation.creator_email,
-        ),
-        creator_type=_resolve_creation_field(
-            args.creation_creator_type,
-            pitloom_config.creation_creator_type,
-            default_creation.creator_type,
-        ),
+        creators=_resolve_creators(args, pitloom_config.creators),
+        tools=_resolve_tools(args, pitloom_config.tools),
         creation_datetime=_resolve_creation_field(
             args.creation_datetime,
-            pitloom_config.creation_creation_datetime,
+            pitloom_config.creation_datetime,
             default_creation.creation_datetime,
-        ),
-        creation_tool=_resolve_creation_tool(
-            args,
-            pitloom_config.creation_creation_tool,
-            default_creation.creation_tool,
         ),
         creation_comment=_resolve_creation_field(
             args.creation_comment,
@@ -412,41 +500,57 @@ def _build_creation_option_rows(
     eff_desc: bool,
     desc_src: str,
 ) -> list[tuple[str, str, str]]:
-    """Build ordered rows for creation-related verbose options."""
-    return [
+    """Build ordered rows for creation-related verbose options.
+
+    Each creator and each tool is listed individually with its source, since
+    both are now lists rather than single values.
+    """
+    rows: list[tuple[str, str, str]] = [
         ("pretty", str(eff_pretty), pretty_src),
         ("describe_relationship", str(eff_desc), desc_src),
-        (
-            "creator_name",
-            _quote_optional(creation.creator_name.value),
-            creation.creator_name.source,
-        ),
-        (
-            "creator_email",
-            _quote_optional(creation.creator_email.value),
-            creation.creator_email.source,
-        ),
-        (
-            "creator_type",
-            _quote_optional(creation.creator_type.value),
-            creation.creator_type.source,
-        ),
+    ]
+
+    if creation.creators.value:
+        for index, creator in enumerate(creation.creators.value, start=1):
+            rows.append(
+                (
+                    f"creator[{index}]",
+                    f"name={creator.name!r} type={creator.type!r} "
+                    f"email={_quote_optional(creator.email)}",
+                    creation.creators.source,
+                )
+            )
+    else:
+        rows.append(
+            ("creators", "[] (SoftwareAgent 'Pitloom')", creation.creators.source)
+        )
+
+    tools_value = creation.tools.value
+    if tools_value is None:
+        rows.append(("tools", "None (default: 'Pitloom')", creation.tools.source))
+    elif not tools_value:
+        rows.append(("tools", "[] (createdUsing omitted)", creation.tools.source))
+    else:
+        for index, tool in enumerate(tools_value, start=1):
+            rows.append(
+                (f"tool[{index}]", f"name={tool.name!r}", creation.tools.source)
+            )
+
+    rows.append(
         (
             "creation_datetime",
             _quote_optional(creation.creation_datetime.value),
             creation.creation_datetime.source,
-        ),
-        (
-            "creation_tool",
-            _quote_optional(creation.creation_tool.value),
-            creation.creation_tool.source,
-        ),
+        )
+    )
+    rows.append(
         (
             "creation_comment",
             _quote_optional(creation.creation_comment.value),
             creation.creation_comment.source,
-        ),
-    ]
+        )
+    )
+    return rows
 
 
 def _print_aligned_rows(rows: list[tuple[str, str, str]]) -> None:

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -115,7 +115,12 @@ class _CreatorTypeAction(argparse.Action):
         creators: list[Creator] | None = getattr(namespace, self.dest)
         if not creators:
             parser.error(f"{option_string} must come after a --creator-name")
-        creators[-1].type = values
+        # Reconstruct rather than mutate in-place so this routes through
+        # Creator.__post_init__ normalisation/validation (defense in depth,
+        # in case `choices=` on this argument is ever loosened).
+        creators[-1] = Creator(
+            name=creators[-1].name, type=values, email=creators[-1].email
+        )
 
 
 class _CreatorEmailAction(argparse.Action):
@@ -131,7 +136,10 @@ class _CreatorEmailAction(argparse.Action):
         creators: list[Creator] | None = getattr(namespace, self.dest)
         if not creators:
             parser.error(f"{option_string} must come after a --creator-name")
-        creators[-1].email = values
+        # Reconstruct rather than mutate in-place, see _CreatorTypeAction.
+        creators[-1] = Creator(
+            name=creators[-1].name, type=creators[-1].type, email=values
+        )
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/src/pitloom/assemble/spdx3/creation_info.py
+++ b/src/pitloom/assemble/spdx3/creation_info.py
@@ -17,7 +17,7 @@ from datetime import datetime, timezone
 from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.__about__ import __version__
-from pitloom.core.creation import CreationMetadata
+from pitloom.core.creation import VALID_CREATOR_TYPES, CreationMetadata, ToolInfo
 from pitloom.core.models import generate_spdx_id
 from pitloom.export.spdx3_json import require_spdx_id
 
@@ -51,99 +51,120 @@ def spdx3_utc_now() -> datetime:
 #: Valid ``creator_type`` values -> the SPDX 3 Agent subclass to construct.
 #: All four are valid ``createdBy`` types per the spec; "agent" is the
 #: generic base class, for a creator that is deliberately unspecified.
+#: Keys must match :data:`pitloom.core.creation.VALID_CREATOR_TYPES` exactly
+#: -- that constant is the canonical source of valid creator-type names
+#: (validated eagerly in ``Creator.__post_init__``); this dict just adds the
+#: SPDX 3 Agent subclass for each, which ``core`` cannot know about since
+#: ``core`` must not import from ``assemble``.
 CREATOR_TYPES: dict[str, type[spdx3.Agent]] = {
     "person": spdx3.Person,
     "organization": spdx3.Organization,
     "software-agent": spdx3.SoftwareAgent,
     "agent": spdx3.Agent,
 }
+assert set(CREATOR_TYPES) == VALID_CREATOR_TYPES, (
+    "CREATOR_TYPES keys must match pitloom.core.creation.VALID_CREATOR_TYPES"
+)
 
 
-def _tool_summary(creation_tool: str) -> str | None:
-    """Pitloom's version, but only when *creation_tool* is still the default
-    ``"Pitloom"`` name -- a user-supplied tool name may not refer to Pitloom
-    itself, so no version is asserted in that case.
+def _tool_summary(tool_name: str) -> str | None:
+    """Pitloom's version, but only when *tool_name* is literally ``"Pitloom"``
+    -- a user-supplied tool name may not refer to Pitloom itself, so no
+    version is asserted in that case.
     """
-    if creation_tool == CreationMetadata().creation_tool:
+    if tool_name == "Pitloom":
         return f"Pitloom {__version__}"
     return None
 
 
-def build_creator_agent(
+def build_creator_agents(
     creation_metadata: CreationMetadata,
     doc_name: str,
     doc_uuid: str,
     spdx_ci: spdx3.CreationInfo,
-) -> spdx3.Agent:
-    """Build the ``createdBy`` Agent.
+) -> list[spdx3.Agent]:
+    """Build the ``createdBy`` Agents, one per named creator.
 
-    A named creator becomes whichever Agent subclass ``creator_type``
+    Each named creator becomes whichever Agent subclass its ``type``
     selects -- ``Person`` (default), ``Organization``, ``SoftwareAgent``, or
     the generic ``Agent`` -- see :data:`CREATOR_TYPES`. With no named
-    creator, the automated ``SoftwareAgent`` ``"Pitloom"`` stands in --
+    creators, the automated ``SoftwareAgent`` ``"Pitloom"`` stands in --
     Pitloom running on its own -- which satisfies ``createdBy``'s required
     Agent without asserting a human did the work.
 
     Raises:
-        ValueError: If ``creator_type`` is set but not one of
+        ValueError: If a creator's ``type`` is set but not one of
             :data:`CREATOR_TYPES`.
     """
-    if not creation_metadata.creator_name:
-        return spdx3.SoftwareAgent(
-            spdxId=generate_spdx_id(
-                "SoftwareAgent", doc_name=doc_name, doc_uuid=doc_uuid
-            ),
-            name="Pitloom",
-            creationInfo=spdx_ci,
-        )
-
-    creator_type = (creation_metadata.creator_type or "person").strip().lower()
-    agent_cls = CREATOR_TYPES.get(creator_type)
-    if agent_cls is None:
-        valid = ", ".join(sorted(CREATOR_TYPES))
-        raise ValueError(
-            f"Invalid creator_type {creation_metadata.creator_type!r}; "
-            f"must be one of: {valid}."
-        )
-    agent = agent_cls(
-        spdxId=generate_spdx_id(
-            agent_cls.__name__, doc_name=doc_name, doc_uuid=doc_uuid
-        ),
-        name=creation_metadata.creator_name,
-        creationInfo=spdx_ci,
-    )
-    if creation_metadata.creator_email:
-        agent.externalIdentifier = [
-            spdx3.ExternalIdentifier(
-                externalIdentifierType=spdx3.ExternalIdentifierType.email,
-                identifier=creation_metadata.creator_email,
+    if not creation_metadata.creators:
+        return [
+            spdx3.SoftwareAgent(
+                spdxId=generate_spdx_id(
+                    "SoftwareAgent", doc_name=doc_name, doc_uuid=doc_uuid
+                ),
+                name="Pitloom",
+                creationInfo=spdx_ci,
             )
         ]
-    return agent
+
+    agents: list[spdx3.Agent] = []
+    for creator in creation_metadata.creators:
+        creator_type = (creator.type or "person").strip().lower()
+        agent_cls = CREATOR_TYPES.get(creator_type)
+        if agent_cls is None:
+            valid = ", ".join(sorted(CREATOR_TYPES))
+            raise ValueError(
+                f"Invalid creator type {creator.type!r}; must be one of: {valid}."
+            )
+        agent = agent_cls(
+            spdxId=generate_spdx_id(
+                agent_cls.__name__, doc_name=doc_name, doc_uuid=doc_uuid
+            ),
+            name=creator.name,
+            creationInfo=spdx_ci,
+        )
+        if creator.email:
+            agent.externalIdentifier = [
+                spdx3.ExternalIdentifier(
+                    externalIdentifierType=spdx3.ExternalIdentifierType.email,
+                    identifier=creator.email,
+                )
+            ]
+        agents.append(agent)
+    return agents
 
 
-def build_tool(
+def build_tools(
     creation_metadata: CreationMetadata,
     doc_name: str,
     doc_uuid: str,
     spdx_ci: spdx3.CreationInfo,
-) -> spdx3.Tool | None:
-    """Build the ``createdUsing`` Tool, or ``None`` when suppressed.
+) -> list[spdx3.Tool]:
+    """Build the ``createdUsing`` Tools.
 
-    ``Tool.summary`` carries Pitloom's version, but only for the default
-    ``"Pitloom"`` tool name (see :func:`_tool_summary`).
+    ``tools is None`` yields the default single ``Tool`` ``"Pitloom"``;
+    ``tools == []`` suppresses ``createdUsing`` entirely; otherwise one
+    ``Tool`` per :class:`~pitloom.core.creation.ToolInfo`.  ``Tool.summary``
+    carries Pitloom's version, but only for a tool literally named
+    ``"Pitloom"`` (see :func:`_tool_summary`).
     """
-    if not creation_metadata.creation_tool:
-        return None
-    tool = spdx3.Tool(
-        spdxId=generate_spdx_id("Tool", doc_name=doc_name, doc_uuid=doc_uuid),
-        name=creation_metadata.creation_tool,
-        creationInfo=spdx_ci,
+    tool_infos = (
+        [ToolInfo(name="Pitloom")]
+        if creation_metadata.tools is None
+        else creation_metadata.tools
     )
-    summary = _tool_summary(creation_metadata.creation_tool)
-    if summary:
-        tool.summary = summary
-    return tool
+    tools: list[spdx3.Tool] = []
+    for tool_info in tool_infos:
+        tool = spdx3.Tool(
+            spdxId=generate_spdx_id("Tool", doc_name=doc_name, doc_uuid=doc_uuid),
+            name=tool_info.name,
+            creationInfo=spdx_ci,
+        )
+        summary = _tool_summary(tool_info.name)
+        if summary:
+            tool.summary = summary
+        tools.append(tool)
+    return tools
 
 
 def build_creation_info(
@@ -152,13 +173,13 @@ def build_creation_info(
     doc_uuid: str,
     *,
     default_comment: str | None = None,
-) -> tuple[spdx3.CreationInfo, spdx3.Agent, spdx3.Tool | None]:
-    """Assemble a ``CreationInfo`` plus its creator Agent and Tool.
+) -> tuple[spdx3.CreationInfo, list[spdx3.Agent], list[spdx3.Tool]]:
+    """Assemble a ``CreationInfo`` plus its creator Agents and Tools.
 
     ``created`` comes from ``creation_metadata.creation_datetime`` (normalised
     to SPDX DateTime) or the current UTC time.  ``comment`` uses
     ``creation_metadata.creation_comment`` if set, else *default_comment*.
-    The creator Agent goes in ``createdBy`` and the Tool (when present) in
+    The creator Agents go in ``createdBy`` and the Tools (when present) in
     ``createdUsing``.
     """
     created = (
@@ -176,20 +197,20 @@ def build_creation_info(
     if comment:
         spdx_ci.comment = comment
 
-    creator = build_creator_agent(creation_metadata, doc_name, doc_uuid, spdx_ci)
-    tool = build_tool(creation_metadata, doc_name, doc_uuid, spdx_ci)
+    agents = build_creator_agents(creation_metadata, doc_name, doc_uuid, spdx_ci)
+    tools = build_tools(creation_metadata, doc_name, doc_uuid, spdx_ci)
 
-    spdx_ci.createdBy = [require_spdx_id(creator)]
-    if tool is not None:
-        spdx_ci.createdUsing = [require_spdx_id(tool)]
-    return spdx_ci, creator, tool
+    spdx_ci.createdBy = [require_spdx_id(agent) for agent in agents]
+    if tools:
+        spdx_ci.createdUsing = [require_spdx_id(tool) for tool in tools]
+    return spdx_ci, agents, tools
 
 
 __all__ = [
     "parse_iso_datetime",
     "to_spdx3_datetime",
     "spdx3_utc_now",
-    "build_creator_agent",
-    "build_tool",
+    "build_creator_agents",
+    "build_tools",
     "build_creation_info",
 ]

--- a/src/pitloom/assemble/spdx3/creation_info.py
+++ b/src/pitloom/assemble/spdx3/creation_info.py
@@ -62,9 +62,10 @@ CREATOR_TYPES: dict[str, type[spdx3.Agent]] = {
     "software-agent": spdx3.SoftwareAgent,
     "agent": spdx3.Agent,
 }
-assert set(CREATOR_TYPES) == VALID_CREATOR_TYPES, (
-    "CREATOR_TYPES keys must match pitloom.core.creation.VALID_CREATOR_TYPES"
-)
+if set(CREATOR_TYPES) != VALID_CREATOR_TYPES:
+    raise RuntimeError(
+        "CREATOR_TYPES keys must match pitloom.core.creation.VALID_CREATOR_TYPES"
+    )
 
 
 def _tool_summary(tool_name: str) -> str | None:

--- a/src/pitloom/assemble/spdx3/document.py
+++ b/src/pitloom/assemble/spdx3/document.py
@@ -29,7 +29,7 @@ from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 
 def _build_creation_bundle(
     doc: DocumentModel, doc_uuid: str
-) -> tuple[spdx3.CreationInfo, spdx3.Agent, spdx3.Tool | None]:
+) -> tuple[spdx3.CreationInfo, list[spdx3.Agent], list[spdx3.Tool]]:
     """Create shared SPDX creation objects for the document."""
     return build_creation_info(doc.creation_metadata, doc.project.name, doc_uuid)
 
@@ -48,7 +48,7 @@ def _build_provenance_comment(doc: DocumentModel) -> str | None:
 def _build_main_package(
     doc: DocumentModel,
     spdx_ci: spdx3.CreationInfo,
-    creator: spdx3.Agent,
+    agents: list[spdx3.Agent],
     doc_uuid: str,
 ) -> spdx3.software_Package:
     """Create the SPDX package representing the Python project."""
@@ -63,9 +63,10 @@ def _build_main_package(
     main_package.software_packageVersion = metadata.version or "unknown"
     # suppliedBy names who supplied the package, so only assert it for a real
     # named creator -- not for the default SoftwareAgent "Pitloom", which is
-    # the SBOM tool, not the package's supplier.
-    if creation_metadata.creator_name:
-        main_package.suppliedBy = creator.spdxId
+    # the SBOM tool, not the package's supplier.  suppliedBy is single-valued
+    # in SPDX 3, so when multiple creators are named, the *first* one is used.
+    if creation_metadata.creators:
+        main_package.suppliedBy = agents[0].spdxId
     if metadata.description:
         main_package.description = metadata.description
     if download_location:
@@ -205,16 +206,17 @@ def build(doc: DocumentModel, merkle_root: str | None = None) -> Spdx3JsonExport
     )
     _clear_doc_counters(doc_uuid)
 
-    # --- Creation info, creator agent, and creation tool ---
-    spdx_ci, creator, tool = _build_creation_bundle(doc, doc_uuid)
+    # --- Creation info, creator agents, and creation tools ---
+    spdx_ci, agents, tools = _build_creation_bundle(doc, doc_uuid)
 
     exporter.add_creation_info(spdx_ci)
-    exporter.add_agent(creator)
-    if tool is not None:
+    for agent in agents:
+        exporter.add_agent(agent)
+    for tool in tools:
         exporter.object_set.add(tool)
 
     # --- Main package ---
-    main_package = _build_main_package(doc, spdx_ci, creator, doc_uuid)
+    main_package = _build_main_package(doc, spdx_ci, agents, doc_uuid)
 
     # --- SBOM and document envelope ---
     sbom = spdx3.software_Sbom(
@@ -325,11 +327,12 @@ def build_model(
     )
     _clear_doc_counters(doc_uuid)
 
-    spdx_ci, creator, tool = build_creation_info(creation_metadata, doc_name, doc_uuid)
+    spdx_ci, agents, tools = build_creation_info(creation_metadata, doc_name, doc_uuid)
 
     exporter.add_creation_info(spdx_ci)
-    exporter.add_agent(creator)
-    if tool is not None:
+    for agent in agents:
+        exporter.add_agent(agent)
+    for tool in tools:
         exporter.object_set.add(tool)
 
     ai_pkg = _build_ai_package(model, spdx_ci, doc_name, doc_uuid)

--- a/src/pitloom/core/config.py
+++ b/src/pitloom/core/config.py
@@ -11,10 +11,26 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from pitloom.core.creation import Creator, ToolInfo
+
 if sys.version_info >= (3, 11):
     import tomllib
 else:
     import tomli as tomllib
+
+
+#: Old (pre-multi-creator) ``[tool.pitloom.creation]`` keys that moved to
+#: ``[[tool.pitloom.creator]]`` / ``[[tool.pitloom.creation-tool]]``.
+_MOVED_CREATION_KEYS: dict[str, str] = {
+    "creator-name": "[[tool.pitloom.creator]] (key: name)",
+    "creator_name": "[[tool.pitloom.creator]] (key: name)",
+    "creator-email": "[[tool.pitloom.creator]] (key: email)",
+    "creator_email": "[[tool.pitloom.creator]] (key: email)",
+    "creator-type": "[[tool.pitloom.creator]] (key: type)",
+    "creator_type": "[[tool.pitloom.creator]] (key: type)",
+    "creation-tool": "[[tool.pitloom.creation-tool]] (key: name)",
+    "creation_tool": "[[tool.pitloom.creation-tool]] (key: name)",
+}
 
 
 @dataclass
@@ -36,16 +52,13 @@ class PitloomConfig:
             The full filename is derived by appending the format-specific
             extension (e.g., ``".spdx3.json"``).
             When ``None``, callers choose a context-appropriate default.
-        creation_creator_name: Optional creator name override from
-            ``[tool.pitloom.creation]``.
-        creation_creator_email: Optional creator email override from
-            ``[tool.pitloom.creation]``.
-        creation_creator_type: Optional creator type (``"person"``,
-            ``"organization"``, ``"software-agent"``, or ``"agent"``) from
-            ``[tool.pitloom.creation]``.
-        creation_creation_datetime: Optional creation timestamp override from
-            ``[tool.pitloom.creation]``.
-        creation_creation_tool: Optional creation tool name override from
+        creators: Named creators read from ``[[tool.pitloom.creator]]``
+            array-of-tables.  Empty when none are configured.
+        tools: Creation tools read from ``[[tool.pitloom.creation-tool]]``
+            array-of-tables.  ``None`` when not configured (caller default
+            applies); an explicit ``no-creation-tool = true`` under
+            ``[tool.pitloom.creation]`` maps to an empty list.
+        creation_datetime: Optional creation timestamp override from
             ``[tool.pitloom.creation]``.
         creation_comment: Optional comment mapped to SPDX ``CreationInfo.comment``.
     """
@@ -54,24 +67,104 @@ class PitloomConfig:
     pretty: bool = False
     describe_relationship: bool | None = None
     sbom_basename: str | None = None
-    creation_creator_name: str | None = None
-    creation_creator_email: str | None = None
-    creation_creator_type: str | None = None
-    creation_creation_datetime: str | None = None
-    creation_creation_tool: str | None = None
+    creators: list[Creator] = field(default_factory=list)
+    tools: list[ToolInfo] | None = None
+    creation_datetime: str | None = None
     creation_comment: str | None = None
+
+
+def _check_moved_creation_keys(
+    pitloom_data: dict[str, Any], creation_data: dict[str, Any]
+) -> None:
+    """Raise a clear error if old single-valued creator/tool keys are present.
+
+    These keys used to be accepted either directly under ``[tool.pitloom]``
+    or under ``[tool.pitloom.creation]`` -- both locations are checked here.
+
+    ``[tool.pitloom]`` needs an extra check that ``[tool.pitloom.creation]``
+    doesn't: the new ``[[tool.pitloom.creation-tool]]`` array-of-tables
+    legitimately reuses the top-level key name ``creation-tool`` (as a list
+    of tables), so only a *string* value under that name at the top level
+    is the old, moved, single-valued usage -- a list is the new form and
+    must not be flagged.
+    """
+    for key in pitloom_data:
+        moved_to = _MOVED_CREATION_KEYS.get(key)
+        if moved_to is not None and isinstance(pitloom_data[key], str):
+            raise ValueError(
+                f"[tool.pitloom] {key!r} has moved to {moved_to}. "
+                "Update your pyproject.toml."
+            )
+    for key in creation_data:
+        moved_to = _MOVED_CREATION_KEYS.get(key)
+        if moved_to is not None:
+            raise ValueError(
+                f"[tool.pitloom.creation] {key!r} has moved to {moved_to}. "
+                "Update your pyproject.toml."
+            )
+
+
+def _read_creators(pitloom_data: dict[str, Any]) -> list[Creator]:
+    """Read ``[[tool.pitloom.creator]]`` array-of-tables into ``Creator`` objects."""
+    raw = pitloom_data.get("creator", [])
+    if not isinstance(raw, list):
+        return []
+    creators: list[Creator] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        creator_type = entry.get("type")
+        email = entry.get("email")
+        creators.append(
+            Creator(
+                name=name,
+                type=creator_type if isinstance(creator_type, str) else "person",
+                email=email if isinstance(email, str) else None,
+            )
+        )
+    return creators
+
+
+def _read_tools(pitloom_data: dict[str, Any]) -> list[ToolInfo] | None:
+    """Read ``[[tool.pitloom.creation-tool]]`` array-of-tables into ``ToolInfo``."""
+    raw = pitloom_data.get("creation-tool", pitloom_data.get("creation_tool"))
+    if raw is None:
+        return None
+    if not isinstance(raw, list):
+        return None
+    tools: list[ToolInfo] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if isinstance(name, str) and name:
+            tools.append(ToolInfo(name=name))
+    return tools
 
 
 def _read_pitloom_config(data: dict[str, Any]) -> PitloomConfig:
     """Read ``[tool.pitloom]`` settings and return a :class:`PitloomConfig`.
 
-    Creation metadata can be set in either ``[tool.pitloom.creation]``
-    (preferred) or legacy flat keys under ``[tool.pitloom]``.
+    Creators come from ``[[tool.pitloom.creator]]``, tools from
+    ``[[tool.pitloom.creation-tool]]``; ``[tool.pitloom.creation]`` still
+    carries the document-level singletons: ``creation-datetime``,
+    ``creation-comment``, and ``no-creation-tool``.
+
+    Raises:
+        ValueError: If ``[tool.pitloom]`` or ``[tool.pitloom.creation]``
+            still has old single-valued ``creator-name``/``creator-email``/
+            ``creator-type``/``creation-tool`` keys -- these moved to the
+            array-of-tables form.
     """
     pitloom_data = data.get("tool", {}).get("pitloom", {})
     creation_data = pitloom_data.get("creation", {})
     if not isinstance(creation_data, dict):
         creation_data = {}
+
+    _check_moved_creation_keys(pitloom_data, creation_data)
 
     def _pick_str(*sources: tuple[dict[str, Any], tuple[str, ...]]) -> str | None:
         """Return the first string found by key, scanning *sources* in order.
@@ -99,25 +192,18 @@ def _read_pitloom_config(data: dict[str, Any]) -> PitloomConfig:
     if desc_rel is not None:
         desc_rel = bool(desc_rel)
     sbom_basename: str | None = pitloom_data.get("sbom-basename") or None
-    creation_creator_name = _pick_str(
-        (creation_data, ("creator-name", "creator_name")),
-        (pitloom_data, ("creator-name", "creator_name")),
-    )
-    creation_creator_email = _pick_str(
-        (creation_data, ("creator-email", "creator_email")),
-        (pitloom_data, ("creator-email", "creator_email")),
-    )
-    creation_creator_type = _pick_str(
-        (creation_data, ("creator-type", "creator_type")),
-        (pitloom_data, ("creator-type", "creator_type")),
-    )
-    creation_creation_datetime = _pick_str(
+
+    creators = _read_creators(pitloom_data)
+    tools = _read_tools(pitloom_data)
+    no_creation_tool = creation_data.get("no-creation-tool")
+    if no_creation_tool is None:
+        no_creation_tool = creation_data.get("no_creation_tool")
+    if no_creation_tool:
+        tools = []
+
+    creation_datetime = _pick_str(
         (creation_data, ("creation-datetime", "creation_datetime", "datetime")),
         (pitloom_data, ("creation-datetime", "creation_datetime")),
-    )
-    creation_creation_tool = _pick_str(
-        (creation_data, ("creation-tool", "creation_tool", "tool")),
-        (pitloom_data, ("creation-tool", "creation_tool")),
     )
     creation_comment = _pick_str(
         (creation_data, ("creation-comment", "creation_comment", "comment")),
@@ -129,11 +215,9 @@ def _read_pitloom_config(data: dict[str, Any]) -> PitloomConfig:
         fragments=fragments,
         describe_relationship=desc_rel,
         sbom_basename=sbom_basename,
-        creation_creator_name=creation_creator_name,
-        creation_creator_email=creation_creator_email,
-        creation_creator_type=creation_creator_type,
-        creation_creation_datetime=creation_creation_datetime,
-        creation_creation_tool=creation_creation_tool,
+        creators=creators,
+        tools=tools,
+        creation_datetime=creation_datetime,
         creation_comment=creation_comment,
     )
 

--- a/src/pitloom/core/config.py
+++ b/src/pitloom/core/config.py
@@ -76,17 +76,12 @@ class PitloomConfig:
 def _check_moved_creation_keys(
     pitloom_data: dict[str, Any], creation_data: dict[str, Any]
 ) -> None:
-    """Raise a clear error if old single-valued creator/tool keys are present.
+    """Raise a clear error if single-valued creator/tool keys are present
+    directly under ``[tool.pitloom]`` or ``[tool.pitloom.creation]``; they
+    belong in ``[[tool.pitloom.creator]]`` / ``[[tool.pitloom.creation-tool]]``.
 
-    These keys used to be accepted either directly under ``[tool.pitloom]``
-    or under ``[tool.pitloom.creation]`` -- both locations are checked here.
-
-    ``[tool.pitloom]`` needs an extra check that ``[tool.pitloom.creation]``
-    doesn't: the new ``[[tool.pitloom.creation-tool]]`` array-of-tables
-    legitimately reuses the top-level key name ``creation-tool`` (as a list
-    of tables), so only a *string* value under that name at the top level
-    is the old, moved, single-valued usage -- a list is the new form and
-    must not be flagged.
+    A top-level *string* ``creation-tool`` is the invalid single-valued
+    form; a *list* is the valid array-of-tables and must not be flagged.
     """
     for key in pitloom_data:
         moved_to = _MOVED_CREATION_KEYS.get(key)
@@ -108,18 +103,26 @@ def _read_creators(pitloom_data: dict[str, Any]) -> list[Creator]:
     """Read ``[[tool.pitloom.creator]]`` array-of-tables into ``Creator`` objects.
 
     Raises:
-        ValueError: If an entry in a present ``[[tool.pitloom.creator]]``
-            array is missing a valid (non-empty string) ``name``. A silently
-            dropped entry could otherwise reduce ``creators`` to ``[]``,
-            which changes the effective default creator.
+        ValueError: If ``creator`` is present but not an array of tables
+            (e.g. a single ``[tool.pitloom.creator]`` table, or
+            ``creator = ["Alice"]``), or if an entry is not a table or is
+            missing a valid (non-empty string) ``name``.
     """
-    raw = pitloom_data.get("creator", [])
-    if not isinstance(raw, list):
+    raw = pitloom_data.get("creator")
+    if raw is None:
         return []
+    if not isinstance(raw, list):
+        raise ValueError(
+            "[tool.pitloom.creator] must be an array of tables "
+            f"([[tool.pitloom.creator]]), got {type(raw).__name__}"
+        )
     creators: list[Creator] = []
     for entry in raw:
         if not isinstance(entry, dict):
-            continue
+            raise ValueError(
+                "[[tool.pitloom.creator]] entry must be a table, got "
+                f"{type(entry).__name__}: {entry!r}"
+            )
         name = entry.get("name")
         if not isinstance(name, str) or not name:
             raise ValueError(
@@ -142,23 +145,26 @@ def _read_tools(pitloom_data: dict[str, Any]) -> list[ToolInfo] | None:
     """Read ``[[tool.pitloom.creation-tool]]`` array-of-tables into ``ToolInfo``.
 
     Raises:
-        ValueError: If an entry in a present ``[[tool.pitloom.creation-tool]]``
-            array is missing a valid (non-empty string) ``name``. Without this
-            check, a typo/blank ``name`` would silently be dropped, which for
-            an array of all-invalid entries would produce ``[]`` -- and an
-            empty list means "suppress createdUsing entirely" downstream,
-            unintentionally dropping the default "Pitloom" tool instead of
-            falling back to default behaviour.
+        ValueError: If ``creation-tool`` is present but not an array of
+            tables (e.g. a single ``[tool.pitloom.creation-tool]`` table, or
+            ``creation-tool = ["MyWrapper"]``), or if an entry is not a
+            table or is missing a valid (non-empty string) ``name``.
     """
     raw = pitloom_data.get("creation-tool", pitloom_data.get("creation_tool"))
     if raw is None:
         return None
     if not isinstance(raw, list):
-        return None
+        raise ValueError(
+            "[tool.pitloom.creation-tool] must be an array of tables "
+            f"([[tool.pitloom.creation-tool]]), got {type(raw).__name__}"
+        )
     tools: list[ToolInfo] = []
     for entry in raw:
         if not isinstance(entry, dict):
-            continue
+            raise ValueError(
+                "[[tool.pitloom.creation-tool]] entry must be a table, got "
+                f"{type(entry).__name__}: {entry!r}"
+            )
         name = entry.get("name")
         if not isinstance(name, str) or not name:
             raise ValueError(

--- a/src/pitloom/core/config.py
+++ b/src/pitloom/core/config.py
@@ -214,7 +214,9 @@ def _read_pitloom_config(data: dict[str, Any]) -> PitloomConfig:
         ValueError: If ``[tool.pitloom]`` or ``[tool.pitloom.creation]``
             still has old single-valued ``creator-name``/``creator-email``/
             ``creator-type``/``creation-tool`` keys -- these moved to the
-            array-of-tables form.
+            array-of-tables form -- or if ``no-creation-tool`` is present
+            but not a boolean (e.g. the string ``"false"``, which Python
+            truthiness would otherwise silently treat as enabled).
     """
     pitloom_data = data.get("tool", {}).get("pitloom", {})
     creation_data = pitloom_data.get("creation", {})
@@ -255,6 +257,11 @@ def _read_pitloom_config(data: dict[str, Any]) -> PitloomConfig:
     no_creation_tool = creation_data.get("no-creation-tool")
     if no_creation_tool is None:
         no_creation_tool = creation_data.get("no_creation_tool")
+    if no_creation_tool is not None and not isinstance(no_creation_tool, bool):
+        raise ValueError(
+            "[tool.pitloom.creation] 'no-creation-tool' must be a boolean, "
+            f"got {type(no_creation_tool).__name__}: {no_creation_tool!r}"
+        )
     if no_creation_tool:
         tools = []
 

--- a/src/pitloom/core/config.py
+++ b/src/pitloom/core/config.py
@@ -105,7 +105,14 @@ def _check_moved_creation_keys(
 
 
 def _read_creators(pitloom_data: dict[str, Any]) -> list[Creator]:
-    """Read ``[[tool.pitloom.creator]]`` array-of-tables into ``Creator`` objects."""
+    """Read ``[[tool.pitloom.creator]]`` array-of-tables into ``Creator`` objects.
+
+    Raises:
+        ValueError: If an entry in a present ``[[tool.pitloom.creator]]``
+            array is missing a valid (non-empty string) ``name``. A silently
+            dropped entry could otherwise reduce ``creators`` to ``[]``,
+            which changes the effective default creator.
+    """
     raw = pitloom_data.get("creator", [])
     if not isinstance(raw, list):
         return []
@@ -115,7 +122,10 @@ def _read_creators(pitloom_data: dict[str, Any]) -> list[Creator]:
             continue
         name = entry.get("name")
         if not isinstance(name, str) or not name:
-            continue
+            raise ValueError(
+                "[[tool.pitloom.creator]] entry is missing a valid 'name' "
+                f"(got {name!r})"
+            )
         creator_type = entry.get("type")
         email = entry.get("email")
         creators.append(
@@ -129,7 +139,17 @@ def _read_creators(pitloom_data: dict[str, Any]) -> list[Creator]:
 
 
 def _read_tools(pitloom_data: dict[str, Any]) -> list[ToolInfo] | None:
-    """Read ``[[tool.pitloom.creation-tool]]`` array-of-tables into ``ToolInfo``."""
+    """Read ``[[tool.pitloom.creation-tool]]`` array-of-tables into ``ToolInfo``.
+
+    Raises:
+        ValueError: If an entry in a present ``[[tool.pitloom.creation-tool]]``
+            array is missing a valid (non-empty string) ``name``. Without this
+            check, a typo/blank ``name`` would silently be dropped, which for
+            an array of all-invalid entries would produce ``[]`` -- and an
+            empty list means "suppress createdUsing entirely" downstream,
+            unintentionally dropping the default "Pitloom" tool instead of
+            falling back to default behaviour.
+    """
     raw = pitloom_data.get("creation-tool", pitloom_data.get("creation_tool"))
     if raw is None:
         return None
@@ -140,8 +160,12 @@ def _read_tools(pitloom_data: dict[str, Any]) -> list[ToolInfo] | None:
         if not isinstance(entry, dict):
             continue
         name = entry.get("name")
-        if isinstance(name, str) and name:
-            tools.append(ToolInfo(name=name))
+        if not isinstance(name, str) or not name:
+            raise ValueError(
+                "[[tool.pitloom.creation-tool]] entry is missing a valid "
+                f"'name' (got {name!r})"
+            )
+        tools.append(ToolInfo(name=name))
     return tools
 
 

--- a/src/pitloom/core/config.py
+++ b/src/pitloom/core/config.py
@@ -32,6 +32,13 @@ _MOVED_CREATION_KEYS: dict[str, str] = {
     "creation_tool": "[[tool.pitloom.creation-tool]] (key: name)",
 }
 
+#: Subset of ``_MOVED_CREATION_KEYS`` where a top-level ``list`` value is
+#: valid (the new array-of-tables form) rather than stale -- see
+#: :func:`_check_moved_creation_keys`.
+_MOVED_CREATION_KEYS_LIST_VALID: frozenset[str] = frozenset(
+    {"creation-tool", "creation_tool"}
+)
+
 
 @dataclass
 class PitloomConfig:
@@ -80,16 +87,25 @@ def _check_moved_creation_keys(
     directly under ``[tool.pitloom]`` or ``[tool.pitloom.creation]``; they
     belong in ``[[tool.pitloom.creator]]`` / ``[[tool.pitloom.creation-tool]]``.
 
-    A top-level *string* ``creation-tool`` is the invalid single-valued
-    form; a *list* is the valid array-of-tables and must not be flagged.
+    A top-level *list* ``creation-tool`` is the valid array-of-tables form
+    and must not be flagged; any other value there (string, int, bool,
+    ...) is the old/invalid single-valued form. The other moved keys
+    (``creator-name``/``creator-email``/``creator-type``) have no valid
+    form at all under ``[tool.pitloom]``, so any value present there --
+    regardless of type -- is flagged.
     """
     for key in pitloom_data:
         moved_to = _MOVED_CREATION_KEYS.get(key)
-        if moved_to is not None and isinstance(pitloom_data[key], str):
-            raise ValueError(
-                f"[tool.pitloom] {key!r} has moved to {moved_to}. "
-                "Update your pyproject.toml."
-            )
+        if moved_to is None:
+            continue
+        if key in _MOVED_CREATION_KEYS_LIST_VALID and isinstance(
+            pitloom_data[key], list
+        ):
+            continue
+        raise ValueError(
+            f"[tool.pitloom] {key!r} has moved to {moved_to}. "
+            "Update your pyproject.toml."
+        )
     for key in creation_data:
         moved_to = _MOVED_CREATION_KEYS.get(key)
         if moved_to is not None:
@@ -106,7 +122,8 @@ def _read_creators(pitloom_data: dict[str, Any]) -> list[Creator]:
         ValueError: If ``creator`` is present but not an array of tables
             (e.g. a single ``[tool.pitloom.creator]`` table, or
             ``creator = ["Alice"]``), or if an entry is not a table or is
-            missing a valid (non-empty string) ``name``.
+            missing a valid (non-empty string) ``name``, or if an entry's
+            ``type`` or ``email`` is present but not a string.
     """
     raw = pitloom_data.get("creator")
     if raw is None:
@@ -130,12 +147,22 @@ def _read_creators(pitloom_data: dict[str, Any]) -> list[Creator]:
                 f"(got {name!r})"
             )
         creator_type = entry.get("type")
+        if creator_type is not None and not isinstance(creator_type, str):
+            raise ValueError(
+                "[[tool.pitloom.creator]] entry 'type' must be a string, got "
+                f"{type(creator_type).__name__}: {creator_type!r}"
+            )
         email = entry.get("email")
+        if email is not None and not isinstance(email, str):
+            raise ValueError(
+                "[[tool.pitloom.creator]] entry 'email' must be a string, got "
+                f"{type(email).__name__}: {email!r}"
+            )
         creators.append(
             Creator(
                 name=name,
-                type=creator_type if isinstance(creator_type, str) else "person",
-                email=email if isinstance(email, str) else None,
+                type=creator_type if creator_type is not None else "person",
+                email=email,
             )
         )
     return creators

--- a/src/pitloom/core/creation.py
+++ b/src/pitloom/core/creation.py
@@ -6,7 +6,62 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+#: Valid ``Creator.type`` values -- the SPDX 3 Agent subclass a creator maps
+#: onto is selected by one of these names.  ``"agent"`` is the generic base
+#: class, for a creator that is deliberately unspecified.  This is the
+#: canonical set; :mod:`pitloom.assemble.spdx3.creation_info` builds its
+#: name -> Agent-class map from these same names (``core`` must not import
+#: from ``assemble``, so the mapping itself has to live there).
+VALID_CREATOR_TYPES: frozenset[str] = frozenset(
+    {"person", "organization", "software-agent", "agent"}
+)
+
+
+@dataclass
+class Creator:
+    """A single named creator, mapping onto an SPDX 3 Agent.
+
+    Attributes:
+        name: Display name of the person or organisation that initiated
+            the SBOM generation.
+        type: Agent subclass: ``"person"`` (default), ``"organization"``,
+            ``"software-agent"``, or the generic ``"agent"``.  All four are
+            valid ``createdBy`` types per the SPDX 3 spec.  Validated (and
+            normalised to lower-case, stripped) in ``__post_init__``.
+        email: E-mail address of the creator.  Recorded as an ``email``
+            external identifier on the creator Agent.
+
+    Raises:
+        ValueError: If ``type`` (after normalisation) is not one of
+            :data:`VALID_CREATOR_TYPES`.
+    """
+
+    name: str
+    type: str = "person"
+    email: str | None = None
+
+    def __post_init__(self) -> None:
+        normalized = (self.type or "person").strip().lower()
+        if normalized not in VALID_CREATOR_TYPES:
+            valid = ", ".join(sorted(VALID_CREATOR_TYPES))
+            raise ValueError(
+                f"Invalid creator type {self.type!r}; must be one of: {valid}."
+            )
+        self.type = normalized
+
+
+@dataclass
+class ToolInfo:
+    """A single creation tool, mapping onto an SPDX 3 Tool.
+
+    Attributes:
+        name: Name of the tool.  A tool literally named ``"Pitloom"`` gets
+            a version summary appended automatically.
+    """
+
+    name: str
 
 
 @dataclass
@@ -14,35 +69,31 @@ class CreationMetadata:
     """Metadata describing who and what generated an SBOM.
 
     Pitloom's own model for creation provenance -- distinct from, but
-    mapping onto, SPDX 3 ``CreationInfo``: the *creator* becomes an Agent in
-    ``createdBy`` (``Person``, ``Organization``, ``SoftwareAgent``, or the
-    generic ``Agent`` -- see ``creator_type``), and the *tool* becomes a
-    ``Tool`` in ``createdUsing``.  When no creator is named, the assembler
-    records the automated ``SoftwareAgent`` ``"Pitloom"`` in ``createdBy``
-    -- Pitloom acting on its own -- rather than inventing a ``Person``.
+    mapping onto, SPDX 3 ``CreationInfo``: each *creator* becomes an Agent
+    in ``createdBy`` (``Person``, ``Organization``, ``SoftwareAgent``, or
+    the generic ``Agent`` -- see ``Creator.type``), and each *tool* becomes
+    a ``Tool`` in ``createdUsing``.  When no creator is named, the
+    assembler records the automated ``SoftwareAgent`` ``"Pitloom"`` in
+    ``createdBy`` -- Pitloom acting on its own -- rather than inventing a
+    ``Person``.
 
     Attributes:
-        creator_name: Display name of the person or organisation that
-            initiated the SBOM generation.  When ``None`` (default), no named
-            creator is asserted and the assembler emits the ``SoftwareAgent``
-            ``"Pitloom"`` in ``createdBy`` instead.
-        creator_email: E-mail address of the creator.  Recorded as an
-            ``email`` external identifier on the creator Agent.  Ignored when
-            ``creator_name`` is ``None``.
-        creator_type: Agent subclass for a named creator: ``"person"``
-            (default), ``"organization"``, ``"software-agent"``, or the
-            generic ``"agent"``.  All four are valid ``createdBy`` types per
-            the SPDX 3 spec.  Ignored when ``creator_name`` is ``None``.
+        creators: Named creators, in order.  When empty (default), no named
+            creator is asserted and the assembler emits the
+            ``SoftwareAgent`` ``"Pitloom"`` in ``createdBy`` instead.  When
+            multiple creators are supplied, each becomes its own Agent; the
+            SPDX 3 ``suppliedBy`` of the main package (single-valued) is set
+            to the *first* named creator.
+        tools: Creation tools, in order.  ``None`` (default) means the
+            default single ``Tool`` ``"Pitloom"``.  An empty list suppresses
+            ``createdUsing`` entirely (the old ``--no-creation-tool``
+            behaviour).  A non-empty list emits one ``Tool`` per entry.
         creation_datetime: ISO 8601 string for the creation timestamp.
             Full ISO forms are accepted (e.g. offsets and fractional
             seconds). Pitloom preserves input precision internally and
             normalises to SPDX 3 DateTime (``YYYY-MM-DDThh:mm:ssZ``)
             only at export time.
             When ``None`` the assembler uses the current UTC time.
-        creation_tool: Name of the tool that produced the SBOM, emitted as a
-            ``Tool`` in ``createdUsing``.  Defaults to ``"Pitloom"``.  When
-            ``None``, no tool element is emitted and ``createdUsing`` is
-            omitted from ``CreationInfo``.
         creation_comment: Optional comment to include on the SPDX
             ``CreationInfo`` element.  Callers (CLI, Hatchling build hook)
             set this to a static description of the invocation channel,
@@ -54,13 +105,11 @@ class CreationMetadata:
             ``builtTime`` is omitted from the SBOM.
     """
 
-    creator_name: str | None = None
-    creator_email: str | None = None
-    creator_type: str = "person"
+    creators: list[Creator] = field(default_factory=list)
+    tools: list[ToolInfo] | None = None
     creation_datetime: str | None = None
-    creation_tool: str | None = "Pitloom"
     creation_comment: str | None = None
     build_datetime: str | None = None
 
 
-__all__ = ["CreationMetadata"]
+__all__ = ["VALID_CREATOR_TYPES", "CreationMetadata", "Creator", "ToolInfo"]

--- a/src/pitloom/core/creation.py
+++ b/src/pitloom/core/creation.py
@@ -34,8 +34,8 @@ class Creator:
             external identifier on the creator Agent.
 
     Raises:
-        ValueError: If ``type`` (after normalisation) is not one of
-            :data:`VALID_CREATOR_TYPES`.
+        ValueError: If ``name`` is empty or whitespace-only, or if ``type``
+            (after normalisation) is not one of :data:`VALID_CREATOR_TYPES`.
     """
 
     name: str
@@ -43,6 +43,8 @@ class Creator:
     email: str | None = None
 
     def __post_init__(self) -> None:
+        if not self.name or not self.name.strip():
+            raise ValueError(f"Creator name must be non-empty, got {self.name!r}.")
         normalized = (self.type or "person").strip().lower()
         if normalized not in VALID_CREATOR_TYPES:
             valid = ", ".join(sorted(VALID_CREATOR_TYPES))
@@ -59,9 +61,16 @@ class ToolInfo:
     Attributes:
         name: Name of the tool.  A tool literally named ``"Pitloom"`` gets
             a version summary appended automatically.
+
+    Raises:
+        ValueError: If ``name`` is empty or whitespace-only.
     """
 
     name: str
+
+    def __post_init__(self) -> None:
+        if not self.name or not self.name.strip():
+            raise ValueError(f"ToolInfo name must be non-empty, got {self.name!r}.")
 
 
 @dataclass
@@ -86,8 +95,8 @@ class CreationMetadata:
             to the *first* named creator.
         tools: Creation tools, in order.  ``None`` (default) means the
             default single ``Tool`` ``"Pitloom"``.  An empty list suppresses
-            ``createdUsing`` entirely (the old ``--no-creation-tool``
-            behaviour).  A non-empty list emits one ``Tool`` per entry.
+            ``createdUsing`` entirely (matches ``--no-creation-tool``).  A
+            non-empty list emits one ``Tool`` per entry.
         creation_datetime: ISO 8601 string for the creation timestamp.
             Full ISO forms are accepted (e.g. offsets and fractional
             seconds). Pitloom preserves input precision internally and

--- a/src/pitloom/extract/_fasttext.py
+++ b/src/pitloom/extract/_fasttext.py
@@ -6,10 +6,13 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
 from pitloom.core.ai_metadata import AiModelFormat, AiModelFormatInfo, AiModelMetadata
+
+log = logging.getLogger(__name__)
 
 # Maps Args attribute names (from model.f.getArgs()) to hyperparameter keys.
 # The Python fasttext package exposes training configuration via the C++
@@ -45,6 +48,7 @@ def _load_fasttext_model(model_path: Path) -> Any:
     try:
         return fasttext.load_model(str(model_path))
     except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug("Failed to load fastText model from %s: %s", model_path, exc)
         raise ValueError(
             f"Failed to load fastText model from {model_path}: {exc}"
         ) from exc
@@ -60,7 +64,8 @@ def _extract_fasttext_args(
 
     try:
         args = model.f.getArgs()
-    except Exception:  # pylint: disable=broad-exception-caught
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug("Failed to read fastText model.f.getArgs(): %s", exc)
         return hyperparameters, properties, type_of_model
 
     for attr, param_key in _FASTTEXT_ARGS_HYPERPARAMS:
@@ -95,7 +100,8 @@ def _extract_fasttext_outputs(
 
     try:
         labels = get_labels()
-    except Exception:  # pylint: disable=broad-exception-caught
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug("Failed to read fastText model labels: %s", exc)
         return properties, outputs
 
     if labels:

--- a/src/pitloom/extract/_gguf.py
+++ b/src/pitloom/extract/_gguf.py
@@ -6,11 +6,14 @@
 
 from __future__ import annotations
 
+import logging
 import struct
 from pathlib import Path
 from typing import Any
 
 from pitloom.core.ai_metadata import AiModelFormat, AiModelFormatInfo, AiModelMetadata
+
+log = logging.getLogger(__name__)
 
 # Standard GGUF general keys used for SPDX AI fields
 _GGUF_NAME_KEYS = ("general.name",)
@@ -59,7 +62,12 @@ def _resolve_quantization(file_type_value: Any) -> str | None:
         from gguf import GGMLQuantizationType
 
         return str(GGMLQuantizationType(int_val).name)
-    except Exception:  # pylint: disable=broad-exception-caught
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug(
+            "Failed to resolve GGUF quantization name for file_type=%r: %s",
+            file_type_value,
+            exc,
+        )
         return str(int_val)
 
 
@@ -99,6 +107,7 @@ def read_gguf(model_path: Path) -> AiModelMetadata:
     try:
         reader = GGUFReader(str(model_path), mode="r")
     except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug("Failed to open GGUF file %s: %s", model_path, exc)
         raise ValueError(f"Failed to read GGUF file {model_path}: {exc}") from exc
 
     source = f"Source: {model_path.name}"

--- a/src/pitloom/extract/_hdf5.py
+++ b/src/pitloom/extract/_hdf5.py
@@ -49,10 +49,13 @@ References:
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
 from pitloom.core.ai_metadata import AiModelFormat, AiModelFormatInfo, AiModelMetadata
+
+log = logging.getLogger(__name__)
 
 
 def _decode_h5_attr(value: Any) -> str | None:
@@ -294,6 +297,7 @@ def read_hdf5(model_path: Path) -> AiModelMetadata:
     try:
         hf = h5py.File(str(model_path), "r")
     except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug("Failed to open HDF5 file %s: %s", model_path, exc)
         raise ValueError(f"Failed to read HDF5 file {model_path}: {exc}") from exc
 
     with hf:

--- a/src/pitloom/extract/_huggingface.py
+++ b/src/pitloom/extract/_huggingface.py
@@ -50,6 +50,7 @@ with an up-to-date database (``licenseid update``).
 from __future__ import annotations
 
 import json
+import logging
 import re
 from typing import Any, NamedTuple
 
@@ -60,6 +61,8 @@ from pitloom.core.ai_metadata import (
     AiModelUsage,
 )
 from pitloom.core.dataset_metadata import DatasetMetadata, DatasetReference
+
+log = logging.getLogger(__name__)
 
 # Match full HF URLs: https://huggingface.co/owner/name[/anything]
 _HF_URL_RE = re.compile(r"https?://huggingface\.co/([^/]+/[^/]+?)(?:/.*)?$")
@@ -243,7 +246,8 @@ def _safe_load_json(model_id: str, filename: str) -> dict[str, Any] | None:
         local_path = hf_hub_download(repo_id=model_id, filename=filename)
         with open(local_path, encoding="utf-8") as fh:
             return json.load(fh)  # type: ignore[no-any-return]
-    except Exception:  # pylint: disable=broad-exception-caught
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug("Failed to load %s for %s: %s", filename, model_id, exc)
         return None
 
 
@@ -258,7 +262,8 @@ def _load_model_card(
         card = ModelCard.load(model_id)
         card_data: dict[str, Any] = card.data.to_dict() if card.data else {}
         return card.text or None, card_data
-    except Exception:  # pylint: disable=broad-exception-caught
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug("Failed to load model card for %s: %s", model_id, exc)
         return None, {}
 
 
@@ -293,7 +298,8 @@ def _load_model_info(model_id: str) -> dict[str, Any]:
         if info.tags:
             result["tags"] = list(info.tags)
         return result
-    except Exception:  # pylint: disable=broad-exception-caught
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug("Failed to load model_info() for %s: %s", model_id, exc)
         return {}
 
 
@@ -309,7 +315,8 @@ def _list_license_files_in_repo(model_id: str) -> list[str]:
 
         existing: set[str] = set(list_repo_files(model_id))
         return [f for f in _HF_LICENSE_FILENAMES if f in existing]
-    except Exception:  # pylint: disable=broad-exception-caught
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug("Failed to list repo files for %s: %s", model_id, exc)
         return []
 
 
@@ -339,7 +346,13 @@ def _detect_license_from_hf_files(
             text = (
                 _Path(local_path).read_text(encoding="utf-8", errors="replace").strip()
             )
-        except Exception:  # pylint: disable=broad-exception-caught
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            log.debug(
+                "Failed to download/read license file %s for %s: %s",
+                filename,
+                model_id,
+                exc,
+            )
             continue
 
         if not text:

--- a/src/pitloom/extract/_keras.py
+++ b/src/pitloom/extract/_keras.py
@@ -25,11 +25,14 @@ References:
 from __future__ import annotations
 
 import json
+import logging
 import zipfile
 from pathlib import Path
 from typing import Any
 
 from pitloom.core.ai_metadata import AiModelFormat, AiModelFormatInfo, AiModelMetadata
+
+log = logging.getLogger(__name__)
 
 
 def _parse_model_config(
@@ -157,6 +160,7 @@ def read_keras(model_path: Path) -> AiModelMetadata:
             f"Failed to read Keras file {model_path}: not a valid ZIP archive"
         ) from exc
     except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug("Failed to read Keras file %s: %s", model_path, exc)
         raise ValueError(f"Failed to read Keras file {model_path}: {exc}") from exc
 
     return AiModelMetadata(

--- a/src/pitloom/extract/_license.py
+++ b/src/pitloom/extract/_license.py
@@ -105,8 +105,8 @@ def canonicalize_license_id(raw: str) -> str:
         results = AggregatedLicenseMatcher().match(license_id=raw)
         if results:
             return str(results[0]["license_id"])
-    except Exception:  # pylint: disable=broad-exception-caught
-        pass
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        _logger.debug("Failed to canonicalize license id %r: %s", raw, exc)
     return raw
 
 

--- a/src/pitloom/extract/_numpy.py
+++ b/src/pitloom/extract/_numpy.py
@@ -11,10 +11,13 @@ References:
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
 from pitloom.core.ai_metadata import AiModelFormat, AiModelFormatInfo, AiModelMetadata
+
+log = logging.getLogger(__name__)
 
 # Maps NPY format major version -> header encoding.
 #   Version 1.x: 2-byte LE uint16 header-length field, latin1 encoding.
@@ -131,6 +134,7 @@ def read_numpy(model_path: Path) -> AiModelMetadata:
             if inputs:
                 provenance["inputs"] = f"{source} | Fields: array names, shapes, dtypes"
     except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug("Failed to read NumPy file %s: %s", model_path, exc)
         raise ValueError(f"Failed to read NumPy file {model_path}: {exc}") from exc
 
     return AiModelMetadata(

--- a/src/pitloom/extract/_onnx.py
+++ b/src/pitloom/extract/_onnx.py
@@ -6,10 +6,13 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
 from pitloom.core.ai_metadata import AiModelFormat, AiModelFormatInfo, AiModelMetadata
+
+log = logging.getLogger(__name__)
 
 
 def _onnx_tensor_specs(value_infos: Any) -> list[dict[str, Any]]:
@@ -70,6 +73,7 @@ def read_onnx(model_path: Path) -> AiModelMetadata:  # pylint: disable=too-many-
         # load_external_data=False avoids loading large external tensor files
         model = onnx.load(str(model_path), load_external_data=False)
     except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug("Failed to load ONNX model from %s: %s", model_path, exc)
         raise ValueError(f"Failed to load ONNX model from {model_path}: {exc}") from exc
 
     source = f"Source: {model_path.name}"

--- a/src/pitloom/extract/_pytorch.py
+++ b/src/pitloom/extract/_pytorch.py
@@ -11,11 +11,14 @@ References:
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 from zipfile import ZipFile
 
 from pitloom.core.ai_metadata import AiModelFormat, AiModelFormatInfo, AiModelMetadata
+
+log = logging.getLogger(__name__)
 
 
 def _fickling_get_top_class(pkl_bytes: bytes) -> str | None:
@@ -37,7 +40,8 @@ def _fickling_get_top_class(pkl_bytes: bytes) -> str | None:
 
     try:
         pkl = Pickled.load(io.BytesIO(pkl_bytes))
-    except Exception:  # pylint: disable=broad-exception-caught
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug("fickling failed to parse pickle bytes: %s", exc)
         return None
 
     def _dotted_name(node: Any) -> str | None:
@@ -95,8 +99,8 @@ def _read_pytorch_zip(
                 provenance["type_of_model"] = (
                     f"{source} | Field: {pkl_entry} (fickling)"
                 )
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            log.debug("Failed to inspect %s in %s: %s", pkl_entry, source, exc)
 
     return type_of_model, properties, provenance
 

--- a/src/pitloom/extract/_pytorch_pt2.py
+++ b/src/pitloom/extract/_pytorch_pt2.py
@@ -10,10 +10,13 @@ References:
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from zipfile import ZipFile
 
 from pitloom.core.ai_metadata import AiModelFormat, AiModelFormatInfo, AiModelMetadata
+
+log = logging.getLogger(__name__)
 
 
 def _read_pt2_meta_entry(
@@ -46,8 +49,8 @@ def _read_pt2_meta_entry(
                 field_name = "model_name"
             if name and field_name:
                 return name, f"{source} | Field: {meta_entry}.{field_name}"
-    except Exception:  # pylint: disable=broad-exception-caught
-        pass
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug("Failed to parse PT2 metadata entry %s: %s", meta_entry, exc)
     return None, None
 
 
@@ -119,8 +122,8 @@ def _read_pt2_extra_files(
         if full in file_list:
             try:
                 return zf.read(full).decode("utf-8", errors="replace").strip() or None
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                log.debug("Failed to read PT2 extra file %s: %s", full, exc)
         return None
 
     name = _read_text("extra/name")
@@ -153,7 +156,8 @@ def _read_pt2_extra_files(
                 properties["tags"] = ", ".join(str(t) for t in tags_list)
             else:
                 properties["tags"] = tags_raw
-        except Exception:  # pylint: disable=broad-exception-caught
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            log.debug("Failed to parse PT2 extra/tags as JSON: %s", exc)
             properties["tags"] = tags_raw
 
     if "author" in properties or "tags" in properties:
@@ -195,7 +199,8 @@ def _read_pt2_graph_io(
 
     try:
         data = json.loads(zf.read(model_json_path))
-    except Exception:  # pylint: disable=broad-exception-caught
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug("Failed to parse PT2 model graph %s: %s", model_json_path, exc)
         return [], []
 
     graph = (data.get("graph_module") or {}).get("graph") or {}
@@ -219,6 +224,7 @@ def _read_pt2_graph_io(
     return inputs, outputs
 
 
+# pylint: disable=too-many-locals
 def _read_pt2_zip(
     zf: ZipFile,
     source: str,
@@ -278,8 +284,8 @@ def _read_pt2_zip(
                 provenance["format_version"] = (
                     f"{source} | Field: {prefix}archive_version"
                 )
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            log.debug("Failed to read PT2 %sarchive_version: %s", prefix, exc)
 
     # PT2 Archive: optional metadata JSON (simple format).
     for meta_entry in ("METADATA.json", "metadata.json", "extra/metadata.json"):

--- a/src/pitloom/extract/_safetensors.py
+++ b/src/pitloom/extract/_safetensors.py
@@ -6,9 +6,12 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from pitloom.core.ai_metadata import AiModelFormat, AiModelFormatInfo, AiModelMetadata
+
+log = logging.getLogger(__name__)
 
 
 def read_safetensors(model_path: Path) -> AiModelMetadata:
@@ -54,6 +57,7 @@ def read_safetensors(model_path: Path) -> AiModelMetadata:
             raw_metadata: dict[str, str] = f.metadata() or {}
             tensor_keys: list[str] = list(f.keys())
     except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug("Failed to read Safetensors file %s: %s", model_path, exc)
         raise ValueError(
             f"Failed to read Safetensors file {model_path}: {exc}"
         ) from exc

--- a/src/pitloom/extract/setuptools.py
+++ b/src/pitloom/extract/setuptools.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import ast
 import configparser
+import logging
 import re
 import sys
 from pathlib import Path
@@ -54,6 +55,17 @@ if sys.version_info >= (3, 11):
     import tomllib
 else:
     import tomli as tomllib
+
+log = logging.getLogger(__name__)
+
+
+class _NoProjectNameError(ValueError):
+    """A setup.cfg/setup.py file has no project name -- try the next source.
+
+    Distinct from other ``ValueError``s the same reader can raise (e.g. a
+    malformed ``[tool:pitloom]`` section), which are genuine config mistakes
+    that must propagate rather than be treated as "try elsewhere".
+    """
 
 
 # Matches "file: some/path" or "attr: module.attribute"
@@ -89,8 +101,8 @@ def detect_build_backend(project_dir: Path) -> str | None:
                 return backend
         if build_backend:
             return build_backend.split(".")[0].lower()
-    except Exception:  # pylint: disable=broad-exception-caught
-        pass
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug("Failed to detect build backend from %s: %s", pyproject_path, exc)
     return None
 
 
@@ -112,7 +124,10 @@ def read_setuptools(project_dir: Path) -> tuple[ProjectMetadata, PitloomConfig]:
     Raises:
         FileNotFoundError: If neither ``setup.cfg`` nor ``setup.py`` exist,
             or neither contains a project name.
-        ValueError: If a project name cannot be found in any source.
+        ValueError: If ``setup.cfg``'s ``[tool:pitloom]``/
+            ``[tool:pitloom:creation]`` has invalid config -- this
+            propagates rather than falling through to ``setup.py``, since
+            it is a genuine config mistake, not a missing-name signal.
     """
     setup_cfg = project_dir / "setup.cfg"
     setup_py = project_dir / "setup.py"
@@ -124,7 +139,7 @@ def read_setuptools(project_dir: Path) -> tuple[ProjectMetadata, PitloomConfig]:
     if setup_cfg.exists():
         try:
             cfg_metadata, cfg_config = read_setup_cfg(project_dir)
-        except (FileNotFoundError, ValueError):
+        except (FileNotFoundError, _NoProjectNameError):
             pass
 
     if setup_py.exists():
@@ -170,7 +185,10 @@ def read_setup_cfg(
 
     Raises:
         FileNotFoundError: If ``setup.cfg`` is not found.
-        ValueError: If ``name`` is absent from the ``[metadata]`` section.
+        _NoProjectNameError: If ``name`` is absent from the ``[metadata]``
+            section.
+        ValueError: If ``[tool:pitloom]``/``[tool:pitloom:creation]`` has
+            invalid config (e.g. a bad ``creator-type``).
     """
     setup_cfg_path = project_dir / "setup.cfg"
     if not setup_cfg_path.exists():
@@ -184,7 +202,9 @@ def read_setup_cfg(
 
     name = metadata_raw.get("name", "").strip()
     if not name:
-        raise ValueError("Project name is required in setup.cfg [metadata] section")
+        raise _NoProjectNameError(
+            "Project name is required in setup.cfg [metadata] section"
+        )
 
     raw_version = metadata_raw.get("version", "").strip()
     version, version_source = _resolve_cfg_version(raw_version, project_dir)

--- a/src/pitloom/extract/setuptools.py
+++ b/src/pitloom/extract/setuptools.py
@@ -47,6 +47,7 @@ from pathlib import Path
 from typing import Any
 
 from pitloom.core.config import PitloomConfig
+from pitloom.core.creation import Creator, ToolInfo
 from pitloom.core.project import ProjectMetadata
 
 if sys.version_info >= (3, 11):
@@ -695,17 +696,39 @@ def _read_pitloom_config_from_cfg(
     fragments_raw = raw.get("fragments", "")
     fragments = [f.strip() for f in fragments_raw.splitlines() if f.strip()]
 
+    # setup.cfg (INI) cannot express array-of-tables, so only a single
+    # creator and a single tool are supported here -- multi-creator/tool
+    # setups need pyproject.toml or the library API.
+    creator_name = _pick_str("creator-name", "creator_name")
+    creators = (
+        [
+            Creator(
+                name=creator_name,
+                type=_pick_str("creator-type", "creator_type") or "person",
+                email=_pick_str("creator-email", "creator_email"),
+            )
+        ]
+        if creator_name
+        else []
+    )
+    creation_tool_name = _pick_str("creation-tool", "creation_tool", "tool")
+    tools = [ToolInfo(name=creation_tool_name)] if creation_tool_name else None
+
+    no_creation_tool_str = (
+        (_pick_str("no-creation-tool", "no_creation_tool") or "").strip().lower()
+    )
+    if no_creation_tool_str in ("true", "1", "yes"):
+        tools = []
+
     return PitloomConfig(
         pretty=pretty,
         describe_relationship=desc_rel,
         sbom_basename=sbom_basename,
         fragments=fragments,
-        creation_creator_name=_pick_str("creator-name", "creator_name"),
-        creation_creator_email=_pick_str("creator-email", "creator_email"),
-        creation_creator_type=_pick_str("creator-type", "creator_type"),
-        creation_creation_datetime=_pick_str(
+        creators=creators,
+        tools=tools,
+        creation_datetime=_pick_str(
             "creation-datetime", "creation_datetime", "datetime"
         ),
-        creation_creation_tool=_pick_str("creation-tool", "creation_tool", "tool"),
         creation_comment=_pick_str("creation-comment", "creation_comment", "comment"),
     )

--- a/src/pitloom/loom.py
+++ b/src/pitloom/loom.py
@@ -70,7 +70,7 @@ class _ActiveRun:
         # SoftwareAgent "Pitloom" is the createdBy actor, with the Tool
         # "Pitloom" in createdUsing. Unattended capture defaults the comment
         # to the loom-SDK note.
-        self.creation_info, agent, tool = build_creation_info(
+        self.creation_info, agents, tools = build_creation_info(
             creation_metadata or CreationMetadata(),
             "pitloom-sdk",
             self.doc_uuid,
@@ -78,8 +78,9 @@ class _ActiveRun:
         )
 
         self.exporter = Spdx3JsonExporter()
-        self.exporter.add_agent(agent)
-        if tool is not None:
+        for agent in agents:
+            self.exporter.add_agent(agent)
+        for tool in tools:
             self.exporter.object_set.add(tool)
 
         self.model: spdx3.ai_AIPackage | None = None
@@ -337,7 +338,7 @@ class Run(contextlib.ContextDecorator):
         loom.run(
             "fragments/train.spdx3.json",
             creation_metadata=CreationMetadata(
-                creator_name="Alice", creator_type="person"
+                creators=[Creator(name="Alice", type="person")]
             ),
         )
 

--- a/src/pitloom/loom.py
+++ b/src/pitloom/loom.py
@@ -6,6 +6,7 @@
 
 import contextlib
 import inspect
+import logging
 import types
 from pathlib import Path
 from uuid import uuid4
@@ -17,6 +18,8 @@ from pitloom.assemble.spdx3.creation_info import build_creation_info
 from pitloom.core.creation import CreationMetadata
 from pitloom.core.models import generate_spdx_id
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
+
+log = logging.getLogger(__name__)
 
 
 def _get_caller_info() -> str:
@@ -42,8 +45,8 @@ def _get_caller_info() -> str:
                     f"Method: inspect_caller (tool: pitloom.loom, "
                     f"function: {func_name})"
                 )
-    except Exception:  # pylint: disable=broad-exception-caught
-        pass
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        log.debug("Failed to determine caller info: %s", exc)
     return "Source: unknown | Method: inspect_caller (tool: pitloom.loom)"
 
 

--- a/src/pitloom/plugins/hatch.py
+++ b/src/pitloom/plugins/hatch.py
@@ -32,32 +32,25 @@ _SPDX3_JSON_EXT = ".spdx3.json"
 
 
 def _build_creation_metadata(pitloom_config: PitloomConfig) -> CreationMetadata:
-    """Build creation metadata from ``[tool.pitloom.creation]``.
+    """Build creation metadata from ``[[tool.pitloom.creator]]`` /
+    ``[[tool.pitloom.creation-tool]]`` / ``[tool.pitloom.creation]``.
 
     Unset fields fall through to :class:`CreationMetadata`'s own defaults --
-    no named creator (the assembler emits the ``SoftwareAgent`` "Pitloom")
-    and ``creation_tool`` -> ``"Pitloom"`` -- matching the CLI.
+    no named creators (the assembler emits the ``SoftwareAgent`` "Pitloom")
+    and ``tools`` -> ``[Pitloom]`` -- matching the CLI.
     """
     comment = pitloom_config.creation_comment
-    kwargs: dict[str, Any] = {
-        "creation_comment": (
+    return CreationMetadata(
+        creators=pitloom_config.creators,
+        tools=pitloom_config.tools,
+        creation_comment=(
             comment
             if comment is not None
             else "Generated via Pitloom Hatchling build hook (PEP 770)"
         ),
-        "build_datetime": to_spdx3_datetime(datetime.now(timezone.utc)).isoformat(),
-    }
-    if pitloom_config.creation_creator_name:
-        kwargs["creator_name"] = pitloom_config.creation_creator_name
-    if pitloom_config.creation_creator_email:
-        kwargs["creator_email"] = pitloom_config.creation_creator_email
-    if pitloom_config.creation_creator_type:
-        kwargs["creator_type"] = pitloom_config.creation_creator_type
-    if pitloom_config.creation_creation_tool:
-        kwargs["creation_tool"] = pitloom_config.creation_creation_tool
-    if pitloom_config.creation_creation_datetime:
-        kwargs["creation_datetime"] = pitloom_config.creation_creation_datetime
-    return CreationMetadata(**kwargs)
+        creation_datetime=pitloom_config.creation_datetime,
+        build_datetime=to_spdx3_datetime(datetime.now(timezone.utc)).isoformat(),
+    )
 
 
 def _build_document_model(
@@ -226,9 +219,10 @@ class PitloomBuildHook(BuildHookInterface[BuilderConfig]):
 _MOVED_KEYS = {
     "sbom-basename": "[tool.pitloom] sbom-basename",
     "fragments": "[tool.pitloom.fragments] files",
-    "creator-name": "[tool.pitloom.creation] creator-name",
-    "creator-email": "[tool.pitloom.creation] creator-email",
-    "creator-type": "[tool.pitloom.creation] creator-type",
+    "creator-name": "[[tool.pitloom.creator]] (key: name)",
+    "creator-email": "[[tool.pitloom.creator]] (key: email)",
+    "creator-type": "[[tool.pitloom.creator]] (key: type)",
+    "creation-tool": "[[tool.pitloom.creation-tool]] (key: name)",
 }
 
 

--- a/tests/fixtures/projects/sampleproject-hatchling-dynver/pyproject.toml
+++ b/tests/fixtures/projects/sampleproject-hatchling-dynver/pyproject.toml
@@ -35,6 +35,6 @@ enabled = true
 [tool.pitloom]
 sbom-basename = "sbom"
 
-[tool.pitloom.creation]
-creator-name = "Pitloom CI"
-creator-email = "ci@loom.example"
+[[tool.pitloom.creator]]
+name = "Pitloom CI"
+email = "ci@loom.example"

--- a/tests/fixtures/projects/sampleproject-hatchling/pyproject.toml
+++ b/tests/fixtures/projects/sampleproject-hatchling/pyproject.toml
@@ -30,6 +30,6 @@ enabled = true
 [tool.pitloom]
 sbom-basename = "sbom"
 
-[tool.pitloom.creation]
-creator-name = "Pitloom CI"
-creator-email = "ci@loom.example"
+[[tool.pitloom.creator]]
+name = "Pitloom CI"
+email = "ci@loom.example"

--- a/tests/fixtures/projects/sampleproject-hatchling/pyproject.toml
+++ b/tests/fixtures/projects/sampleproject-hatchling/pyproject.toml
@@ -33,3 +33,13 @@ sbom-basename = "sbom"
 [[tool.pitloom.creator]]
 name = "Pitloom CI"
 email = "ci@loom.example"
+
+[[tool.pitloom.creator]]
+name = "Sample Project Org"
+type = "organization"
+
+[[tool.pitloom.creation-tool]]
+name = "Pitloom"
+
+[[tool.pitloom.creation-tool]]
+name = "CI Wrapper"

--- a/tests/test_extract_fasttext.py
+++ b/tests/test_extract_fasttext.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any, TypedDict, cast
 from unittest.mock import MagicMock, patch
@@ -117,7 +118,9 @@ def test_fasttext_missing_library(tmp_path: Path) -> None:
             read_fasttext(model_file)
 
 
-def test_fasttext_load_failure(tmp_path: Path) -> None:
+def test_fasttext_load_failure(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     model_file = tmp_path / "model.bin"
     model_file.write_bytes(b"corrupt")
 
@@ -125,8 +128,60 @@ def test_fasttext_load_failure(tmp_path: Path) -> None:
     mock_fasttext.load_model.side_effect = OSError("bad file")
 
     with patch.dict("sys.modules", {"fasttext": mock_fasttext}):
-        with pytest.raises(ValueError, match="Failed to load fastText"):
-            read_fasttext(model_file)
+        with caplog.at_level(logging.DEBUG, logger="pitloom.extract._fasttext"):
+            with pytest.raises(ValueError, match="Failed to load fastText"):
+                read_fasttext(model_file)
+
+    # Load failure is now logged at debug level before being re-raised.
+    assert any("model.bin" in r.message for r in caplog.records)
+
+
+def test_fasttext_get_args_failure_logs_and_returns_empty(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """model.f.getArgs() failing (e.g. an unexpected binding version) is
+    caught, logged, and hyperparameters/type_of_model fall back to empty/None
+    rather than raising."""
+    model_file = tmp_path / "model.bin"
+    model_file.write_bytes(b"fake")
+
+    mock_model = MagicMock()
+    mock_model.f.getArgs.side_effect = RuntimeError("binding mismatch")
+    mock_model.get_labels.return_value = []
+
+    mock_fasttext = MagicMock()
+    mock_fasttext.load_model.return_value = mock_model
+
+    with patch.dict("sys.modules", {"fasttext": mock_fasttext}):
+        with caplog.at_level(logging.DEBUG, logger="pitloom.extract._fasttext"):
+            meta = read_fasttext(model_file)
+
+    assert meta.hyperparameters == {}
+    assert meta.type_of_model is None
+    assert any("getArgs" in r.message for r in caplog.records)
+
+
+def test_fasttext_get_labels_failure_logs_and_returns_empty_outputs(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """model.get_labels() failing is caught, logged, and outputs/labels fall
+    back to empty rather than raising."""
+    model_file = tmp_path / "model.bin"
+    model_file.write_bytes(b"fake")
+
+    mock_model = _make_fasttext_model()
+    mock_model.get_labels.side_effect = RuntimeError("binding mismatch")
+
+    mock_fasttext = MagicMock()
+    mock_fasttext.load_model.return_value = mock_model
+
+    with patch.dict("sys.modules", {"fasttext": mock_fasttext}):
+        with caplog.at_level(logging.DEBUG, logger="pitloom.extract._fasttext"):
+            meta = read_fasttext(model_file)
+
+    assert meta.outputs == []
+    assert "labels" not in meta.properties
+    assert any("labels" in r.message for r in caplog.records)
 
 
 def test_fasttext_basic_extraction(tmp_path: Path) -> None:

--- a/tests/test_extract_gguf.py
+++ b/tests/test_extract_gguf.py
@@ -10,12 +10,14 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from pitloom.core.ai_metadata import AiModelFormat, AiModelMetadata
+from pitloom.extract._gguf import _resolve_quantization
 from pitloom.extract.ai_model import read_gguf
 
 # ---------------------------------------------------------------------------
@@ -106,7 +108,7 @@ def test_gguf_minimal_fields(tmp_path: Path) -> None:
     assert meta.version is None
 
 
-def test_gguf_load_failure(tmp_path: Path) -> None:
+def test_gguf_load_failure(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     model_file = tmp_path / "model.gguf"
     model_file.write_bytes(b"corrupt")
 
@@ -114,8 +116,28 @@ def test_gguf_load_failure(tmp_path: Path) -> None:
     mock_gguf.GGUFReader.side_effect = ValueError("bad magic")
 
     with patch.dict("sys.modules", {"gguf": mock_gguf}):
-        with pytest.raises(ValueError, match="Failed to read GGUF"):
-            read_gguf(model_file)
+        with caplog.at_level(logging.DEBUG, logger="pitloom.extract._gguf"):
+            with pytest.raises(ValueError, match="Failed to read GGUF"):
+                read_gguf(model_file)
+
+    # Open failure is now logged at debug level before being re-raised.
+    assert any("model.gguf" in r.message for r in caplog.records)
+
+
+def test_gguf_resolve_quantization_unknown_value_logs_and_falls_back(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An out-of-range file_type value can't be resolved to a
+    GGMLQuantizationType member; the failure is logged and the raw integer
+    string is returned as a fallback (behaviour unchanged from before the
+    logging was added)."""
+    pytest.importorskip("gguf")
+
+    with caplog.at_level(logging.DEBUG, logger="pitloom.extract._gguf"):
+        result = _resolve_quantization(99999)
+
+    assert result == "99999"
+    assert any("99999" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_extract_hdf5.py
+++ b/tests/test_extract_hdf5.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import json as _json
+import logging
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -56,6 +57,24 @@ def test_read_hdf5_missing_library(tmp_path: Path) -> None:
     with patch.dict("sys.modules", {"h5py": None}):
         with pytest.raises(ImportError, match="h5py"):
             read_hdf5(model_file)
+
+
+def test_read_hdf5_open_failure_logs_and_raises(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    model_file = tmp_path / "model.h5"
+    model_file.write_bytes(b"corrupt")
+
+    mock_h5py = MagicMock()
+    mock_h5py.File.side_effect = OSError("unable to open file (bad signature)")
+
+    with patch.dict("sys.modules", {"h5py": mock_h5py}):
+        with caplog.at_level(logging.DEBUG, logger="pitloom.extract._hdf5"):
+            with pytest.raises(ValueError, match="Failed to read HDF5 file"):
+                read_hdf5(model_file)
+
+    # Open failure is now logged at debug level before being re-raised.
+    assert any("model.h5" in r.message for r in caplog.records)
 
 
 def test_read_hdf5_format_plain(tmp_path: Path) -> None:

--- a/tests/test_extract_huggingface.py
+++ b/tests/test_extract_huggingface.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -17,6 +18,10 @@ from pitloom.core.ai_metadata import AiModelFormat, AiModelMetadata
 from pitloom.core.dataset_metadata import DatasetReference
 from pitloom.extract._huggingface import (
     _detect_license_from_hf_files,
+    _list_license_files_in_repo,
+    _load_model_card,
+    _load_model_info,
+    _safe_load_json,
     is_huggingface_source,
     parse_hf_model_id,
     read_huggingface,
@@ -612,6 +617,80 @@ def test_detect_license_from_hf_files_returns_none_on_empty_file(
         with patch("huggingface_hub.hf_hub_download", return_value=str(empty_file)):
             detected_id, _ = _detect_license_from_hf_files("org/model")
     assert detected_id is None
+
+
+# ---------------------------------------------------------------------------
+# Robustness: each private HF I/O helper degrades gracefully and logs at
+# debug level when the underlying huggingface_hub call raises. These call
+# the helpers directly (unlike the read_huggingface() tests above, which
+# mock the helpers themselves away) so the actual except blocks run.
+# ---------------------------------------------------------------------------
+
+
+def test_safe_load_json_download_failure_logs_and_returns_none(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with patch("huggingface_hub.hf_hub_download", side_effect=OSError("network down")):
+        with caplog.at_level(logging.DEBUG, logger="pitloom.extract._huggingface"):
+            result = _safe_load_json("org/model", "config.json")
+    assert result is None
+    assert any("config.json" in r.message for r in caplog.records)
+
+
+def test_load_model_card_failure_logs_and_returns_empty(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with patch(
+        "huggingface_hub.ModelCard.load", side_effect=OSError("card fetch failed")
+    ):
+        with caplog.at_level(logging.DEBUG, logger="pitloom.extract._huggingface"):
+            text, data = _load_model_card("org/model")
+    assert text is None
+    assert data == {}
+    assert any("org/model" in r.message for r in caplog.records)
+
+
+def test_load_model_info_failure_logs_and_returns_empty(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with patch("huggingface_hub.model_info", side_effect=OSError("info fetch failed")):
+        with caplog.at_level(logging.DEBUG, logger="pitloom.extract._huggingface"):
+            result = _load_model_info("org/model")
+    assert not result
+    assert any("org/model" in r.message for r in caplog.records)
+
+
+def test_list_license_files_in_repo_failure_logs_and_returns_empty(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with patch(
+        "huggingface_hub.list_repo_files", side_effect=OSError("listing failed")
+    ):
+        with caplog.at_level(logging.DEBUG, logger="pitloom.extract._huggingface"):
+            result = _list_license_files_in_repo("org/model")
+    assert not result
+    assert any("org/model" in r.message for r in caplog.records)
+
+
+def test_detect_license_from_hf_files_download_failure_logs_and_continues(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # A license candidate is listed, but downloading/reading it fails --
+    # the loop must catch, log, and continue (returning (None, None) since
+    # no other candidates exist) rather than raising.
+    with patch(
+        "pitloom.extract._huggingface._list_license_files_in_repo",
+        return_value=["LICENSE"],
+    ):
+        with patch(
+            "huggingface_hub.hf_hub_download",
+            side_effect=OSError("download failed"),
+        ):
+            with caplog.at_level(logging.DEBUG, logger="pitloom.extract._huggingface"):
+                detected_id, provenance = _detect_license_from_hf_files("org/model")
+    assert detected_id is None
+    assert provenance is None
+    assert any("LICENSE" in r.message for r in caplog.records)
 
 
 def test_read_huggingface_invalid_source_raises() -> None:

--- a/tests/test_extract_keras.py
+++ b/tests/test_extract_keras.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import io
 import json
+import logging
 import zipfile
 from pathlib import Path
 from typing import Any
@@ -156,6 +157,26 @@ def test_read_keras_bad_zip_raises_value_error(tmp_path: Path) -> None:
     f.write_bytes(b"not a zip file at all")
     with pytest.raises(ValueError, match="not a valid ZIP archive"):
         read_keras(f)
+
+
+def test_read_keras_malformed_metadata_json_logs_and_raises(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A valid ZIP whose metadata.json is not valid JSON hits the generic
+    except (distinct from the zipfile.BadZipFile branch above): the failure
+    is logged, and the same ValueError is raised as before logging was
+    added."""
+    f = tmp_path / "model.keras"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("metadata.json", "{not valid json")
+    f.write_bytes(buf.getvalue())
+
+    with caplog.at_level(logging.DEBUG, logger="pitloom.extract._keras"):
+        with pytest.raises(ValueError, match="Failed to read Keras file"):
+            read_keras(f)
+
+    assert any("model.keras" in r.message for r in caplog.records)
 
 
 def test_read_keras_no_name_description_license(tmp_path: Path) -> None:

--- a/tests/test_extract_numpy.py
+++ b/tests/test_extract_numpy.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -231,14 +232,20 @@ def test_read_numpy_npz_no_format_version(tmp_path: Path) -> None:
     assert meta.format_info.format_version is None
 
 
-def test_read_numpy_invalid_file(tmp_path: Path) -> None:
+def test_read_numpy_invalid_file(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     model_file = tmp_path / "bad.npy"
     model_file.write_bytes(b"not numpy")
     mock_np = MagicMock()
     mock_np.load.side_effect = ValueError("Invalid npy header")
     with patch.dict("sys.modules", {"numpy": mock_np}):
-        with pytest.raises(ValueError, match="Failed to read NumPy"):
-            read_numpy(model_file)
+        with caplog.at_level(logging.DEBUG, logger="pitloom.extract._numpy"):
+            with pytest.raises(ValueError, match="Failed to read NumPy"):
+                read_numpy(model_file)
+
+    # Read failure is now logged at debug level before being re-raised.
+    assert any("bad.npy" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_extract_onnx.py
+++ b/tests/test_extract_onnx.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -168,7 +169,7 @@ def test_onnx_no_graph_name_falls_back(tmp_path: Path) -> None:
     assert meta.format_info.model_format == AiModelFormat.ONNX
 
 
-def test_onnx_load_failure(tmp_path: Path) -> None:
+def test_onnx_load_failure(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     model_file = tmp_path / "model.onnx"
     model_file.write_bytes(b"corrupt")
 
@@ -176,8 +177,12 @@ def test_onnx_load_failure(tmp_path: Path) -> None:
     mock_onnx.load.side_effect = RuntimeError("bad protobuf")
 
     with patch.dict("sys.modules", {"onnx": mock_onnx}):
-        with pytest.raises(ValueError, match="Failed to load ONNX model"):
-            read_onnx(model_file)
+        with caplog.at_level(logging.DEBUG, logger="pitloom.extract._onnx"):
+            with pytest.raises(ValueError, match="Failed to load ONNX model"):
+                read_onnx(model_file)
+
+    # Load failure is now logged at debug level before being re-raised.
+    assert any("model.onnx" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_extract_pytorch.py
+++ b/tests/test_extract_pytorch.py
@@ -14,14 +14,16 @@ Covers mocked and integration tests.
 from __future__ import annotations
 
 import io as _io
+import logging
 import zipfile as _zipfile
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from pitloom.core.ai_metadata import AiModelFormat
+from pitloom.extract._pytorch import _fickling_get_top_class, _read_pytorch_zip
 from pitloom.extract.ai_model import read_pytorch
 
 # ---------------------------------------------------------------------------
@@ -101,6 +103,50 @@ def test_read_pytorch_no_name_version(tmp_path: Path) -> None:
         meta = read_pytorch(model_file)
     assert meta.name is None
     assert meta.version is None
+
+
+# ---------------------------------------------------------------------------
+# Malformed input -- exceptions are caught, logged at debug level, and
+# degrade gracefully (behaviour unchanged; only visibility was added).
+# ---------------------------------------------------------------------------
+
+
+def test_fickling_get_top_class_malformed_pickle_logs_and_returns_none(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    pytest.importorskip("fickling")
+
+    # b"\x80\x99" starts a pickle stream (protocol opcode) but is truncated
+    # before a STOP opcode, so fickling's AST parser raises.
+    with caplog.at_level(logging.DEBUG, logger="pitloom.extract._pytorch"):
+        result = _fickling_get_top_class(b"\x80\x99")
+
+    assert result is None
+    assert any(
+        "fickling failed to parse pickle bytes" in r.message for r in caplog.records
+    )
+
+
+def test_read_pytorch_zip_inspect_failure_logs_and_continues(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A ZIP entry that exists in the file list but fails to read (e.g. a
+    corrupt/encrypted archive member) is caught, logged, and the function
+    still returns its normal (type_of_model=None) result rather than
+    raising."""
+    mock_zf = MagicMock()
+    mock_zf.namelist.return_value = ["archive/data.pkl"]
+    mock_zf.read.side_effect = RuntimeError("bad CRC-32")
+
+    with caplog.at_level(logging.DEBUG, logger="pitloom.extract._pytorch"):
+        type_of_model, properties, provenance = _read_pytorch_zip(
+            mock_zf, "Source: model.pt"
+        )
+
+    assert type_of_model is None
+    assert "type_of_model" not in provenance
+    assert "archive_contents" in properties
+    assert any("archive/data.pkl" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_extract_pytorch_pt2.py
+++ b/tests/test_extract_pytorch_pt2.py
@@ -15,13 +15,16 @@ from __future__ import annotations
 
 import io as _io
 import json as _json
+import logging
 import zipfile as _zipfile
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
 from pitloom.core.ai_metadata import AiModelFormat
+from pitloom.extract._pytorch_pt2 import _read_pt2_extra_files, _read_pt2_zip
 from pitloom.extract.ai_model import read_pytorch_pt2
 
 # ---------------------------------------------------------------------------
@@ -167,6 +170,94 @@ def test_read_pytorch_pt2_extra_tags_json_array(tmp_path: Path) -> None:
     )
     meta = read_pytorch_pt2(model_file)
     assert meta.properties.get("tags") == "a, b"
+
+
+def test_read_pytorch_pt2_malformed_metadata_json_logs_and_name_is_none(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Invalid JSON in METADATA.json is caught, logged, and name falls back
+    to None (same behaviour as a METADATA.json without a name field)."""
+    model_file = tmp_path / "model.pt2"
+    model_file.write_bytes(
+        _make_pt2_zip({"version": b"2", "METADATA.json": b"{not valid json"})
+    )
+    with caplog.at_level(logging.DEBUG, logger="pitloom.extract._pytorch_pt2"):
+        meta = read_pytorch_pt2(model_file)
+    assert meta.name is None
+    assert any("METADATA.json" in r.message for r in caplog.records)
+
+
+def test_read_pytorch_pt2_malformed_extra_tags_logs_and_keeps_raw_value(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """extra/tags content that isn't valid JSON is caught, logged, and the
+    raw string is kept as-is (same fallback behaviour as before logging)."""
+    model_file = tmp_path / "model.pt2"
+    model_file.write_bytes(_make_pt2_zip({"mdl/extra/tags": b"not a json array"}))
+    with caplog.at_level(logging.DEBUG, logger="pitloom.extract._pytorch_pt2"):
+        meta = read_pytorch_pt2(model_file)
+    assert meta.properties.get("tags") == "not a json array"
+    assert any(
+        "Failed to parse PT2 extra/tags as JSON" in r.message for r in caplog.records
+    )
+
+
+def test_read_pytorch_pt2_malformed_model_json_logs_and_returns_empty_io(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Invalid JSON in models/model.json is caught, logged, and inputs/outputs
+    fall back to empty lists (same as when the file is absent)."""
+    model_file = tmp_path / "model.pt2"
+    model_file.write_bytes(_make_pt2_zip({"mdl/models/model.json": b"{not valid json"}))
+    with caplog.at_level(logging.DEBUG, logger="pitloom.extract._pytorch_pt2"):
+        meta = read_pytorch_pt2(model_file)
+    assert meta.inputs == []
+    assert meta.outputs == []
+    assert any("models/model.json" in r.message for r in caplog.records)
+
+
+def test_read_pt2_extra_files_read_failure_logs_and_returns_none(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A ZIP member listed in the archive that fails to read (e.g. a
+    corrupt/encrypted entry) is caught, logged, and treated the same as a
+    missing extra/name file (falls back to None)."""
+    mock_zf = MagicMock()
+    mock_zf.namelist.return_value = ["extra/name"]
+    mock_zf.read.side_effect = RuntimeError("bad CRC-32")
+
+    properties: dict[str, str] = {}
+    provenance: dict[str, str] = {}
+    with caplog.at_level(logging.DEBUG, logger="pitloom.extract._pytorch_pt2"):
+        name, description, version, license_expr = _read_pt2_extra_files(
+            mock_zf, "", "Source: model.pt2", properties, provenance
+        )
+
+    assert name is None
+    assert description is None
+    assert version is None
+    assert license_expr is None
+    assert "name" not in provenance
+    assert any("extra/name" in r.message for r in caplog.records)
+
+
+def test_read_pt2_zip_archive_version_read_failure_logs_and_continues(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A ZIP member listed in the archive that fails to read while resolving
+    archive_version is caught, logged, and format_version falls back to
+    None instead of raising."""
+    mock_zf = MagicMock()
+    mock_zf.namelist.return_value = ["archive_version"]
+    mock_zf.read.side_effect = RuntimeError("bad CRC-32")
+
+    with caplog.at_level(logging.DEBUG, logger="pitloom.extract._pytorch_pt2"):
+        result = _read_pt2_zip(mock_zf, "Source: model.pt2")
+
+    (_, _, _, _, format_version, _, provenance, _, _) = result
+    assert format_version is None
+    assert "format_version" not in provenance
+    assert any("archive_version" in r.message for r in caplog.records)
 
 
 def test_read_pytorch_pt2_model_json_inputs_outputs(tmp_path: Path) -> None:

--- a/tests/test_extract_safetensors.py
+++ b/tests/test_extract_safetensors.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -123,7 +124,9 @@ def test_safetensors_fallback_keys(tmp_path: Path) -> None:
     assert meta.architecture == "llama"
 
 
-def test_safetensors_read_failure(tmp_path: Path) -> None:
+def test_safetensors_read_failure(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     model_file = tmp_path / "model.safetensors"
     model_file.write_bytes(b"corrupt")
 
@@ -131,8 +134,12 @@ def test_safetensors_read_failure(tmp_path: Path) -> None:
     mock_safetensors.safe_open.side_effect = OSError("bad file")
 
     with patch.dict("sys.modules", {"safetensors": mock_safetensors}):
-        with pytest.raises(ValueError, match="Failed to read Safetensors"):
-            read_safetensors(model_file)
+        with caplog.at_level(logging.DEBUG, logger="pitloom.extract._safetensors"):
+            with pytest.raises(ValueError, match="Failed to read Safetensors"):
+                read_safetensors(model_file)
+
+    # Read failure is now logged at debug level before being re-raised.
+    assert any("model.safetensors" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -36,7 +36,7 @@ import pytest
 
 from pitloom.assemble import generate_sbom
 from pitloom.assemble.spdx3.fragments import merge_fragments
-from pitloom.core.creation import CreationMetadata
+from pitloom.core.creation import CreationMetadata, Creator
 from pitloom.export.spdx3_json import Spdx3JsonExporter
 
 _FRAGMENTS_DIR = Path(__file__).parent / "fixtures" / "fragments"
@@ -424,7 +424,7 @@ def test_generate_sbom_includes_ai_model_fragment_elements() -> None:
 
         sbom_json = generate_sbom(
             tmppath,
-            creation_metadata=CreationMetadata(creator_name="Test"),
+            creation_metadata=CreationMetadata(creators=[Creator(name="Test")]),
         )
         data = json.loads(sbom_json)
         graph: list[dict[str, Any]] = data.get("@graph", [])
@@ -481,7 +481,7 @@ files = ["dataset-fragment.spdx3.json"]
 
         sbom_json = generate_sbom(
             tmppath,
-            creation_metadata=CreationMetadata(creator_name="Test"),
+            creation_metadata=CreationMetadata(creators=[Creator(name="Test")]),
         )
         graph = json.loads(sbom_json).get("@graph", [])
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -17,7 +17,7 @@ from pitloom.__about__ import __version__
 from pitloom.assemble import generate_sbom
 from pitloom.assemble.spdx3.document import build, build_model
 from pitloom.core.ai_metadata import AiModelFormat, AiModelFormatInfo, AiModelMetadata
-from pitloom.core.creation import CreationMetadata
+from pitloom.core.creation import CreationMetadata, Creator, ToolInfo
 from pitloom.core.document import DocumentModel
 from pitloom.core.models import generate_spdx_id
 from pitloom.core.project import ProjectFile, ProjectMetadata
@@ -51,8 +51,7 @@ Source = "https://github.com/test/test-package"
         sbom_json = generate_sbom(
             tmppath,
             creation_metadata=CreationMetadata(
-                creator_name="Test Creator",
-                creator_email="test@example.com",
+                creators=[Creator(name="Test Creator", email="test@example.com")],
             ),
         )
 
@@ -221,8 +220,8 @@ version = "0.1.0"
         sbom_json = generate_sbom(
             tmppath,
             creation_metadata=CreationMetadata(
-                creator_name="Test Creator",
-                creation_tool=None,
+                creators=[Creator(name="Test Creator")],
+                tools=[],
                 creation_comment="Generated in CI",
             ),
         )
@@ -270,7 +269,7 @@ version = "0.1.0"
 
 
 def test_generate_sbom_tool_summary_omitted_for_custom_tool_name() -> None:
-    """A user-supplied creation_tool name gets no Pitloom-version summary."""
+    """A user-supplied tool name gets no Pitloom-version summary."""
     pyproject_content = """
 [build-system]
 requires = ["hatchling"]
@@ -288,7 +287,7 @@ version = "0.1.0"
 
         sbom_json = generate_sbom(
             tmppath,
-            creation_metadata=CreationMetadata(creation_tool="MyWrapper"),
+            creation_metadata=CreationMetadata(tools=[ToolInfo("MyWrapper")]),
         )
         sbom_data = json.loads(sbom_json)
         graph = sbom_data["@graph"]
@@ -346,7 +345,7 @@ version = "0.1.0"
             generate_sbom(
                 tmppath,
                 creation_metadata=CreationMetadata(
-                    creator_name="Alice", creator_email="alice@example.com"
+                    creators=[Creator(name="Alice", email="alice@example.com")]
                 ),
             )
         )["@graph"]
@@ -364,7 +363,7 @@ version = "0.1.0"
 
 
 def test_generate_sbom_organization_creator() -> None:
-    """creator_type='organization' makes the named creator an Organization."""
+    """type='organization' makes the named creator an Organization."""
     pyproject_content = """
 [project]
 name = "org-app"
@@ -378,7 +377,7 @@ version = "0.1.0"
             generate_sbom(
                 tmppath,
                 creation_metadata=CreationMetadata(
-                    creator_name="Acme Corp", creator_type="organization"
+                    creators=[Creator(name="Acme Corp", type="organization")]
                 ),
             )
         )["@graph"]
@@ -415,7 +414,7 @@ version = "0.1.0"
             generate_sbom(
                 tmppath,
                 creation_metadata=CreationMetadata(
-                    creator_name="Bot", creator_type=creator_type
+                    creators=[Creator(name="Bot", type=creator_type)]
                 ),
             )
         )["@graph"]
@@ -426,7 +425,7 @@ version = "0.1.0"
 
 
 def test_generate_sbom_invalid_creator_type_raises() -> None:
-    """An unrecognised creator_type raises ValueError naming the valid set,
+    """An unrecognised creator type raises ValueError naming the valid set,
     rather than silently falling back to Person."""
     pyproject_content = """
 [project]
@@ -437,11 +436,11 @@ version = "0.1.0"
         tmppath = Path(tmpdir)
         (tmppath / "pyproject.toml").write_text(pyproject_content)
 
-        with pytest.raises(ValueError, match="Invalid creator_type"):
+        with pytest.raises(ValueError, match="Invalid creator type"):
             generate_sbom(
                 tmppath,
                 creation_metadata=CreationMetadata(
-                    creator_name="Bot", creator_type="robot"
+                    creators=[Creator(name="Bot", type="robot")]
                 ),
             )
 
@@ -466,7 +465,7 @@ version = "0.1.0"
         sbom_json = generate_sbom(
             tmppath,
             creation_metadata=CreationMetadata(
-                creator_name="Test Creator",
+                creators=[Creator(name="Test Creator")],
                 creation_datetime="2026-01-01T12:34:56.789123+02:30",
             ),
         )
@@ -476,6 +475,111 @@ version = "0.1.0"
         creation_infos = [e for e in graph if e["type"] == "CreationInfo"]
         assert len(creation_infos) == 1
         assert creation_infos[0]["created"] == "2026-01-01T10:04:56Z"
+
+
+def test_generate_sbom_multiple_creators_and_supplied_by_first() -> None:
+    """Multiple creators each become their own Agent in createdBy, of the
+    correct subclass; suppliedBy on the main package is the *first* named
+    creator."""
+    pyproject_content = """
+[project]
+name = "multi-creator-app"
+version = "0.1.0"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        (tmppath / "pyproject.toml").write_text(pyproject_content)
+
+        graph = json.loads(
+            generate_sbom(
+                tmppath,
+                creation_metadata=CreationMetadata(
+                    creators=[
+                        Creator(name="Acme Corp", type="organization"),
+                        Creator(name="Alice", email="alice@example.com"),
+                    ]
+                ),
+            )
+        )["@graph"]
+
+        agents = _creation_agents(graph)
+        assert [a["type"] for a in agents] == ["Organization", "Person"]
+        assert agents[0]["name"] == "Acme Corp"
+        assert agents[1]["name"] == "Alice"
+
+        main_pkg = next(
+            e
+            for e in graph
+            if e["type"] == "software_Package" and e["name"] == "multi-creator-app"
+        )
+        assert main_pkg["suppliedBy"] == agents[0]["spdxId"]
+
+
+def test_generate_sbom_multiple_creators_same_type_distinct_agents() -> None:
+    """Two creators of the *same* type each become their own Agent, with
+    distinct spdxIds, and both are present in createdBy -- same-type
+    creators must not collapse into a single Agent."""
+    pyproject_content = """
+[project]
+name = "multi-person-app"
+version = "0.1.0"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        (tmppath / "pyproject.toml").write_text(pyproject_content)
+
+        graph = json.loads(
+            generate_sbom(
+                tmppath,
+                creation_metadata=CreationMetadata(
+                    creators=[
+                        Creator(name="Alice", type="person"),
+                        Creator(name="Bob", type="person"),
+                    ]
+                ),
+            )
+        )["@graph"]
+
+        agents = _creation_agents(graph)
+        assert [a["type"] for a in agents] == ["Person", "Person"]
+        assert [a["name"] for a in agents] == ["Alice", "Bob"]
+        assert agents[0]["spdxId"] != agents[1]["spdxId"]
+
+        creation_infos = [e for e in graph if e["type"] == "CreationInfo"]
+        assert len(creation_infos) == 1
+        assert set(creation_infos[0]["createdBy"]) == {
+            agents[0]["spdxId"],
+            agents[1]["spdxId"],
+        }
+
+
+def test_generate_sbom_multiple_tools() -> None:
+    """Multiple tools each become their own Tool in createdUsing."""
+    pyproject_content = """
+[project]
+name = "multi-tool-app"
+version = "0.1.0"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        (tmppath / "pyproject.toml").write_text(pyproject_content)
+
+        sbom_json = generate_sbom(
+            tmppath,
+            creation_metadata=CreationMetadata(
+                tools=[ToolInfo("Pitloom"), ToolInfo("MyWrapper")]
+            ),
+        )
+        graph = json.loads(sbom_json)["@graph"]
+
+        creation_infos = [e for e in graph if e["type"] == "CreationInfo"]
+        assert len(creation_infos) == 1
+        by_id = {e["spdxId"]: e for e in graph if "spdxId" in e}
+        tools = [by_id[ref] for ref in creation_infos[0]["createdUsing"]]
+
+        assert [t["name"] for t in tools] == ["Pitloom", "MyWrapper"]
+        assert tools[0]["summary"] == f"Pitloom {__version__}"
+        assert "summary" not in tools[1]
 
 
 def test_generate_sbom_sentimentdemo_structure() -> None:

--- a/tests/test_hatch_hook.py
+++ b/tests/test_hatch_hook.py
@@ -146,9 +146,10 @@ def test_validate_config_invalid_raises(field: str, bad_value: Any, match: str) 
     [
         ("sbom-basename", r"\[tool\.pitloom\] sbom-basename"),
         ("fragments", r"\[tool\.pitloom\.fragments\] files"),
-        ("creator-name", r"\[tool\.pitloom\.creation\] creator-name"),
-        ("creator-email", r"\[tool\.pitloom\.creation\] creator-email"),
-        ("creator-type", r"\[tool\.pitloom\.creation\] creator-type"),
+        ("creator-name", r"\[\[tool\.pitloom\.creator\]\]"),
+        ("creator-email", r"\[\[tool\.pitloom\.creator\]\]"),
+        ("creator-type", r"\[\[tool\.pitloom\.creator\]\]"),
+        ("creation-tool", r"\[\[tool\.pitloom\.creation-tool\]\]"),
     ],
 )
 def test_validate_config_moved_key_raises(key: str, new_location: str) -> None:
@@ -206,12 +207,12 @@ def test_hook_sbom_is_valid_json() -> None:
 
 
 def test_hook_creator_name_propagated() -> None:
-    """[tool.pitloom.creation] creator-name must appear in the SBOM graph."""
+    """[[tool.pitloom.creator]] name must appear in the SBOM graph."""
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         write_pyproject_with_pitloom_config(
             tmp_path,
-            '[tool.pitloom.creation]\ncreator-name = "Test Creator"\n',
+            '[[tool.pitloom.creator]]\nname = "Test Creator"\n',
         )
 
         hook = make_hook(tmp, {})
@@ -228,15 +229,13 @@ def test_hook_creator_name_propagated() -> None:
 
 
 def test_hook_organization_creator_from_config() -> None:
-    """[tool.pitloom.creation] creator-type = organization emits an
+    """[[tool.pitloom.creator]] type = organization emits an
     Organization (not a Person) in the SBOM graph."""
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         write_pyproject_with_pitloom_config(
             tmp_path,
-            "[tool.pitloom.creation]\n"
-            'creator-name = "Acme Corp"\n'
-            'creator-type = "organization"\n',
+            '[[tool.pitloom.creator]]\nname = "Acme Corp"\ntype = "organization"\n',
         )
 
         hook = make_hook(tmp, {})
@@ -254,6 +253,42 @@ def test_hook_organization_creator_from_config() -> None:
         hook.finalize("standard", build_data, "")
 
 
+def test_hook_multiple_creators_appear_in_graph() -> None:
+    """Multiple [[tool.pitloom.creator]] tables all appear in the SBOM
+    @graph, as their respective Agent subclasses."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        write_pyproject_with_pitloom_config(
+            tmp_path,
+            "[[tool.pitloom.creator]]\n"
+            'name = "Acme Corp"\n'
+            'type = "organization"\n'
+            "\n"
+            "[[tool.pitloom.creator]]\n"
+            'name = "Alice"\n'
+            'email = "alice@example.com"\n',
+        )
+
+        hook = make_hook(tmp, {})
+        build_data: dict[str, Any] = {}
+        hook.initialize("standard", build_data)
+
+        assert hook._sbom_staging_path is not None
+        graph = json.loads(hook._sbom_staging_path.read_text(encoding="utf-8"))[
+            "@graph"
+        ]
+        orgs = [e.get("name") for e in graph if e.get("type") == "Organization"]
+        persons = [e.get("name") for e in graph if e.get("type") == "Person"]
+        assert orgs == ["Acme Corp"]
+        assert persons == ["Alice"]
+
+        creation_infos = [e for e in graph if e.get("type") == "CreationInfo"]
+        assert len(creation_infos) == 1
+        assert len(creation_infos[0]["createdBy"]) == 2
+
+        hook.finalize("standard", build_data, "")
+
+
 @pytest.mark.parametrize(
     ("creator_type", "expected_element_type"),
     [
@@ -264,15 +299,13 @@ def test_hook_organization_creator_from_config() -> None:
 def test_hook_software_agent_and_generic_agent_creator_from_config(
     creator_type: str, expected_element_type: str
 ) -> None:
-    """[tool.pitloom.creation] creator-type also allows a named
+    """[[tool.pitloom.creator]] type also allows a named
     SoftwareAgent or generic Agent, not just Person/Organization."""
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         write_pyproject_with_pitloom_config(
             tmp_path,
-            "[tool.pitloom.creation]\n"
-            'creator-name = "CI Bot"\n'
-            f'creator-type = "{creator_type}"\n',
+            f'[[tool.pitloom.creator]]\nname = "CI Bot"\ntype = "{creator_type}"\n',
         )
 
         hook = make_hook(tmp, {})
@@ -292,7 +325,7 @@ def test_hook_software_agent_and_generic_agent_creator_from_config(
 
 
 def test_hook_default_creator_is_software_agent() -> None:
-    """With no [tool.pitloom.creation] creator-name, the hook records the
+    """With no [[tool.pitloom.creator]], the hook records the
     SoftwareAgent "Pitloom" as the createdBy agent."""
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -4,6 +4,7 @@
 
 """Tests for license text detection utilities."""
 
+import logging
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -15,6 +16,7 @@ from pitloom.extract._license import (
     _looks_like_spdx_license_id,
     _read_license_from_citation_cff,
     _read_license_from_codemeta_json,
+    canonicalize_license_id,
     collect_license_candidates,
     detect_license_for_project,
     detect_license_from_text,
@@ -250,6 +252,28 @@ def licenseid_db_path_fixture() -> Path:
     if not db.exists():
         pytest.skip("licenseid database not built -- run 'licenseid update'")
     return db
+
+
+# ---------------------------------------------------------------------------
+# canonicalize_license_id
+# ---------------------------------------------------------------------------
+
+
+def test_canonicalize_license_id_match_failure_logs_and_returns_raw(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failure inside AggregatedLicenseMatcher (e.g. a corrupt database) is
+    caught, logged, and the raw input is returned unchanged -- same fallback
+    behaviour as before logging was added."""
+    with patch(
+        "pitloom.extract._license.AggregatedLicenseMatcher",
+        side_effect=RuntimeError("db corrupt"),
+    ):
+        with caplog.at_level(logging.DEBUG, logger="pitloom.extract._license"):
+            result = canonicalize_license_id("mit")
+
+    assert result == "mit"
+    assert any("mit" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_loom.py
+++ b/tests/test_loom.py
@@ -5,15 +5,31 @@
 """Integration and unit tests for the pitloom.loom module."""
 
 import json
+import logging
 import tempfile
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
 from pitloom import loom
 from pitloom.__about__ import __version__
 from pitloom.core.creation import CreationMetadata, Creator
+
+
+def test_get_caller_info_exception_logs_and_returns_fallback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When inspect.stack() itself raises, _get_caller_info() catches it,
+    logs at debug level, and returns the same "unknown source" fallback
+    string as before logging was added."""
+    with patch("pitloom.loom.inspect.stack", side_effect=RuntimeError("no frames")):
+        with caplog.at_level(logging.DEBUG, logger="pitloom.loom"):
+            result = loom._get_caller_info()  # pylint: disable=protected-access
+
+    assert result == "Source: unknown | Method: inspect_caller (tool: pitloom.loom)"
+    assert any("caller info" in r.message for r in caplog.records)
 
 
 def test_loom_run_as_context_manager() -> None:

--- a/tests/test_loom.py
+++ b/tests/test_loom.py
@@ -13,7 +13,7 @@ import pytest
 
 from pitloom import loom
 from pitloom.__about__ import __version__
-from pitloom.core.creation import CreationMetadata
+from pitloom.core.creation import CreationMetadata, Creator
 
 
 def test_loom_run_as_context_manager() -> None:
@@ -310,11 +310,11 @@ def _run_creation_info(
 
 
 def test_loom_run_named_person_creator() -> None:
-    """loom.run(creation_metadata=CreationMetadata(creator_name=...)) records a Person
-    in createdBy, on par with the CLI."""
+    """loom.run(creation_metadata=CreationMetadata(creators=[Creator(...)])) records
+    a Person in createdBy, on par with the CLI."""
     with tempfile.TemporaryDirectory() as tmpdir:
         output_file = Path(tmpdir) / "frag.json"
-        creation = CreationMetadata(creator_name="Alice", creator_email="a@ex.com")
+        creation = CreationMetadata(creators=[Creator(name="Alice", email="a@ex.com")])
         with loom.run(output_file, creation_metadata=creation):
             loom.set_model("test-model")
 
@@ -324,12 +324,11 @@ def test_loom_run_named_person_creator() -> None:
 
 
 def test_loom_run_organization_creator() -> None:
-    """creator_type='organization' on the CreationMetadata records an
-    Organization."""
+    """type='organization' on a Creator records an Organization."""
     with tempfile.TemporaryDirectory() as tmpdir:
         output_file = Path(tmpdir) / "frag.json"
         creation = CreationMetadata(
-            creator_name="Acme Corp", creator_type="organization"
+            creators=[Creator(name="Acme Corp", type="organization")]
         )
         with loom.run(output_file, creation_metadata=creation):
             loom.set_model("test-model")
@@ -349,11 +348,13 @@ def test_loom_run_organization_creator() -> None:
 def test_loom_run_software_agent_and_generic_agent_creator(
     creator_type: str, expected_element_type: str
 ) -> None:
-    """creator_type also allows a named SoftwareAgent or the generic Agent,
+    """A creator's type also allows a named SoftwareAgent or the generic Agent,
     not just Person/Organization."""
     with tempfile.TemporaryDirectory() as tmpdir:
         output_file = Path(tmpdir) / "frag.json"
-        creation = CreationMetadata(creator_name="CI Bot", creator_type=creator_type)
+        creation = CreationMetadata(
+            creators=[Creator(name="CI Bot", type=creator_type)]
+        )
         with loom.run(output_file, creation_metadata=creation):
             loom.set_model("test-model")
 
@@ -363,23 +364,23 @@ def test_loom_run_software_agent_and_generic_agent_creator(
 
 
 def test_loom_run_invalid_creator_type_raises() -> None:
-    """An unrecognised creator_type raises ValueError rather than silently
-    falling back to Person."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        output_file = Path(tmpdir) / "frag.json"
-        creation = CreationMetadata(creator_name="Bot", creator_type="robot")
-        with pytest.raises(ValueError, match="Invalid creator_type"):
-            with loom.run(output_file, creation_metadata=creation):
-                loom.set_model("test-model")
+    """An unrecognised creator type raises ValueError rather than silently
+    falling back to Person.
+
+    Validation now happens eagerly in ``Creator.__post_init__`` (construction
+    time) rather than later at fragment assembly, so the invalid type is
+    rejected before ``loom.run`` is ever reached."""
+    with pytest.raises(ValueError, match="Invalid creator type"):
+        Creator(name="Bot", type="robot")
 
 
 def test_loom_run_suppress_tool_and_fixed_datetime() -> None:
-    """creation_tool=None omits createdUsing; creation_datetime is
+    """tools=[] omits createdUsing; creation_datetime is
     normalised into created."""
     with tempfile.TemporaryDirectory() as tmpdir:
         output_file = Path(tmpdir) / "frag.json"
         creation = CreationMetadata(
-            creation_tool=None,
+            tools=[],
             creation_datetime="2026-01-15T10:00:00Z",
         )
         with loom.run(output_file, creation_metadata=creation):

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -368,7 +368,7 @@ def test_model_mode_passes_creation_info(
     assert __main__.main() == 0
     ci = captured["creation_metadata"]
     assert isinstance(ci, CreationMetadata)
-    assert ci.creator_name == "TestBot"
+    assert [c.name for c in ci.creators] == ["TestBot"]
 
 
 def test_model_mode_nonexistent_file_returns_error(
@@ -476,6 +476,129 @@ def test_project_mode_creator_type_software_agent_and_agent(
     graph = json.loads(out.read_text())["@graph"]
     matches = [e.get("name") for e in graph if e.get("type") == expected_element_type]
     assert "CI Bot" in matches
+
+
+def test_project_mode_multiple_interleaved_creators(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Repeated --creator-name interleaved with --creator-type/--creator-email
+    starts a new creator each time; --creator-type/--creator-email bind to
+    the most recently named creator."""
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    (project_dir / "pyproject.toml").write_text(
+        '[project]\nname = "multi-cli-app"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    out = tmp_path / "multi-cli-app.spdx3.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "loom",
+            str(project_dir),
+            "-o",
+            str(out),
+            "--creator-name",
+            "Acme Corp",
+            "--creator-type",
+            "organization",
+            "--creator-name",
+            "Alice",
+            "--creator-email",
+            "alice@example.com",
+        ],
+    )
+
+    assert __main__.main() == 0
+
+    graph = json.loads(out.read_text())["@graph"]
+    orgs = [e for e in graph if e.get("type") == "Organization"]
+    persons = [e for e in graph if e.get("type") == "Person"]
+    assert [o["name"] for o in orgs] == ["Acme Corp"]
+    assert [p["name"] for p in persons] == ["Alice"]
+    assert persons[0]["externalIdentifier"]
+
+
+def test_creator_type_invalid_choice_rejected_by_argparse(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--creator-type bogus`` is rejected by argparse's ``choices=``
+    before Pitloom even sees it -- CLI validation stays uniform with the
+    eager ``Creator.__post_init__`` validation used by config/library
+    callers."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "loom",
+            ".",
+            "--creator-name",
+            "Bot",
+            "--creator-type",
+            "bogus",
+        ],
+    )
+    with pytest.raises(SystemExit):
+        __main__.main()
+    assert "invalid choice" in capsys.readouterr().err
+
+
+def test_creator_type_before_creator_name_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--creator-type before any --creator-name is a clear argparse error."""
+    monkeypatch.setattr(sys, "argv", ["loom", ".", "--creator-type", "organization"])
+    with pytest.raises(SystemExit):
+        __main__.main()
+    assert "--creator-type must come after a --creator-name" in capsys.readouterr().err
+
+
+def test_creator_email_before_creator_name_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--creator-email before any --creator-name is a clear argparse error."""
+    monkeypatch.setattr(sys, "argv", ["loom", ".", "--creator-email", "a@example.com"])
+    with pytest.raises(SystemExit):
+        __main__.main()
+    assert "--creator-email must come after a --creator-name" in capsys.readouterr().err
+
+
+def test_project_mode_repeated_creation_tool(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Repeated --creation-tool records more than one Tool in createdUsing."""
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    (project_dir / "pyproject.toml").write_text(
+        '[project]\nname = "multi-tool-cli-app"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+    out = tmp_path / "multi-tool-cli-app.spdx3.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "loom",
+            str(project_dir),
+            "-o",
+            str(out),
+            "--creation-tool",
+            "Pitloom",
+            "--creation-tool",
+            "MyWrapper",
+        ],
+    )
+
+    assert __main__.main() == 0
+
+    graph = json.loads(out.read_text())["@graph"]
+    tools = [e for e in graph if e.get("type") == "Tool"]
+    assert sorted(t["name"] for t in tools) == ["MyWrapper", "Pitloom"]
 
 
 def test_no_args_returns_error(
@@ -748,7 +871,7 @@ def test_hf_mode_passes_creation_info(
     assert __main__.main() == 0
     ci = captured["creation_metadata"]
     assert isinstance(ci, CreationMetadata)
-    assert ci.creator_name == "Researcher"
+    assert [c.name for c in ci.creators] == ["Researcher"]
 
 
 def test_hf_mode_passes_pretty_flag(

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -520,6 +520,61 @@ def test_project_mode_multiple_interleaved_creators(
     assert persons[0]["externalIdentifier"]
 
 
+def test_project_mode_three_creators_type_and_email_bind_to_most_recent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """With three creators, each --creator-type/--creator-email must bind to
+    the creator most recently named, not the first or a stale index -- a
+    regression check for the switch from in-place mutation
+    (``creators[-1].type = values``) to reconstructing the last ``Creator``
+    (``creators[-1] = Creator(...)``) in ``_CreatorTypeAction``/
+    ``_CreatorEmailAction``."""
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    (project_dir / "pyproject.toml").write_text(
+        '[project]\nname = "three-cli-app"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    out = tmp_path / "three-cli-app.spdx3.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "loom",
+            str(project_dir),
+            "-o",
+            str(out),
+            "--creator-name",
+            "Acme Corp",
+            "--creator-type",
+            "organization",
+            "--creator-name",
+            "Alice",
+            "--creator-type",
+            "person",
+            "--creator-email",
+            "alice@example.com",
+            "--creator-name",
+            "CI Bot",
+            "--creator-type",
+            "software-agent",
+        ],
+    )
+
+    assert __main__.main() == 0
+
+    graph = json.loads(out.read_text())["@graph"]
+    orgs = {e["name"] for e in graph if e.get("type") == "Organization"}
+    persons = {e.get("name"): e for e in graph if e.get("type") == "Person"}
+    agents = {e["name"] for e in graph if e.get("type") == "SoftwareAgent"}
+
+    assert orgs == {"Acme Corp"}
+    assert set(persons) == {"Alice"}
+    assert agents == {"CI Bot"}
+    # The email must land on Alice, not on Acme Corp or CI Bot.
+    assert persons["Alice"]["externalIdentifier"]
+
+
 def test_creator_type_invalid_choice_rejected_by_argparse(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -237,6 +237,85 @@ version = "0.1.0"
     assert "creation_comment      : 'Generated via Pitloom CLI'" in captured.out
 
 
+def test_project_mode_malformed_pitloom_config_surfaces_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A malformed [tool.pitloom] section must be a hard error, not a silent
+    fallback to default config.
+
+    ``creator-name`` directly under ``[tool.pitloom]`` is the old/invalid
+    single-valued form (creators now live under
+    ``[[tool.pitloom.creator]]``), so ``read_pyproject`` raises ``ValueError``.
+    Before the fix, ``_load_project_config`` and ``_resolve_output_path``
+    each caught and silently discarded that error, so the CLI would still
+    exit 0 and generate an SBOM with default creators and a generic output
+    filename. It must now propagate: exit code 1, no SBOM written.
+    """
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    (project_dir / "pyproject.toml").write_text(
+        """
+[project]
+name = "x"
+
+[tool.pitloom]
+creator-name = 123
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    def _fake_generate_sbom(*args: object, **kwargs: object) -> str:
+        raise AssertionError(
+            "generate_sbom must not run when [tool.pitloom] config is malformed"
+        )
+
+    monkeypatch.setattr(__main__, "generate_sbom", _fake_generate_sbom)
+    monkeypatch.setattr(sys, "argv", ["loom", str(project_dir)])
+
+    exit_code = __main__.main()
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "Error generating SBOM" in captured.err
+    assert not (project_dir / "x.spdx3.json").exists()
+    assert not (tmp_path / "sbom.spdx3.json").exists()
+
+
+def test_resolve_output_path_malformed_pyproject_raises(tmp_path: Path) -> None:
+    """_resolve_output_path() reads pyproject.toml directly (via
+    read_pyproject()) and must propagate a malformed [tool.pitloom]
+    ValueError rather than silently falling back to a default output path.
+
+    This is a narrower, direct-call complement to
+    test_project_mode_malformed_pitloom_config_surfaces_error above: that
+    end-to-end test never actually exercises this propagation path inside
+    _resolve_output_path(), because _load_project_config() -- called first
+    in _run_project_mode() -- raises on the same malformed config and
+    short-circuits before _resolve_output_path() is ever reached.
+    """
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    (project_dir / "pyproject.toml").write_text(
+        """
+[project]
+name = "x"
+
+[tool.pitloom]
+creator-name = 123
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError):
+        __main__._resolve_output_path(  # pylint: disable=protected-access
+            None, project_dir
+        )
+
+
 # ---------------------------------------------------------------------------
 # -m / --aimodel: model-mode tests
 # ---------------------------------------------------------------------------

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -301,6 +301,50 @@ no-creation-tool = true
         assert config.tools == []
 
 
+def test_extract_pitloom_no_creation_tool_false_boolean_keeps_tools() -> None:
+    """``no-creation-tool = false`` (a real TOML boolean) must NOT suppress
+    tools -- confirms the type-check fix distinguishes it from the string
+    ``"false"`` case below."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[tool.pitloom.creation]
+no-creation-tool = false
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        _, config = read_pyproject(pyproject_path)
+
+        assert config.tools is None
+
+
+def test_extract_pitloom_no_creation_tool_string_raises() -> None:
+    """``no-creation-tool = "false"`` (a quoted string, not a TOML boolean)
+    must raise rather than being silently treated as truthy -- a bare
+    Python ``if x:`` check would otherwise treat the non-empty string
+    ``"false"`` as enabled, suppressing tools opposite to the user's intent."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[tool.pitloom.creation]
+no-creation-tool = "false"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        with pytest.raises(ValueError, match="must be a boolean"):
+            read_pyproject(pyproject_path)
+
+
 @pytest.mark.parametrize(
     "old_key",
     ["creator-name", "creator-email", "creator-type", "creation-tool"],

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -459,6 +459,112 @@ creation-tool = []
         assert config.tools == []
 
 
+def test_extract_pitloom_creator_single_table_raises() -> None:
+    """``[tool.pitloom.creator]`` as a single table (not
+    ``[[tool.pitloom.creator]]``) raises ValueError instead of being
+    silently treated as absent."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[tool.pitloom.creator]
+name = "Alice"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        with pytest.raises(ValueError, match="must be an array of tables"):
+            read_pyproject(pyproject_path)
+
+
+def test_extract_pitloom_creator_list_of_strings_raises() -> None:
+    """``creator = ["Alice"]`` (a list of strings, not tables) raises
+    ValueError instead of silently dropping every entry."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[tool.pitloom]
+creator = ["Alice"]
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        with pytest.raises(ValueError, match="entry must be a table"):
+            read_pyproject(pyproject_path)
+
+
+def test_extract_pitloom_creation_tool_single_table_raises() -> None:
+    """``[tool.pitloom.creation-tool]`` as a single table (not
+    ``[[tool.pitloom.creation-tool]]``) raises ValueError instead of being
+    silently treated as absent."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[tool.pitloom.creation-tool]
+name = "MyWrapper"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        with pytest.raises(ValueError, match="must be an array of tables"):
+            read_pyproject(pyproject_path)
+
+
+def test_extract_pitloom_creation_tool_list_of_strings_raises() -> None:
+    """``creation-tool = ["MyWrapper"]`` (a list of strings, not tables)
+    raises ValueError instead of silently dropping every entry."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[tool.pitloom]
+creation-tool = ["MyWrapper"]
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        with pytest.raises(ValueError, match="entry must be a table"):
+            read_pyproject(pyproject_path)
+
+
+def test_creator_empty_name_raises() -> None:
+    """``Creator(name="")`` raises ValueError eagerly at construction."""
+    with pytest.raises(ValueError, match="Creator name must be non-empty"):
+        Creator(name="")
+
+
+def test_creator_whitespace_name_raises() -> None:
+    """``Creator(name="   ")`` raises ValueError eagerly at construction."""
+    with pytest.raises(ValueError, match="Creator name must be non-empty"):
+        Creator(name="   ")
+
+
+def test_tool_info_empty_name_raises() -> None:
+    """``ToolInfo(name="")`` raises ValueError eagerly at construction."""
+    with pytest.raises(ValueError, match="ToolInfo name must be non-empty"):
+        ToolInfo(name="")
+
+
+def test_tool_info_whitespace_name_raises() -> None:
+    """``ToolInfo(name="   ")`` raises ValueError eagerly at construction."""
+    with pytest.raises(ValueError, match="ToolInfo name must be non-empty"):
+        ToolInfo(name="   ")
+
+
 def test_extract_metadata_canonicalises_dependency_names() -> None:
     """Dependency package names are canonicalised per PEP 503.
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -351,6 +351,58 @@ version = "1.0.0"
             read_pyproject(pyproject_path)
 
 
+@pytest.mark.parametrize(
+    "value_toml",
+    ["123", '["x"]', "true"],
+    ids=["int", "list", "bool"],
+)
+def test_extract_pitloom_moved_creation_key_non_string_raises(
+    value_toml: str,
+) -> None:
+    """``creator-name`` has no valid form at all directly under
+    ``[tool.pitloom]`` -- the new creator schema lives entirely under a
+    different key (``[[tool.pitloom.creator]]``). Any value there (int,
+    list, bool, ...) is a leftover/typo of the old moved form and must
+    raise, not just the ``str`` case."""
+    pyproject_content = f"""
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[tool.pitloom]
+creator-name = {value_toml}
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        with pytest.raises(ValueError, match="has moved to"):
+            read_pyproject(pyproject_path)
+
+
+def test_extract_pitloom_creation_tool_int_top_level_raises() -> None:
+    """A non-list, non-string ``creation-tool`` (e.g. an int) directly
+    under ``[tool.pitloom]`` is still the old/invalid single-valued form
+    and must raise -- only a ``list`` is the valid new array-of-tables
+    form."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[tool.pitloom]
+creation-tool = 123
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        with pytest.raises(ValueError, match="has moved to"):
+            read_pyproject(pyproject_path)
+
+
 def test_extract_pitloom_creation_tool_array_not_flagged_as_moved() -> None:
     """The *new* ``[[tool.pitloom.creation-tool]]`` array-of-tables reuses
     the ``creation-tool`` name at the top level of ``[tool.pitloom]`` (as a
@@ -437,6 +489,49 @@ email = "nobody@example.com"
             read_pyproject(pyproject_path)
 
 
+def test_extract_pitloom_creator_type_wrong_pytype_raises() -> None:
+    """A ``[[tool.pitloom.creator]]`` entry with a non-string ``type``
+    (e.g. an int) raises ValueError instead of silently falling back to
+    the default ``"person"`` type."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[[tool.pitloom.creator]]
+name = "Alice"
+type = 123
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        with pytest.raises(ValueError, match="'type' must be a string"):
+            read_pyproject(pyproject_path)
+
+
+def test_extract_pitloom_creator_email_wrong_pytype_raises() -> None:
+    """A ``[[tool.pitloom.creator]]`` entry with a non-string ``email``
+    (e.g. an int) raises ValueError instead of silently becoming ``None``."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[[tool.pitloom.creator]]
+name = "Alice"
+email = 123
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        with pytest.raises(ValueError, match="'email' must be a string"):
+            read_pyproject(pyproject_path)
+
+
 def test_extract_pitloom_empty_creation_tool_array_still_yields_empty_list() -> None:
     """A genuinely empty ``[[tool.pitloom.creation-tool]]`` array (zero
     tables present) still correctly yields ``tools == []`` -- only a
@@ -503,7 +598,10 @@ creator = ["Alice"]
 def test_extract_pitloom_creation_tool_single_table_raises() -> None:
     """``[tool.pitloom.creation-tool]`` as a single table (not
     ``[[tool.pitloom.creation-tool]]``) raises ValueError instead of being
-    silently treated as absent."""
+    silently treated as absent.
+
+    Caught by ``_check_moved_creation_keys`` (any non-list ``creation-tool``
+    is the old single-valued form) before ``_read_tools`` ever runs."""
     pyproject_content = """
 [project]
 name = "test-package"
@@ -517,7 +615,7 @@ name = "MyWrapper"
         pyproject_path = tmppath / "pyproject.toml"
         pyproject_path.write_text(pyproject_content)
 
-        with pytest.raises(ValueError, match="must be an array of tables"):
+        with pytest.raises(ValueError, match="has moved to"):
             read_pyproject(pyproject_path)
 
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from pitloom.core.creation import Creator, ToolInfo
 from pitloom.extract.pyproject import read_pyproject
 
 
@@ -159,18 +160,72 @@ description = "A test package"
         assert metadata.version == "2.0.0"
 
 
-def test_extract_pitloom_creation_settings() -> None:
-    """Read creation metadata settings from ``[tool.pitloom.creation]``."""
+@pytest.mark.parametrize(
+    "raw_type,normalized",
+    [
+        ("person", "person"),
+        ("organization", "organization"),
+        ("software-agent", "software-agent"),
+        ("agent", "agent"),
+        ("Person", "person"),
+        (" organization ", "organization"),
+    ],
+)
+def test_creator_valid_types_construct_and_normalize(
+    raw_type: str, normalized: str
+) -> None:
+    """Every valid creator type constructs fine; type is normalised to
+    stripped lower-case."""
+    creator = Creator(name="Someone", type=raw_type)
+    assert creator.type == normalized
+
+
+def test_creator_invalid_type_raises_at_construction() -> None:
+    """``Creator(type="bogus")`` raises ValueError eagerly at construction,
+    not only later at SPDX assembly time."""
+    with pytest.raises(ValueError, match="Invalid creator type"):
+        Creator(name="Bot", type="bogus")
+
+
+def test_extract_pitloom_bad_creator_type_raises_at_config_read() -> None:
+    """A bad ``type`` in ``[[tool.pitloom.creator]]`` raises ValueError as
+    soon as the config is read, since ``_read_creators`` constructs
+    ``Creator`` objects whose ``__post_init__`` validates ``type``."""
     pyproject_content = """
 [project]
 name = "test-package"
 version = "1.0.0"
 
+[[tool.pitloom.creator]]
+name = "Bot"
+type = "robot"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        with pytest.raises(ValueError, match="Invalid creator type"):
+            read_pyproject(pyproject_path)
+
+
+def test_extract_pitloom_creation_settings() -> None:
+    """Read creation metadata settings from ``[[tool.pitloom.creator]]`` /
+    ``[[tool.pitloom.creation-tool]]`` / ``[tool.pitloom.creation]``."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[[tool.pitloom.creator]]
+name = "Config Creator"
+email = "config@example.com"
+
+[[tool.pitloom.creation-tool]]
+name = "Config Tool"
+
 [tool.pitloom.creation]
-creator-name = "Config Creator"
-creator-email = "config@example.com"
 creation-datetime = "2026-01-01T00:00:00+00:00"
-creation-tool = "Config Tool"
 creation-comment = "Created from config"
 """
 
@@ -181,11 +236,142 @@ creation-comment = "Created from config"
 
         _, config = read_pyproject(pyproject_path)
 
-        assert config.creation_creator_name == "Config Creator"
-        assert config.creation_creator_email == "config@example.com"
-        assert config.creation_creation_datetime == "2026-01-01T00:00:00+00:00"
-        assert config.creation_creation_tool == "Config Tool"
+        assert config.creators == [
+            Creator(name="Config Creator", email="config@example.com")
+        ]
+        assert config.creation_datetime == "2026-01-01T00:00:00+00:00"
+        assert config.tools == [ToolInfo(name="Config Tool")]
         assert config.creation_comment == "Created from config"
+
+
+def test_extract_pitloom_multiple_creators_and_tools() -> None:
+    """Multiple ``[[tool.pitloom.creator]]`` / ``[[tool.pitloom.creation-tool]]``
+    tables are all read, in order."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[[tool.pitloom.creator]]
+name = "Acme Corp"
+type = "organization"
+
+[[tool.pitloom.creator]]
+name = "Alice"
+email = "alice@example.com"
+
+[[tool.pitloom.creation-tool]]
+name = "Pitloom"
+
+[[tool.pitloom.creation-tool]]
+name = "MyWrapper"
+"""
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        _, config = read_pyproject(pyproject_path)
+
+        assert config.creators == [
+            Creator(name="Acme Corp", type="organization"),
+            Creator(name="Alice", email="alice@example.com"),
+        ]
+        assert config.tools == [ToolInfo(name="Pitloom"), ToolInfo(name="MyWrapper")]
+
+
+def test_extract_pitloom_no_creation_tool_suppresses_tools() -> None:
+    """``[tool.pitloom.creation] no-creation-tool = true`` maps to ``tools=[]``."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[tool.pitloom.creation]
+no-creation-tool = true
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        _, config = read_pyproject(pyproject_path)
+
+        assert config.tools == []
+
+
+@pytest.mark.parametrize(
+    "old_key",
+    ["creator-name", "creator-email", "creator-type", "creation-tool"],
+)
+def test_extract_pitloom_moved_creation_keys_raise(old_key: str) -> None:
+    """Old single-valued keys under ``[tool.pitloom.creation]`` raise a clear
+    moved-key error instead of being silently ignored."""
+    pyproject_content = f"""
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[tool.pitloom.creation]
+{old_key} = "whatever"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        with pytest.raises(ValueError, match="has moved to"):
+            read_pyproject(pyproject_path)
+
+
+@pytest.mark.parametrize(
+    "old_key",
+    ["creator-name", "creator-email", "creator-type", "creation-tool"],
+)
+def test_extract_pitloom_moved_creation_keys_raise_top_level(old_key: str) -> None:
+    """The pre-multi-creator reader also accepted these keys directly under
+    ``[tool.pitloom]`` (not just ``[tool.pitloom.creation]``); that top-level
+    form must raise the same moved-key error rather than being silently
+    ignored."""
+    pyproject_content = f"""
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[tool.pitloom]
+{old_key} = "whatever"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        with pytest.raises(ValueError, match="has moved to"):
+            read_pyproject(pyproject_path)
+
+
+def test_extract_pitloom_creation_tool_array_not_flagged_as_moved() -> None:
+    """The *new* ``[[tool.pitloom.creation-tool]]`` array-of-tables reuses
+    the ``creation-tool`` name at the top level of ``[tool.pitloom]`` (as a
+    list of tables, not a string) -- it must not be mistaken for the old,
+    moved, single-valued ``creation-tool = "name"`` usage."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[[tool.pitloom.creation-tool]]
+name = "MyWrapper"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        _, config = read_pyproject(pyproject_path)
+
+        assert config.tools == [ToolInfo(name="MyWrapper")]
 
 
 def test_extract_metadata_canonicalises_dependency_names() -> None:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -374,6 +374,91 @@ name = "MyWrapper"
         assert config.tools == [ToolInfo(name="MyWrapper")]
 
 
+def test_extract_pitloom_creation_tool_missing_name_raises() -> None:
+    """A ``[[tool.pitloom.creation-tool]]`` entry missing ``name`` raises
+    ValueError instead of being silently dropped (which, if it were the
+    only entry, would incorrectly suppress the default ``createdUsing``
+    'Pitloom' tool)."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[[tool.pitloom.creation-tool]]
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        with pytest.raises(ValueError, match="missing a valid 'name'"):
+            read_pyproject(pyproject_path)
+
+
+def test_extract_pitloom_creation_tool_blank_name_raises() -> None:
+    """A blank (empty-string) ``name`` in ``[[tool.pitloom.creation-tool]]``
+    raises ValueError, same as a missing ``name``."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[[tool.pitloom.creation-tool]]
+name = ""
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        with pytest.raises(ValueError, match="missing a valid 'name'"):
+            read_pyproject(pyproject_path)
+
+
+def test_extract_pitloom_creator_missing_name_raises() -> None:
+    """A ``[[tool.pitloom.creator]]`` entry missing ``name`` raises
+    ValueError instead of being silently dropped (which, if it were the
+    only entry, would silently change the effective default from a named
+    creator to the unattended SoftwareAgent 'Pitloom')."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[[tool.pitloom.creator]]
+email = "nobody@example.com"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        with pytest.raises(ValueError, match="missing a valid 'name'"):
+            read_pyproject(pyproject_path)
+
+
+def test_extract_pitloom_empty_creation_tool_array_still_yields_empty_list() -> None:
+    """A genuinely empty ``[[tool.pitloom.creation-tool]]`` array (zero
+    tables present) still correctly yields ``tools == []`` -- only a
+    malformed *entry within* a present array raises."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[tool.pitloom]
+creation-tool = []
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        _, config = read_pyproject(pyproject_path)
+
+        assert config.tools == []
+
+
 def test_extract_metadata_canonicalises_dependency_names() -> None:
     """Dependency package names are canonicalised per PEP 503.
 

--- a/tests/test_poetry.py
+++ b/tests/test_poetry.py
@@ -480,7 +480,7 @@ def test_fixture_read_poetry_no_pitloom_section_defaults() -> None:
     _, config = read_poetry(POETRY_FIXTURE / "pyproject.toml")
     assert config.sbom_basename is None
     assert config.pretty is False
-    assert config.creators == []
+    assert not config.creators
 
 
 def test_read_poetry_multiple_creators_array_of_tables() -> None:

--- a/tests/test_poetry.py
+++ b/tests/test_poetry.py
@@ -480,7 +480,32 @@ def test_fixture_read_poetry_no_pitloom_section_defaults() -> None:
     _, config = read_poetry(POETRY_FIXTURE / "pyproject.toml")
     assert config.sbom_basename is None
     assert config.pretty is False
-    assert config.creation_creator_name is None
+    assert config.creators == []
+
+
+def test_read_poetry_multiple_creators_array_of_tables() -> None:
+    """Poetry projects also support ``[[tool.pitloom.creator]]``."""
+    content = """
+[tool.poetry]
+name = "poetry-multi-creator"
+version = "0.1.0"
+description = "Test"
+authors = ["Someone <someone@example.com>"]
+
+[[tool.pitloom.creator]]
+name = "Acme Corp"
+type = "organization"
+
+[[tool.pitloom.creator]]
+name = "Alice"
+"""
+    with tempfile.TemporaryDirectory() as d:
+        pyproject_path = Path(d) / "pyproject.toml"
+        pyproject_path.write_text(content, encoding="utf-8")
+        _, config = read_poetry(pyproject_path)
+
+    assert [c.name for c in config.creators] == ["Acme Corp", "Alice"]
+    assert config.creators[0].type == "organization"
 
 
 def test_fixture_read_pyproject_falls_back_to_poetry() -> None:

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -9,7 +9,7 @@ import tempfile
 from pathlib import Path
 
 from pitloom.assemble import generate_sbom
-from pitloom.core.creation import CreationMetadata
+from pitloom.core.creation import CreationMetadata, Creator
 from pitloom.extract.pyproject import read_pyproject
 
 
@@ -104,7 +104,7 @@ dependencies = ["requests>=2.28.0"]
 
         sbom_json = generate_sbom(
             tmppath,
-            creation_metadata=CreationMetadata(creator_name="Test"),
+            creation_metadata=CreationMetadata(creators=[Creator(name="Test")]),
         )
         sbom_data = json.loads(sbom_json)
 

--- a/tests/test_setuptools.py
+++ b/tests/test_setuptools.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from pitloom.core.creation import Creator
 from pitloom.core.project import ProjectMetadata
 from pitloom.extract.setuptools import (
     detect_build_backend,
@@ -292,8 +293,7 @@ creator-email = test@example.com
         _, config = read_setup_cfg(Path(d))
     assert config.pretty is True
     assert config.sbom_basename == "my-sbom"
-    assert config.creation_creator_name == "Test Creator"
-    assert config.creation_creator_email == "test@example.com"
+    assert config.creators == [Creator(name="Test Creator", email="test@example.com")]
 
 
 def test_read_setup_cfg_pitloom_config_creation_section() -> None:
@@ -310,8 +310,43 @@ creation-datetime = 2026-01-01T00:00:00+00:00
     with tempfile.TemporaryDirectory() as d:
         (Path(d) / "setup.cfg").write_text(content)
         _, config = read_setup_cfg(Path(d))
-    assert config.creation_creator_name == "Sub Creator"
-    assert config.creation_creation_datetime == "2026-01-01T00:00:00+00:00"
+    assert config.creators == [Creator(name="Sub Creator")]
+    assert config.creation_datetime == "2026-01-01T00:00:00+00:00"
+
+
+def test_read_setup_cfg_no_creation_tool_suppresses_tools() -> None:
+    """``[tool:pitloom:creation] no-creation-tool = true`` maps to
+    ``tools == []``, mirroring the ``pyproject.toml`` behaviour."""
+    content = """
+[metadata]
+name = pkg
+version = 1.0
+
+[tool:pitloom:creation]
+no-creation-tool = true
+"""
+    with tempfile.TemporaryDirectory() as d:
+        (Path(d) / "setup.cfg").write_text(content)
+        _, config = read_setup_cfg(Path(d))
+    assert config.tools == []
+
+
+def test_read_setup_cfg_no_creation_tool_overrides_explicit_tool_name() -> None:
+    """``no-creation-tool = true`` forces ``tools == []`` even when a
+    ``creation-tool`` name is also set -- suppression wins."""
+    content = """
+[metadata]
+name = pkg
+version = 1.0
+
+[tool:pitloom]
+creation-tool = MyWrapper
+no_creation_tool = yes
+"""
+    with tempfile.TemporaryDirectory() as d:
+        (Path(d) / "setup.cfg").write_text(content)
+        _, config = read_setup_cfg(Path(d))
+    assert config.tools == []
 
 
 def test_read_setup_cfg_no_pitloom_section_returns_defaults() -> None:
@@ -683,8 +718,7 @@ def test_fixture_read_setup_cfg_pitloom_config() -> None:
     """[tool:pitloom] in setup.cfg populates PitloomConfig correctly."""
     _, config = read_setup_cfg(SETUPTOOLS_FIXTURE)
     assert config.sbom_basename == "sbom"
-    assert config.creation_creator_name == "Pitloom CI"
-    assert config.creation_creator_email == "ci@loom.example"
+    assert config.creators == [Creator(name="Pitloom CI", email="ci@loom.example")]
 
 
 def test_fixture_read_setup_cfg_readme_content() -> None:

--- a/tests/test_setuptools.py
+++ b/tests/test_setuptools.py
@@ -4,6 +4,7 @@
 
 """Tests for metadata extraction from setup.cfg and setup.py."""
 
+import logging
 import tempfile
 from pathlib import Path
 
@@ -76,6 +77,21 @@ def test_detect_backend_no_config_files() -> None:
     """Returns None when no build configuration files are present."""
     with tempfile.TemporaryDirectory() as d:
         assert detect_build_backend(Path(d)) is None
+
+
+def test_detect_backend_malformed_pyproject_logs_and_returns_none(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A pyproject.toml that fails to parse is caught, logged, and the
+    function falls back to None -- same as when no backend can be
+    determined -- rather than raising."""
+    content = "[build-system\nbroken toml"
+    with tempfile.TemporaryDirectory() as d:
+        (Path(d) / "pyproject.toml").write_text(content)
+        with caplog.at_level(logging.DEBUG, logger="pitloom.extract.setuptools"):
+            result = detect_build_backend(Path(d))
+    assert result is None
+    assert any("pyproject.toml" in r.message for r in caplog.records)
 
 
 def test_detect_backend_unknown_backend() -> None:
@@ -573,6 +589,34 @@ def test_read_setuptools_cfg_config_returned() -> None:
         (Path(d) / "setup.py").write_text(py)
         _, config = read_setuptools(Path(d))
     assert config.pretty is True
+
+
+def test_read_setuptools_invalid_pitloom_config_raises() -> None:
+    """A malformed [tool:pitloom:creation] in setup.cfg propagates as a
+    ValueError, even when a valid setup.py exists as a fallback source --
+    it is a genuine config mistake, not a "try the next source" signal."""
+    cfg = (
+        "[metadata]\nname = pkg\nversion = 1.0\n\n"
+        "[tool:pitloom:creation]\ncreator-name = Alice\ncreator-type = bogus\n"
+    )
+    py = "from setuptools import setup\nsetup(name='pkg', version='1.0')\n"
+    with tempfile.TemporaryDirectory() as d:
+        (Path(d) / "setup.cfg").write_text(cfg)
+        (Path(d) / "setup.py").write_text(py)
+        with pytest.raises(ValueError, match="Invalid creator type"):
+            read_setuptools(Path(d))
+
+
+def test_read_setuptools_no_name_falls_through_to_setup_py() -> None:
+    """setup.cfg with no [metadata] name is the one legitimate case that
+    falls through to setup.py, rather than raising."""
+    cfg = "[metadata]\ndescription = no name here\n"
+    py = "from setuptools import setup\nsetup(name='fallback-pkg', version='1.0.0')\n"
+    with tempfile.TemporaryDirectory() as d:
+        (Path(d) / "setup.cfg").write_text(cfg)
+        (Path(d) / "setup.py").write_text(py)
+        metadata, _ = read_setuptools(Path(d))
+    assert metadata.name == "fallback-pkg"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_spdx3_dataset.py
+++ b/tests/test_spdx3_dataset.py
@@ -19,7 +19,7 @@ from pitloom.assemble.spdx3.dataset import (
 )
 from pitloom.assemble.spdx3.document import build as build_doc
 from pitloom.core.ai_metadata import AiModelFormat, AiModelFormatInfo, AiModelMetadata
-from pitloom.core.creation import CreationMetadata
+from pitloom.core.creation import CreationMetadata, Creator
 from pitloom.core.dataset_metadata import DatasetMetadata, DatasetReference
 from pitloom.core.document import DocumentModel
 from pitloom.core.models import _clear_doc_counters, compute_doc_uuid, generate_spdx_id
@@ -367,7 +367,7 @@ def test_add_datasets_empty_list_no_elements() -> None:
 
 def test_document_has_dataset_profile_when_model_has_datasets() -> None:
     project = ProjectMetadata(name="myproject", version="1.0")
-    creation = CreationMetadata(creator_name="Test")
+    creation = CreationMetadata(creators=[Creator(name="Test")])
     model = AiModelMetadata(
         name="MyModel",
         format_info=AiModelFormatInfo(model_format=AiModelFormat.ONNX),
@@ -388,7 +388,7 @@ def test_document_has_dataset_profile_when_model_has_datasets() -> None:
 
 def test_document_no_dataset_profile_when_no_datasets() -> None:
     project = ProjectMetadata(name="myproject2", version="1.0")
-    creation = CreationMetadata(creator_name="Test")
+    creation = CreationMetadata(creators=[Creator(name="Test")])
     model = AiModelMetadata(
         name="MyModel",
         format_info=AiModelFormatInfo(model_format=AiModelFormat.ONNX),

--- a/tests/test_wheel_integration.py
+++ b/tests/test_wheel_integration.py
@@ -116,6 +116,49 @@ def test_sbom_graph_contains_creator(built_wheel: Path) -> None:
     )
 
 
+def test_sbom_multiple_creators_and_tools_in_wheel(built_wheel: Path) -> None:
+    """The real, built wheel's SBOM must embed all declared creators and
+    creation tools, correctly linked from CreationInfo.
+
+    Complements ``test_hook_multiple_creators_appear_in_graph`` in
+    ``test_hatch_hook.py``, which asserts the same logical shape via a
+    direct ``BuildHookInterface.initialize()`` call rather than a real
+    ``python -m build`` / Hatchling wheel build -- this test proves the
+    result also lands correctly inside an actual ``.whl`` zip (PEP 770).
+
+    ``sampleproject-hatchling/pyproject.toml`` declares two creators
+    (a Person "Pitloom CI" and an Organization "Sample Project Org") and
+    two creation tools ("Pitloom" and "CI Wrapper").
+    """
+    with zipfile.ZipFile(built_wheel) as zf:
+        (sbom_entry,) = [n for n in zf.namelist() if "/sboms/" in n]
+        data = json.loads(zf.read(sbom_entry))
+    graph = data["@graph"]
+
+    elements_by_id = {
+        element["spdxId"]: element for element in graph if "spdxId" in element
+    }
+
+    creation_infos = [e for e in graph if e.get("type") == "CreationInfo"]
+    assert len(creation_infos) == 1, (
+        f"Expected exactly 1 CreationInfo element, found: {creation_infos}"
+    )
+    creation_info = creation_infos[0]
+
+    created_by = [elements_by_id[i] for i in creation_info.get("createdBy", [])]
+    assert len(created_by) == 2, f"Expected 2 createdBy agents, found: {created_by}"
+    persons = [a for a in created_by if a.get("type") == "Person"]
+    orgs = [a for a in created_by if a.get("type") == "Organization"]
+    assert [p.get("name") for p in persons] == ["Pitloom CI"]
+    assert [o.get("name") for o in orgs] == ["Sample Project Org"]
+
+    created_using = [elements_by_id[i] for i in creation_info.get("createdUsing", [])]
+    tool_names = sorted(t.get("name") for t in created_using)
+    assert tool_names == ["CI Wrapper", "Pitloom"], (
+        f"Expected createdUsing tools ['CI Wrapper', 'Pitloom'], found: {tool_names}"
+    )
+
+
 def test_sbom_is_not_empty(built_wheel: Path) -> None:
     """The SBOM file inside the wheel must have non-trivial content."""
     with zipfile.ZipFile(built_wheel) as zf:

--- a/working-docs/design/format-neutral-representation.md
+++ b/working-docs/design/format-neutral-representation.md
@@ -52,7 +52,7 @@ loom.run() (fragments)   ─┘    (pitloom.core)          [future] CycloneDXAss
 ```python
 @dataclass
 class DocumentModel:
-    creation: CreationMetadata        # who/when generated this document
+    creation_metadata: CreationMetadata  # who/what/when generated this document
     project: ProjectMetadata          # from read_pyproject() / read_setuptools()
     ai_models: list[AiModelMetadata]  # from read_ai_model()
 ```

--- a/working-docs/design/hatchling-build-hook.md
+++ b/working-docs/design/hatchling-build-hook.md
@@ -375,6 +375,7 @@ dependencies = [
 | `test_hook_sbom_is_compact_despite_pretty_config` | Sets `[tool.pitloom] pretty = true`; asserts the embedded SBOM is still RFC 8785 (JCS) canonical. |
 | `test_sbom_graph_contains_file_hashes` (`test_wheel_integration.py`) | Builds a real wheel; asserts every file-kind `software_File` in the embedded SBOM carries a SHA-256 `verifiedUsing` hash. |
 | `test_sbom_graph_contains_main_package_purl` (`test_wheel_integration.py`) | Builds a real wheel; asserts the main package carries a `pkg:pypi/...@<version>` PURL. |
+| `test_sbom_multiple_creators_and_tools_in_wheel` (`test_wheel_integration.py`) | Builds a real wheel from the `sampleproject-hatchling` fixture (now declaring 2 creators + 2 creation tools); resolves `CreationInfo.createdBy`/`createdUsing` to graph elements and asserts both agents and both tools appear correctly. |
 
 ## References
 

--- a/working-docs/design/hatchling-build-hook.md
+++ b/working-docs/design/hatchling-build-hook.md
@@ -128,20 +128,24 @@ enabled = true    # set to false to skip SBOM generation; the only field
 
 `[tool.hatch.build.hooks.pitloom]` controls only whether the hook runs.
 Everything else -- basename, fragments, creator/tool metadata -- is
-configured once under `[tool.pitloom]` / `[tool.pitloom.creation]`, the same
+configured once under `[tool.pitloom]` / `[[tool.pitloom.creator]]` /
+`[[tool.pitloom.creation-tool]]` / `[tool.pitloom.creation]`, the same
 settings the CLI reads via `read_pitloom_config()`. `_validate_config()`
-rejects `sbom-basename`, `creator-name`, `creator-email`, `creator-type`, or
-`fragments` under the hook section (naming the correct location), and
-rejects any other unrecognised key.
+rejects `sbom-basename`, `creator-name`, `creator-email`, `creator-type`,
+`creation-tool`, or `fragments` under the hook section (naming the correct
+location), and rejects any other unrecognised key.
 
 ```toml
 [tool.pitloom]
 sbom-basename = ""          # Name part only, no extension; default "sbom"
 
-[tool.pitloom.creation]
-creator-name = ""           # Defaults to no named creator (SoftwareAgent "Pitloom")
-creator-email = ""          # Optional
-creator-type = ""           # person (default), organization, software-agent, agent
+[[tool.pitloom.creator]]    # Repeatable; omit entirely for no named creator
+name = ""                   # (SoftwareAgent "Pitloom" is recorded instead)
+email = ""                  # Optional
+type = ""                   # person (default), organization, software-agent, agent
+
+[[tool.pitloom.creation-tool]]  # Repeatable; omit for the default "Pitloom" tool
+name = ""
 
 [tool.pitloom.fragments]
 files = []                  # List of pre-generated fragment paths to merge
@@ -191,12 +195,13 @@ high level, `initialize()`:
 
 1. Validates `[tool.hatch.build.hooks.pitloom]` config (`_validate_config`);
    invalid values, or any of the moved keys (`sbom-basename`,
-   `creator-name`, `creator-email`, `creator-type`, `fragments`), raise
-   `ValueError` before any file I/O.
+   `creator-name`, `creator-email`, `creator-type`, `creation-tool`,
+   `fragments`), raise `ValueError` before any file I/O.
 2. Returns early if `enabled = false`, or if `self.target_name != "wheel"`.
 3. Reads `read_pitloom_config(project_dir / "pyproject.toml")` for
-   `[tool.pitloom]` / `[tool.pitloom.creation]` settings (basename,
-   fragments, creator/tool metadata), then builds the format-neutral
+   `[tool.pitloom]` / `[[tool.pitloom.creator]]` /
+   `[[tool.pitloom.creation-tool]]` / `[tool.pitloom.creation]` settings
+   (basename, fragments, creator/tool metadata), then builds the format-neutral
    document via `_build_document_model`, which calls
    `metadata_from_hatchling(self.metadata, project_dir)` for project
    metadata (including the Poetry-fallback gap-fill and dependency/name
@@ -338,13 +343,14 @@ dependencies = [
 | `test_validate_config_defaults_pass` | Empty config (all defaults) must not raise. |
 | `test_validate_config_valid_values_pass` | The only supported key, `enabled`, must not raise. |
 | `test_validate_config_invalid_raises` | Parametrized: an invalid `enabled` type must raise `ValueError` with a clear message. |
-| `test_validate_config_moved_key_raises` | Parametrized: `sbom-basename`/`fragments`/`creator-name`/`creator-email`/`creator-type` under the hook section must raise, naming the new `[tool.pitloom]` / `[tool.pitloom.creation]` location. |
+| `test_validate_config_moved_key_raises` | Parametrized: `sbom-basename`/`fragments`/`creator-name`/`creator-email`/`creator-type`/`creation-tool` under the hook section must raise, naming the new `[tool.pitloom]` / `[[tool.pitloom.creator]]` / `[[tool.pitloom.creation-tool]]` location. |
 | `test_validate_config_unknown_key_raises` | An unrecognised key must raise rather than being silently ignored. |
 | `test_hook_initialize_stages_sbom` | Calls `initialize()` and asserts the staged SBOM path exists and is non-empty. |
 | `test_hook_sbom_is_valid_json` | Asserts the staged SBOM is valid JSON-LD with `@context` and `@graph`. |
-| `test_hook_creator_name_propagated` | Sets `[tool.pitloom.creation] creator-name` in `pyproject.toml`; asserts it appears in `@graph`. |
-| `test_hook_organization_creator_from_config` | Sets `creator-type = "organization"`; asserts an `Organization` (not `Person`) appears. |
-| `test_hook_software_agent_and_generic_agent_creator_from_config` | Parametrized: `creator-type = "software-agent"`/`"agent"` also produce the matching Agent subclass. |
+| `test_hook_creator_name_propagated` | Sets `[[tool.pitloom.creator]] name` in `pyproject.toml`; asserts it appears in `@graph`. |
+| `test_hook_organization_creator_from_config` | Sets `type = "organization"`; asserts an `Organization` (not `Person`) appears. |
+| `test_hook_software_agent_and_generic_agent_creator_from_config` | Parametrized: `type = "software-agent"`/`"agent"` also produce the matching Agent subclass. |
+| `test_hook_multiple_creators_appear_in_graph` | Two `[[tool.pitloom.creator]]` tables both appear in `@graph`, as their own Agent subclasses, and both are listed in `createdBy`. |
 | `test_hook_default_creator_is_software_agent` | No named creator: the hook records the `SoftwareAgent` "Pitloom" as `createdBy`. |
 | `test_hook_creation_comment_and_tool_summary` | Asserts the hook stamps its own `CreationInfo.comment` and a Pitloom-versioned `Tool.summary`. |
 | `test_hook_custom_basename_stored` | Sets `[tool.pitloom] sbom-basename`; asserts `_sbom_filename` and staged path name match. |

--- a/working-docs/design/metadata-provenance.md
+++ b/working-docs/design/metadata-provenance.md
@@ -94,7 +94,7 @@ CLI, the Hatchling build hook, and `pitloom.loom` fragments, so all three
 paths model creation identically:
 
 ```python
-spdx_ci, creator, tool = build_creation_info(
+spdx_ci, agents, tools = build_creation_info(
     creation_metadata,  # a CreationMetadata
     doc_name,
     doc_uuid,
@@ -102,14 +102,14 @@ spdx_ci, creator, tool = build_creation_info(
 )
 ```
 
-`creator` (`createdBy`) is a `Person` or `Organization` when
-`CreationMetadata.creator_name` is set (`creator_type` selects which, plus
+`agents` (`createdBy`) contains a `Person` or `Organization` per entry in
+`CreationMetadata.creators` (`Creator.type` selects which, plus
 `software-agent` and the generic `agent` for naming an automated creator
-that isn't Pitloom itself); with no name given, it is the `SoftwareAgent`
-"Pitloom" -- Pitloom acting unattended, not a fabricated human. `tool`
-(`createdUsing`) is the `Tool` "Pitloom" (carrying a `summary` with
-Pitloom's version), unless suppressed via `creation_tool=None`
-(`--no-creation-tool` on the CLI).
+that isn't Pitloom itself); with no creators given, it is a single
+`SoftwareAgent` "Pitloom" -- Pitloom acting unattended, not a fabricated
+human. `tools` (`createdUsing`) defaults to a single `Tool` "Pitloom"
+(carrying a `summary` with Pitloom's version), unless suppressed via
+`tools=[]` (`--no-creation-tool` on the CLI).
 
 Elements created together in one generation event -- one CLI run, one
 Hatchling build, one `loom.run` -- share a single `CreationInfo` instance,

--- a/working-docs/design/roadmap.md
+++ b/working-docs/design/roadmap.md
@@ -39,6 +39,19 @@ SPDX-License-Identifier: CC0-1.0
   - Poetry version specifiers (`^`, `~`, bare versions) converted to PEP 440
   - `read_pyproject()` falls back to `[tool.poetry]` when `[project]` is absent;
     merges both sections when both are present (`[project]` wins field-by-field)
+- [x] **Multiple creators / tools per `CreationInfo` record** -- `Creator` /
+  `ToolInfo` dataclasses replace the old scalar `creator_name`/
+  `creation_tool` fields; `CreationMetadata.creators: list[Creator]` and
+  `.tools: list[ToolInfo] | None` allow ≥1 Agents in `createdBy` and 0+
+  Tools in `createdUsing`, matching what SPDX 3 allows. CLI: repeatable
+  `--creator-name` (stateful -- `--creator-type`/`--creator-email` bind to
+  the most recently named creator) and repeatable `--creation-tool`.
+  Config: `[[tool.pitloom.creator]]` / `[[tool.pitloom.creation-tool]]`
+  array-of-tables in `pyproject.toml` (Poetry too); `setup.cfg` keeps
+  single-creator/-tool support only (INI can't express array-of-tables).
+  `suppliedBy` on the main package -- single-valued in SPDX 3 -- is set to
+  the first named creator. See
+  [creation-metadata.md](../../docs/creation-metadata.md).
 
 ## Adoption surfaces
 
@@ -95,41 +108,6 @@ wired into a build backend. These two extend reach beyond that. See
   with dataset references; emit SPDX 3 relationship types (`trainedOn`,
   `testedOn`, `finetunedOn`, `validatedOn`, `pretrainedOn`).
   See [sbom-enrichment.md](sbom-enrichment.md).
-
-### Creation metadata
-
-- [ ] **Multiple creators / tools per `CreationInfo` record** -- SPDX 3
-  allows `createdBy` (≥1) and `createdUsing` (0+) to hold several Agents/
-  Tools, but `CreationMetadata` (`src/pitloom/core/creation.py`) is
-  single-valued today: one `creator_name`/`creator_type`, one
-  `creation_tool`. `build_creation_info()` always writes exactly one Agent
-  and at most one Tool per record (see
-  [creation-metadata.md](../../docs/creation-metadata.md) for the current
-  model and its workaround -- separate `CreationInfo` records per
-  generation event). Flagging early, not implementing yet: supporting this
-  properly is a breaking change to both the config surface
-  (`[tool.pitloom.creation] creator-name = "..."` would need to become a
-  list or array-of-tables) and the library API (`CreationMetadata.
-  creator_name: str | None` would need to become list-typed), so the
-  shape should be decided deliberately rather than retrofitted once more
-  code depends on the current scalar fields.
-
-  Config sketch (not yet designed/implemented): TOML array-of-tables --
-  `[[tool.pitloom.creator]]` repeated per creator (each with its own
-  `name`/`type`/`email`), and similarly `[[tool.pitloom.creation-tool]]`
-  repeated per tool -- replacing the current single
-  `[tool.pitloom.creation]` table. Still open:
-  - Library API shape for `CreationMetadata` (`list[Creator]` /
-    `list[ToolInfo]`? nested dataclasses vs. flat lists?) and whether/how
-    `--creator-name` etc. stay usable as single-value CLI shortcuts on top
-    of a list-valued field.
-  - GitHub Action (`action.yml`) inputs are flat strings
-    (`with: creator-name: ...`); a composite action can't easily accept a
-    repeated block the way TOML/array-of-tables or Python lists can, so
-    multi-creator input there needs its own design (e.g. a delimited
-    string, JSON-encoded input, or accept only single creator/tool via
-    the Action while multi-value stays a config-file/library-only
-    feature).
 
 ### Metadata quality
 

--- a/working-docs/design/sbom-fragments.md
+++ b/working-docs/design/sbom-fragments.md
@@ -631,7 +631,7 @@ fragment metadata available to assemblers without re-reading the config:
 @dataclass
 class DocumentModel:
     project: ProjectMetadata
-    creation: CreationMetadata = field(default_factory=CreationMetadata)
+    creation_metadata: CreationMetadata = field(default_factory=CreationMetadata)
     ai_models: list[AiModelMetadata] = field(default_factory=list)
     fragments: list[FragmentConfig] = field(default_factory=list)  # NEW
 ```

--- a/working-docs/implementation/github-action.md
+++ b/working-docs/implementation/github-action.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-07-05
-Last-Modified: 2026-07-06
+Last-Modified: 2026-07-08
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -47,7 +47,7 @@ change any of it).
 | `output` | `sbom.spdx3.json` | SBOM output path. |
 | `extras` | `""` | Comma-separated pip extras, e.g. `aimodel,huggingface`. |
 | `pretty` | `false` | Pretty-print the SBOM JSON. |
-| `args` | `""` | Extra raw flags passed through to `loom` (e.g. `-v --creator-name CI`). |
+| `args` | `""` | Extra raw flags passed through to `loom` (e.g. `-v --creator-name CI`). This is also how to record more than one creator or tool -- `--creator-name`/`--creation-tool` are repeatable CLI flags, and the Action has no dedicated multi-creator input; see the recipe below. |
 | `pitloom-version` | `""` | Version/specifier to install; empty installs latest from PyPI. |
 | `python-version` | `3.x` | Passed to `actions/setup-python`. |
 | `install` | `true` | Set `false` to skip installing Python/Pitloom (assumes it is already on `PATH`). |
@@ -69,6 +69,23 @@ change any of it).
     extras: "aimodel"
     output: "model.spdx3.json"
     pretty: "true"
+```
+
+## Recipe: multiple creators
+
+`--creator-name` is repeatable -- each occurrence starts a new creator, and
+`--creator-type`/`--creator-email` bind to the most recently named one.
+Pass them through `args` (the Action itself has no dedicated multi-creator
+input):
+
+```yaml
+- uses: bact/pitloom@v0.10.0
+  with:
+    project-path: "."
+    output: "sbom.spdx3.json"
+    args: >-
+      --creator-name "Acme Corp" --creator-type organization
+      --creator-name Alice
 ```
 
 ## Recipe: attach the SBOM to a GitHub Release

--- a/working-docs/implementation/summary.md
+++ b/working-docs/implementation/summary.md
@@ -62,6 +62,7 @@ SPDX 3.0 compliant SBOMs in JSON-LD format.
    - `finalize()` cleans up the staging directory
    - Config: `[tool.hatch.build.hooks.pitloom] enabled` only; basename,
      fragments, and creator/tool metadata come from `[tool.pitloom]` /
+     `[[tool.pitloom.creator]]` / `[[tool.pitloom.creation-tool]]` /
      `[tool.pitloom.creation]` -- the same settings the CLI uses
 
 6. **Command-line interface** (`src/pitloom/__main__.py`)
@@ -139,8 +140,8 @@ SBOM written to: sbom.spdx3.json
 - **Total Elements**: 14
 - **CreationInfo**: 1 (with timestamp and creator)
 - **SoftwareAgent**: 1 (default createdBy agent when no creator is named;
-  a `Person`/`Organization` instead when `[tool.pitloom.creation]
-  creator-name` is set)
+  one `Person`/`Organization` per `[[tool.pitloom.creator]]` table instead
+  when set)
 - **Tool**: 1 (Pitloom, in createdUsing)
 - **SpdxDocument**: 1 (root document)
 - **software_Sbom**: 1 (SBOM declaration)


### PR DESCRIPTION
## Summary

Update CreationMetadata signature, CLI options, and config syntax to allow multiple SBOM creators and multiple SBOM creation tools.

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`) and lint passes (`ruff check src/ tests/`,
      `pylint`, `mypy`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
