### PR TITLE
Prepare for v0.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Full release notes: <https://github.com/bact/pitloom/releases>
-- Commit history: <https://github.com/bact/pitloom/compare/v0.9.0...v0.10.0>
+- Commit history: <https://github.com/bact/pitloom/compare/v0.10.0...v0.11.0>
 
-## [Unreleased]
+## [0.11.0] - 2026-07-09
 
 ### Added
 
@@ -311,6 +311,7 @@ release because "Loom" and "Pyloom" were unavailable on PyPI.
 
 ---
 
+[0.11.0]: https://github.com/bact/pitloom/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/bact/pitloom/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/bact/pitloom/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/bact/pitloom/compare/v0.7.1...v0.8.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
 abstract: Automated transparency, woven from the ground up. SBOM generation for Python & AI projects. Extract metadata from GGUF, ONNX, PyTorch, and Safetensors models with native Hatchling build-hook support.
 repository-code: "https://github.com/bact/pitloom"
 type: software
-doi: 10.5281/zenodo.19243681
-version: 0.10.0
+doi: 10.5281/zenodo.19246283
+version: 0.11.0
 license-url: "https://spdx.org/licenses/Apache-2.0"
 keywords:
   - sbom

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ hook:
 
 ```toml
 [build-system]
-requires = ["hatchling>=1.28.0", "pitloom>=0.10.0"]
+requires = ["hatchling>=1.28.0", "pitloom>=0.11.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.hooks.pitloom]
@@ -269,7 +269,7 @@ Add SBOM generation to any repository's CI with a single step, for any
 Python build backend, not just Hatchling:
 
 ```yaml
-- uses: bact/pitloom@v0.10.0
+- uses: bact/pitloom@v0.11.0
 ```
 
 See [working-docs/implementation/github-action.md](working-docs/implementation/github-action.md)

--- a/action.yml
+++ b/action.yml
@@ -44,8 +44,8 @@ inputs:
     default: ""
   pitloom-version:
     description: >-
-      Pitloom version or version specifier to install, e.g. "0.10.0" or
-      ">=0.10,<1.0". Empty installs the latest release from PyPI.
+      Pitloom version or version specifier to install, e.g. "0.11.0" or
+      ">=0.11,<1.0". Empty installs the latest release from PyPI.
     required: false
     default: ""
   python-version:
@@ -96,10 +96,10 @@ runs:
           spec="${spec}[${PL_EXTRAS}]"
         fi
         if [ -n "${PL_VERSION}" ]; then
-          # pitloom-version accepts either a bare version ("0.10.0") or a
-          # full specifier (">=0.10,<1.0"). A leading comparison operator
+          # pitloom-version accepts either a bare version ("0.11.0") or a
+          # full specifier (">=0.11,<1.0"). A leading comparison operator
           # means it is already a specifier; only bare versions need "=="
-          # inserted, otherwise "pitloom==>=0.10,<1.0" is invalid.
+          # inserted, otherwise "pitloom==>=0.11,<1.0" is invalid.
           case "${PL_VERSION}" in
             [\<\>=!~]*) spec="${spec}${PL_VERSION}" ;;
             *) spec="${spec}==${PL_VERSION}" ;;

--- a/codemeta.json
+++ b/codemeta.json
@@ -23,7 +23,7 @@
     "description": "Automated transparency, woven from the ground up. SBOM generation for Python & AI projects. Extract metadata from GGUF, ONNX, PyTorch, and Safetensors models with native Hatchling build-hook support.",
     "developmentStatus": "active",
     "downloadUrl": "https://github.com/bact/pitloom/releases",
-    "identifier": "10.5281/zenodo.19243681",
+    "identifier": "10.5281/zenodo.19246283",
     "isAccessibleForFree": true,
     "issueTracker": "https://github.com/bact/pitloom/issues",
     "keywords": [
@@ -57,5 +57,5 @@
     "programmingLanguage": "Python 3",
     "readme": "https://github.com/bact/pitloom/blob/main/README.md",
     "url": "https://github.com/bact/pitloom",
-    "version": "0.10.0"
+    "version": "0.11.0"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-07-08
-Last-Modified: 2026-07-08
+Last-Modified: 2026-07-09
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -8,11 +8,89 @@ SPDX-License-Identifier: CC0-1.0
 
 # Pitloom
 
+[![PyPI - Version](https://img.shields.io/pypi/v/pitloom)](https://pypi.org/project/pitloom/)
+![GitHub License](https://img.shields.io/github/license/bact/pitloom)
+[![DOI](https://img.shields.io/badge/doi-10.5281%2Fzenodo.19246283-blue)](https://doi.org/10.5281/zenodo.19246283)
+
 **Pitloom** automates the generation of SPDX 3-compliant SBOMs for AI models
 and Python projects, documenting the composition and provenance of software
 systems. It reads metadata directly from Python packages and AI models
 (GGUF, ONNX, PyTorch, Safetensors) and offers native Hatchling integration
 so SBOMs can be generated automatically as part of a build.
+
+## Install
+
+```bash
+pip install pitloom
+```
+
+Install with AI model metadata extraction support:
+
+```bash
+pip install pitloom[ai]
+```
+
+## Use
+
+### Command line
+
+Create SBOM for the Python project in the current directory:
+
+```shell
+loom .
+```
+
+Create SBOM of a local AI model:
+
+```shell
+loom -m path/to/model.safetensors -o model.spdx3.json
+loom -m path/to/model.gguf --pretty
+```
+
+Create SBOM of an AI model on Hugging Face Hub:
+
+```shell
+loom -m https://huggingface.co/mistralai/Mistral-7B-v0.1
+loom -m Qwen/Qwen3-235B-A22B   # bare model ID also works
+```
+
+### GitHub Action
+
+```yaml
+- uses: bact/pitloom@v0.10.0
+```
+
+### Python build hook
+
+Create SBOM during Hatchling build:
+
+```toml
+[build-system]
+requires = ["hatchling>=1.28.0", "pitloom>=0.10.0"]
+build-backend = "hatchling.build"
+```
+
+### Python API
+
+```python
+from pathlib import Path
+from pitloom.assemble import generate_sbom
+
+project_path = Path("/path/to/project")
+generate_sbom(project_path)
+```
+
+### Python tracking decorator
+
+```python
+from pitloom import loom
+
+@loom.run(output_file="fragments/train.json")
+def train_model():
+    loom.set_model("model-name")
+    loom.add_dataset("dataset-name", dataset_type="text")
+    # ... training logic ...
+```
 
 ## Learn more
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ loom -m Qwen/Qwen3-235B-A22B   # bare model ID also works
 ### GitHub Action
 
 ```yaml
