### PR TITLE
Remove assert in production

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,10 @@ Unix philosophy. Consistent, predictable, parseable.
 - Must work with `awk`, `wc`, `xargs`, similar Unix tools.
 - JSON/CSV/file output supported as options.
 
+## Code style
+
+- Code comments must concise and about current implementation. Do not discuss previous iterations.
+
 ## Python
 
 - Min version: Python 3.10. No syntax/features unavailable before 3.10 unless via `__future__`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Unix philosophy. Consistent, predictable, parseable.
 
 ## Code style
 
-- Code comments must concise and about current implementation. Do not discuss previous iterations.
+- Code comments must direct, concise and about current implementation. Do not discuss history. Legimate current behavior vs alternative design is ok.
 
 ## Python
 

--- a/src/pitloom/core/config.py
+++ b/src/pitloom/core/config.py
@@ -213,10 +213,10 @@ def _read_pitloom_config(data: dict[str, Any]) -> PitloomConfig:
     Raises:
         ValueError: If ``[tool.pitloom]`` or ``[tool.pitloom.creation]``
             still has old single-valued ``creator-name``/``creator-email``/
-            ``creator-type``/``creation-tool`` keys -- these moved to the
-            array-of-tables form -- or if ``no-creation-tool`` is present
-            but not a boolean (e.g. the string ``"false"``, which Python
-            truthiness would otherwise silently treat as enabled).
+            ``creator-type``/``creation-tool`` keys -- these belong under
+            the array-of-tables form -- or if ``no-creation-tool`` is
+            present but not a boolean (e.g. the string ``"false"``, which
+            is truthy in Python).
     """
     pitloom_data = data.get("tool", {}).get("pitloom", {})
     creation_data = pitloom_data.get("creation", {})

--- a/src/pitloom/extract/setuptools.py
+++ b/src/pitloom/extract/setuptools.py
@@ -160,8 +160,10 @@ def read_setuptools(project_dir: Path) -> tuple[ProjectMetadata, PitloomConfig]:
     if cfg_metadata is not None:
         return cfg_metadata, cfg_config
 
-    # Only setup.py succeeded
-    assert py_metadata is not None
+    # Only setup.py succeeded -- the branches above already ruled out
+    # "both None" and "cfg_metadata set", so py_metadata must be set here.
+    if py_metadata is None:
+        raise RuntimeError("unreachable: py_metadata must be set here")
     return py_metadata, PitloomConfig()
 
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -771,6 +771,29 @@ def test_generate_sbom_uses_preparsed_metadata_without_reparsing() -> None:
         assert main_package["software_packageVersion"] == "9.9.9"
 
 
+def test_generate_sbom_partial_preparsed_args_reparses_both() -> None:
+    """project_metadata and pitloom_config must be given together.
+
+    Passing only one is treated as if neither were given: both are read
+    fresh from project_dir, and the one caller-supplied value is ignored."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        (tmppath / "pyproject.toml").write_text(
+            '[project]\nname = "real-package"\nversion = "1.0.0"\n'
+        )
+        fake_metadata = ProjectMetadata(name="should-be-discarded")
+
+        sbom_json = generate_sbom(
+            tmppath, project_metadata=fake_metadata, pitloom_config=None
+        )
+        graph = json.loads(sbom_json)["@graph"]
+
+        packages = [e for e in graph if e.get("type") == "software_Package"]
+        names = [p["name"] for p in packages]
+        assert "real-package" in names
+        assert "should-be-discarded" not in names
+
+
 def test_assembler_ai_model_with_inputs_outputs() -> None:
     """Test that AI model metadata with inputs/outputs is serialized into SPDX 3."""
     project = ProjectMetadata(name="ai-project", version="0.1.0")

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -325,9 +325,8 @@ no-creation-tool = false
 
 def test_extract_pitloom_no_creation_tool_string_raises() -> None:
     """``no-creation-tool = "false"`` (a quoted string, not a TOML boolean)
-    must raise rather than being silently treated as truthy -- a bare
-    Python ``if x:`` check would otherwise treat the non-empty string
-    ``"false"`` as enabled, suppressing tools opposite to the user's intent."""
+    raises -- the non-empty string ``"false"`` is truthy in Python, so
+    accepting it would suppress tools opposite to the user's intent."""
     pyproject_content = """
 [project]
 name = "test-package"


### PR DESCRIPTION
## Summary

Remove another `assert` in production code

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`) and lint passes (`ruff check src/ tests/`,
      `pylint src/ tests`, `mypy src/ tests/`)
- [ ] `CHANGELOG.md` updated (if user-facing)
- [ ] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