-- uses: bact/pitloom@v0.10.0
+- uses: bact/pitloom@v0.11.0
 ```
 
 ### Python build hook
@@ -66,7 +66,7 @@ Create SBOM during Hatchling build:
 
 ```toml
 [build-system]
-requires = ["hatchling>=1.28.0", "pitloom>=0.10.0"]
+requires = ["hatchling>=1.28.0", "pitloom>=0.11.0"]
 build-backend = "hatchling.build"
 ```
 

--- a/src/pitloom/__about__.py
+++ b/src/pitloom/__about__.py
@@ -4,4 +4,4 @@
 
 """Package information for Pitloom."""
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/working-docs/design/hatchling-build-hook.md
+++ b/working-docs/design/hatchling-build-hook.md
@@ -118,7 +118,7 @@ The user adds `pitloom` to their build dependencies and enables the hook:
 
 ```toml
 [build-system]
-requires = ["hatchling>=1.28.0", "pitloom>=0.10.0"]
+requires = ["hatchling>=1.28.0", "pitloom>=0.11.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.hooks.pitloom]

--- a/working-docs/implementation/github-action.md
+++ b/working-docs/implementation/github-action.md
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: bact/pitloom@v0.10.0
+      - uses: bact/pitloom@v0.11.0
         with:
           project-path: "."
           output: "sbom.spdx3.json"
@@ -63,7 +63,7 @@ change any of it).
 ## Recipe: AI model SBOM
 
 ```yaml
-- uses: bact/pitloom@v0.10.0
+- uses: bact/pitloom@v0.11.0
   with:
     model: "models/my-model.safetensors"
     extras: "aimodel"
@@ -79,7 +79,7 @@ Pass them through `args` (the Action itself has no dedicated multi-creator
 input):
 
 ```yaml
-- uses: bact/pitloom@v0.10.0
+- uses: bact/pitloom@v0.11.0
   with:
     project-path: "."
     output: "sbom.spdx3.json"
@@ -104,7 +104,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
-      - uses: bact/pitloom@v0.10.0
+      - uses: bact/pitloom@v0.11.0
         id: pitloom
         with:
           project-path: "."
@@ -134,7 +134,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
-      - uses: bact/pitloom@v0.10.0
+      - uses: bact/pitloom@v0.11.0
         with:
           project-path: "."
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary

- Bump version to 0.11.0
- Update website index
- Fix DOI - use 10.5281/zenodo.19246283

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`) and lint passes (`ruff check src/ tests/`,
      `pylint src/ tests`, `mypy src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
