### PR TITLE
Add CISA-lifecycle SBOM generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
           SBOM_NAME="${WHEEL_NAME}.spdx3.json"
 
           # Generate SBOM
-          loom . -o "dist/${SBOM_NAME}" --creator-name "Pitloom CI" --creator-email "ci@example.com"
+          loom source . -o "dist/${SBOM_NAME}" --creator-name "Pitloom CI" --creator-email "ci@example.com"
 
           echo "sbom_name=${SBOM_NAME}" >> "$GITHUB_OUTPUT"
           echo "sbom_path=dist/${SBOM_NAME}" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ ensuring compliance with the PyPA
 
 ```bash
 pip install pitloom
-loom .            # SBOM for the Python project in the current dir
+loom source .     # SBOM for the Python project in the current dir
 ```
 
 ### Optional features
@@ -67,21 +67,33 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev install.
 
 ### Command line
 
-Generate an SBOM for a Python project in the current directory:
+Generate a **Source SBOM** for a Python project in the current directory:
 
 ```bash
-loom .
-loom /path/to/project -o sbom.spdx3.json
+loom source .
+loom source /path/to/project -o sbom.spdx3.json
 ```
 
-Generate an SBOM for a single AI model file, without a Python project
+Generate an **Analyzed SBOM** from a pre-built wheel (extracting bundled binaries as phantom dependencies):
+
+```bash
+loom analyze path/to/mypackage-1.0.0-py3-none-any.whl -o sbom.spdx3.json
+```
+
+Generate a **Deployed SBOM** reflecting the exact installed environment graph:
+
+```bash
+loom deployed -o env.spdx3.json
+```
+
+Generate an **Analyzed SBOM** for a single AI model file, without a Python project
 directory (output written to the current working directory). Supported
 local formats: GGUF, ONNX, Safetensors, PyTorch (`.pt`/`.pth`), Keras,
 HDF5, NumPy, fastText:
 
 ```bash
-loom -m path/to/model.safetensors -o model.spdx3.json
-loom -m path/to/model.gguf --pretty
+loom analyze path/to/model.safetensors -o model.spdx3.json
+loom analyze path/to/model.gguf --pretty
 ```
 
 Or pass a Hugging Face Hub URL or model ID directly -- no local file
@@ -91,8 +103,8 @@ required. Pitloom fetches metadata from the Hub (model card, `config.json`,
 (`pip install pitloom[huggingface]`):
 
 ```bash
-loom -m https://huggingface.co/mistralai/Mistral-7B-v0.1
-loom -m Qwen/Qwen3-235B-A22B   # bare model ID also works
+loom analyze https://huggingface.co/mistralai/Mistral-7B-v0.1
+loom analyze Qwen/Qwen3-235B-A22B   # bare model ID also works
 ```
 
 `loom -h` shows the full option list.
@@ -222,7 +234,7 @@ for what the plugin bundles.
 
 ```bash
 git clone https://github.com/bact/sentimentdemo.git
-loom sentimentdemo
+loom source sentimentdemo
 ```
 
 The generated SBOM includes project metadata, dependencies with version
@@ -244,10 +256,10 @@ it (default `"Pitloom"`, also repeatable; `--no-creation-tool` to omit);
 ISO 8601 timestamp:
 
 ```bash
-loom . --creator-name "Alice" --creator-email "alice@example.com"
-loom . --creator-name "Acme Corp" --creator-type organization
-loom . --creator-name "Acme Corp" --creator-type organization --creator-name Alice
-loom . --creation-datetime "2026-01-15T10:00:00Z" --creation-comment "CI run #123"
+loom source . --creator-name "Alice" --creator-email "alice@example.com"
+loom source . --creator-name "Acme Corp" --creator-type organization
+loom source . --creator-name "Acme Corp" --creator-type organization --creator-name Alice
+loom source . --creation-datetime "2026-01-15T10:00:00Z" --creation-comment "CI run #123"
 ```
 
 The same fields can be set in `pyproject.toml` under
@@ -287,7 +299,7 @@ pitloom ids generate data src --entity model      # pin ids before running
 pitloom ids import existing-sbom.spdx3.json       # or reuse ids from an SBOM
 ```
 
-`pitloom.loom`, `loom -m`, the build hook, and `generate_sbom()` all
+`pitloom.loom`, `loom analyze` (when pointed at a model), the build hook, and `generate_sbom()` all
 auto-discover the registry (or take it from `[tool.pitloom.ids] file`),
 so the same file/entity carries the same id everywhere. Regeneration is
 stable: an unchanged file keeps its id; changed content gets a fresh one

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
   model:
     description: >-
       Path to a local AI model file, or a Hugging Face URL / model ID.
-      When set, runs model mode ("loom -m <model>") instead of project mode.
+      When set, runs analyze mode ("loom analyze <model>") instead of project mode.
     required: false
     default: ""
   output:

--- a/action.yml
+++ b/action.yml
@@ -123,9 +123,9 @@ runs:
 
         declare -a loom_args
         if [ -n "${PL_MODEL}" ]; then
-          loom_args+=("-m" "${PL_MODEL}")
+          loom_args+=("analyze" "${PL_MODEL}")
         else
-          loom_args+=("${PL_PROJECT_PATH}")
+          loom_args+=("source" "${PL_PROJECT_PATH}")
         fi
         loom_args+=("-o" "${PL_OUTPUT}")
         if [ "${PL_PRETTY}" = "true" ]; then

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,24 +40,24 @@ pip install pitloom[ai]
 
 ### Command line
 
-Create SBOM for the Python project in the current directory:
+Create a Source SBOM for the Python project in the current directory:
 
 ```shell
-loom .
+loom source .
 ```
 
-Create SBOM of a local AI model:
+Create an Analyzed SBOM of a local AI model:
 
 ```shell
-loom -m path/to/model.safetensors -o model.spdx3.json
-loom -m path/to/model.gguf --pretty
+loom analyze path/to/model.safetensors -o model.spdx3.json
+loom analyze path/to/model.gguf --pretty
 ```
 
-Create SBOM of an AI model on Hugging Face Hub:
+Create an Analyzed SBOM of an AI model on Hugging Face Hub:
 
 ```shell
-loom -m https://huggingface.co/mistralai/Mistral-7B-v0.1
-loom -m Qwen/Qwen3-235B-A22B   # bare model ID also works
+loom analyze https://huggingface.co/mistralai/Mistral-7B-v0.1
+loom analyze Qwen/Qwen3-235B-A22B   # bare model ID also works
 ```
 
 ### GitHub Action

--- a/examples/sentimentdemo-aibom/README.md
+++ b/examples/sentimentdemo-aibom/README.md
@@ -218,7 +218,7 @@ python -m sentimentdemo.evaluate
 
 ## Stage 4 - Direct AI model extraction (Pitloom CLI)
 
-**Tool:** `loom -m` (Pitloom CLI)
+**Tool:** `loom analyze` (Pitloom CLI)
 **Output fragment:** `fragments/04_model_file.spdx3.json`
 
 Stages 1-3 record information that the *training code* knows. But the
@@ -228,7 +228,7 @@ labels, file hash, and so on. Pitloom reads those straight out of the
 binary:
 
 ```bash
-loom -m models/sentimentdemo.bin -o fragments/04_model_file.spdx3.json --pretty
+loom analyze models/sentimentdemo.bin -o fragments/04_model_file.spdx3.json --pretty
 ```
 
 This is **independent of the training script** - you can run it against
@@ -312,7 +312,7 @@ different sources:
 | Raw + processed datasets, with `hasInput` lineage | Preprocess script | `@loom.run` decorator + STAV IRIs | 1 |
 | AI model, hyperparameters, `trainedOn` relationship | Training script | `loom.run` context manager + STAV IRIs | 2 |
 | Validation set, `testedOn` relationship | Eval script | `loom.run` context manager + STAV IRIs | 3 |
-| Architecture, file hash, vocab/dim/labels | Model file (`sentimentdemo.bin`) | `loom -m` CLI extractor | 4 |
+| Architecture, file hash, vocab/dim/labels | Model file (`sentimentdemo.bin`) | `loom analyze` CLI extractor | 4 |
 
 You can inspect the final SBOM with:
 

--- a/examples/sentimentdemo-aibom/pyproject.toml
+++ b/examples/sentimentdemo-aibom/pyproject.toml
@@ -64,5 +64,5 @@ files = [
     "fragments/01_preprocess.spdx3.json",  # produced by `python -m sentimentdemo.preprocess`
     "fragments/02_train.spdx3.json",       # produced by `python -m sentimentdemo.train`
     "fragments/03_evaluate.spdx3.json",    # produced by `python -m sentimentdemo.evaluate`
-    "fragments/04_model_file.spdx3.json",  # produced by `loom -m models/sentimentdemo.bin`
+    "fragments/04_model_file.spdx3.json",  # produced by `loom analyze models/sentimentdemo.bin`
 ]

--- a/examples/sentimentdemo-aibom/scripts/run_pipeline.sh
+++ b/examples/sentimentdemo-aibom/scripts/run_pipeline.sh
@@ -7,7 +7,7 @@
 #
 # Stage 0 (and the registry refreshes after stages 1 and 2) maintain
 # loom-ids.json: a stable file/entity -> SPDX ID registry. Every stage --
-# the loom runs, the `loom -m` extractor, and the Hatchling build hook --
+# the loom runs, the `loom analyze` extractor, and the Hatchling build hook --
 # consults it, so the same dataset, script, or model carries the same spdxId
 # in every fragment, and the merge step can join the fragments into one
 # connected AI-pipeline graph.
@@ -52,9 +52,9 @@ python -m sentimentdemo.evaluate
 
 echo
 echo "================================================================"
-echo "Stage 4/5  -  Direct AI model extraction (loom -m)"
+echo "Stage 4/5  -  Direct AI model extraction (loom analyze)"
 echo "================================================================"
-loom -m models/sentimentdemo.bin -o fragments/04_model_file.spdx3.json --pretty
+loom analyze models/sentimentdemo.bin -o fragments/04_model_file.spdx3.json --pretty
 
 echo
 echo "================================================================"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,10 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
+    "auditwheel>=6.1.0; sys_platform == 'linux'",
     "hatchling>=1.28.0",
     "licenseid>=0.3.0",
+    "pipdeptree>=2.21.0",
     "pyproject-metadata>=0.12.1",
     "rfc8785>=0.1.4",
     "spdx-python-model>=0.0.6",

--- a/skills/enrich/SKILL.md
+++ b/skills/enrich/SKILL.md
@@ -72,7 +72,7 @@ Steps:
    files = ["fragments/agent-enrichment.spdx3.json"]
    ```
 
-6. Re-run `loom <path>` (generate again) so the merged, enriched SBOM is
+6. Re-run `loom source <path>` or `loom analyze <path>` (generate again) so the merged, enriched SBOM is
    written.
 7. **Post-merge check (mandatory):** validate the merged output is still
    a conformant SPDX 3 JSON document -- a syntactically valid fragment can

--- a/skills/enrich/SKILL.md
+++ b/skills/enrich/SKILL.md
@@ -72,8 +72,8 @@ Steps:
    files = ["fragments/agent-enrichment.spdx3.json"]
    ```
 
-6. Re-run `loom source <path>` or `loom analyze <path>` (generate again) so the merged, enriched SBOM is
-   written.
+6. Re-run `loom source <path>` or `loom analyze <path>` (generate again) so
+   the merged, enriched SBOM is written.
 7. **Post-merge check (mandatory):** validate the merged output is still
    a conformant SPDX 3 JSON document -- a syntactically valid fragment can
    still be missing a required property or use the wrong relationship

--- a/skills/enrich/references/examples.md
+++ b/skills/enrich/references/examples.md
@@ -88,7 +88,7 @@ files = ["fragments/agent-enrichment.spdx3.json"]
 ## 4. Re-generate the SBOM
 
 ```bash
-loom . -o sbom.spdx3.json --pretty
+loom source . -o sbom.spdx3.json --pretty
 ```
 
 The merged output now contains the `dataset_DatasetPackage` element from

--- a/skills/sbom/SKILL.md
+++ b/skills/sbom/SKILL.md
@@ -50,8 +50,8 @@ loom <project-or-model-path>
 ## Project SBOMs (Python packages)
 
 ```bash
-loom .                              # scan the current directory
-loom /path/to/project -o sbom.spdx3.json
+loom source .                              # scan the current directory
+loom source /path/to/project -o sbom.spdx3.json
 ```
 
 Requires a `pyproject.toml` (PEP 621 `[project]` or Poetry
@@ -63,11 +63,11 @@ Pass `-m` with a local model file or a Hugging Face URL/model ID -- no
 project directory required:
 
 ```bash
-loom -m model.safetensors
-loom -m model.onnx
-loom -m model.gguf
-loom -m mistralai/Mistral-7B-v0.1                # bare Hugging Face model ID
-loom -m https://huggingface.co/Qwen/Qwen3-235B-A22B
+loom analyze model.safetensors
+loom analyze model.onnx
+loom analyze model.gguf
+loom analyze mistralai/Mistral-7B-v0.1                # bare Hugging Face model ID
+loom analyze https://huggingface.co/Qwen/Qwen3-235B-A22B
 ```
 
 Supported local formats: GGUF, ONNX, Safetensors, PyTorch (`.pt`/`.pth`),

--- a/skills/sbom/SKILL.md
+++ b/skills/sbom/SKILL.md
@@ -32,20 +32,23 @@ See `references/examples.md` for copy-paste recipes.
 Prefer an ephemeral run so the user's environment is not polluted:
 
 ```bash
-uvx pitloom <project-or-model-path>       # uv's ephemeral runner
+uvx pitloom source <project-path>       # uv's ephemeral runner
 # or
-pipx run pitloom <project-or-model-path>  # pipx's ephemeral runner
+pipx run pitloom source <project-path>  # pipx's ephemeral runner
 ```
 
 Fall back to a normal install only if neither `uv` nor `pipx` is available:
 
 ```bash
 pip install pitloom
-loom <project-or-model-path>
+loom source <project-path>
 ```
 
 `loom` and `pitloom` are two names for the same console-script entry point;
 `uvx`/`pipx run` resolve `pitloom <args>` to that entry point automatically.
+Every invocation needs a subcommand -- `source` (a Python project) or
+`analyze` (a built wheel, an AI model file, or a Hugging Face repo); see
+below.
 
 ## Project SBOMs (Python packages)
 
@@ -59,8 +62,8 @@ Requires a `pyproject.toml` (PEP 621 `[project]` or Poetry
 
 ## AI model SBOMs (AIBOMs)
 
-Pass `-m` with a local model file or a Hugging Face URL/model ID -- no
-project directory required:
+Use `loom analyze` with a local model file or a Hugging Face URL/model ID --
+no project directory required:
 
 ```bash
 loom analyze model.safetensors
@@ -93,13 +96,14 @@ pitloom`).
 ## What Pitloom produces
 
 - An **SPDX 3 JSON** (JSON-LD) document (`@context` + `@graph`), by default
-  named `<name>-<version>.spdx3.json` (project mode) or
-  `<stem>.spdx3.json` (model mode).
-- Project mode includes: the main package, its dependencies, per-file
+  named `<name>-<version>.spdx3.json` (`source`) or `<stem>.spdx3.json`
+  (`analyze`, model target).
+- `source` includes: the main package, its dependencies, per-file
   SHA-256 hashes (Merkle root over the wheel's file set), and a
   `pkg:pypi/<name>@<version>` PURL for the main package.
-- Model mode includes: an `ai_AIPackage` element with whatever metadata the
-  model format embeds (architecture, hyperparameters, framework, etc.).
+- `analyze` (model target) includes: an `ai_AIPackage` element with
+  whatever metadata the model format embeds (architecture,
+  hyperparameters, framework, etc.).
 - If the target project registers Pitloom's Hatchling build hook
   (`[tool.hatch.build.hooks.pitloom]`), building a wheel
   (`python -m build` / `hatch build`) also embeds an SBOM at

--- a/skills/sbom/references/examples.md
+++ b/skills/sbom/references/examples.md
@@ -14,33 +14,33 @@ adapted with minimal edits.
 ## Project SBOM, ephemeral run
 
 ```bash
-uvx pitloom . -o sbom.spdx3.json --pretty
+uvx pitloom source . -o sbom.spdx3.json --pretty
 ```
 
 ## Project SBOM, already-installed Pitloom
 
 ```bash
 pip install pitloom
-loom /path/to/project -o sbom.spdx3.json
+loom source /path/to/project -o sbom.spdx3.json
 ```
 
 ## AI model SBOM, local file
 
 ```bash
-uvx --from 'pitloom[aimodel]' pitloom -m model.safetensors -o model.spdx3.json
+uvx --from 'pitloom[aimodel]' pitloom analyze model.safetensors -o model.spdx3.json
 ```
 
 ## AI model SBOM, Hugging Face Hub model
 
 ```bash
-uvx --from 'pitloom[huggingface]' pitloom -m mistralai/Mistral-7B-v0.1 \
+uvx --from 'pitloom[huggingface]' pitloom analyze mistralai/Mistral-7B-v0.1 \
   -o mistral.spdx3.json --pretty
 ```
 
 ## Project SBOM, multiple creators
 
 ```bash
-loom . --creator-name "Acme Corp" --creator-type organization \
+loom source . --creator-name "Acme Corp" --creator-type organization \
        --creator-name "Alice" --creator-email alice@example.com \
        -o sbom.spdx3.json
 ```

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -304,34 +304,22 @@ def _build_parser() -> argparse.ArgumentParser:
     analyze_parser = subparsers.add_parser(
         "analyze",
         parents=[parent_parser],
-        help="Generate an Analyzed SBOM from a built wheel.",
+        help="Generate an Analyzed SBOM from a built wheel, an AI model file, or a Hugging Face repository.",
     )
     analyze_parser.add_argument(
-        "wheel_path",
-        type=Path,
-        help="Path to the .whl file to analyze.",
+        "target",
+        type=str,
+        help=(
+            "Path to the .whl file, a local AI model file, or a Hugging Face URL / model ID. "
+            "Local AI formats: GGUF, ONNX, Safetensors, PyTorch, Keras, HDF5, NumPy, fastText. "
+            "Hugging Face: full URL or bare model ID."
+        ),
     )
 
     subparsers.add_parser(
         "deployed",
         parents=[parent_parser],
         help="Generate a Deployed SBOM for the currently installed environment.",
-    )
-
-    model_parser = subparsers.add_parser(
-        "model",
-        parents=[parent_parser],
-        help="Generate an Analyzed SBOM for an AI model file or Hugging Face repository.",
-    )
-    model_parser.add_argument(
-        "aimodel",
-        type=str,
-        metavar="MODEL_FILE_OR_HF_URL",
-        help=(
-            "Path to a local AI model file, or a Hugging Face URL / model ID. "
-            "Local formats: GGUF, ONNX, Safetensors, PyTorch, Keras, HDF5, NumPy, fastText. "
-            "Hugging Face: full URL or bare model ID."
-        ),
     )
 
     _add_ids_subparser(subparsers)
@@ -706,8 +694,6 @@ def main() -> int:
 
     if args.command == "ids":
         return _run_ids_cli(args)
-    if args.command == "model":
-        return _run_model_mode(args)
     if args.command == "source":
         return _run_project_mode(args)
     if args.command == "analyze":
@@ -756,11 +742,24 @@ def _run_deployed_mode(args: argparse.Namespace) -> int:
 
 
 def _run_analyze_mode(args: argparse.Namespace) -> int:
+    """Generate an Analyzed SBOM from a built wheel, an AI model, or HF repository."""
+    target: str = args.target
+
+    if target.endswith(".whl"):
+        return _run_wheel_analyze_mode(args, target)
+    
+    if is_huggingface_source(target):
+        return _run_hf_model_mode(args, target)
+    
+    return _run_local_model_mode(args, target)
+
+
+def _run_wheel_analyze_mode(args: argparse.Namespace, target: str) -> int:
     """Generate an Analyzed SBOM from a built wheel."""
     from pitloom.assemble import generate_analyzed_sbom
 
     try:
-        wheel_path: Path = args.wheel_path.resolve()
+        wheel_path: Path = Path(target).resolve()
         if not wheel_path.exists():
             print(f"Error: Wheel file not found: {wheel_path}", file=sys.stderr)
             return 1
@@ -865,7 +864,7 @@ def _add_ids_subparser(subparsers: Any) -> None:
         metavar="NAME[:TYPE]",
         help=(
             "Register a named entity (default TYPE: ai_AIPackage) so that "
-            "loom.set_model()/`loom -m` can reuse its id even before the "
+            "loom.set_model()/`loom model` can reuse its id even before the "
             "model file exists on disk. May be given multiple times."
         ),
     )
@@ -987,12 +986,7 @@ def _run_ids_cli(args: argparse.Namespace) -> int:
     return 1  # pragma: no cover
 
 
-def _run_model_mode(args: argparse.Namespace) -> int:
-    """Generate a standalone SBOM - dispatches to HF or local-file mode."""
-    source: str = args.aimodel
-    if is_huggingface_source(source):
-        return _run_hf_model_mode(args, source)
-    return _run_local_model_mode(args, source)
+
 
 
 def _run_local_model_mode(args: argparse.Namespace, source: str) -> int:

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -143,53 +143,15 @@ class _CreatorEmailAction(argparse.Action):
         )
 
 
-def _build_parser() -> argparse.ArgumentParser:
-    """Create and configure the CLI argument parser."""
-    parser = argparse.ArgumentParser(
-        description="Pitloom - Generate SPDX 3 SBOM for Python projects",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    parser.add_argument(
-        "-V",
-        "--version",
-        action="version",
-        version=f"Pitloom {__version__}",
-    )
+def _build_parent_parser() -> argparse.ArgumentParser:
+    """Build a parent parser containing common options."""
+    parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
         help="Print verbose output including Pitloom version, paths, "
         "and effective options.",
-    )
-    parser.add_argument(
-        "project_dir",
-        type=Path,
-        nargs="?",
-        default=None,
-        help=(
-            "Path to the project directory "
-            "(containing pyproject.toml, setup.cfg, or setup.py). "
-            "Required unless -m/--aimodel is used."
-        ),
-    )
-    parser.add_argument(
-        "-m",
-        "--aimodel",
-        dest="aimodel",
-        type=str,
-        default=None,
-        metavar="MODEL_FILE_OR_HF_URL",
-        help=(
-            "Path to a local AI model file, or a Hugging Face URL / model ID. "
-            "Generate a standalone SBOM for the model as an AIPackage, "
-            "without requiring a project directory. "
-            "Local formats: GGUF, ONNX, Safetensors, PyTorch, "
-            "Keras, HDF5, NumPy, fastText. "
-            "Hugging Face: full URL "
-            "(e.g. https://huggingface.co/mistralai/Mistral-7B-v0.1) "
-            "or bare model ID (e.g. Qwen/Qwen3-235B-A22B)."
-        ),
     )
     parser.add_argument(
         "-o",
@@ -301,6 +263,79 @@ def _build_parser() -> argparse.ArgumentParser:
             "current working directory)."
         ),
     )
+    return parser
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Create and configure the CLI argument parser."""
+    parent_parser = _build_parent_parser()
+
+    parser = argparse.ArgumentParser(
+        prog="loom",
+        description="Pitloom - Generate SPDX 3 SBOM for Python projects",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=f"Pitloom {__version__}",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    source_parser = subparsers.add_parser(
+        "source",
+        parents=[parent_parser],
+        help="Generate a Source SBOM from unbuilt source code.",
+    )
+    source_parser.add_argument(
+        "project_dir",
+        type=Path,
+        nargs="?",
+        default=Path.cwd(),
+        help=(
+            "Path to the project directory "
+            "(containing pyproject.toml, setup.cfg, or setup.py). "
+            "Default is the current directory."
+        ),
+    )
+
+    analyze_parser = subparsers.add_parser(
+        "analyze",
+        parents=[parent_parser],
+        help="Generate an Analyzed SBOM from a built wheel.",
+    )
+    analyze_parser.add_argument(
+        "wheel_path",
+        type=Path,
+        help="Path to the .whl file to analyze.",
+    )
+
+    subparsers.add_parser(
+        "deployed",
+        parents=[parent_parser],
+        help="Generate a Deployed SBOM for the currently installed environment.",
+    )
+
+    model_parser = subparsers.add_parser(
+        "model",
+        parents=[parent_parser],
+        help="Generate an Analyzed SBOM for an AI model file or Hugging Face repository.",
+    )
+    model_parser.add_argument(
+        "aimodel",
+        type=str,
+        metavar="MODEL_FILE_OR_HF_URL",
+        help=(
+            "Path to a local AI model file, or a Hugging Face URL / model ID. "
+            "Local formats: GGUF, ONNX, Safetensors, PyTorch, Keras, HDF5, NumPy, fastText. "
+            "Hugging Face: full URL or bare model ID."
+        ),
+    )
+
+    _add_ids_subparser(subparsers)
+
     return parser
 
 
@@ -663,32 +698,107 @@ def _resolve_hf_output_path(explicit: Path | None, model_id: str) -> Path:
 def main() -> int:
     """Main entry point for the Pitloom CLI.
 
-    Dispatches ``pitloom ids ...`` to the id-registry sub-CLI (see
-    :func:`_run_ids_cli`) before touching the main SBOM-generation parser --
-    ``ids`` is a subcommand, not a project directory, and intercepting it
-    here keeps the main parser (positional ``project_dir`` / ``-m``) exactly
-    as it was, with no argparse subparsers to reconcile against it.
-
     Returns:
         int: Exit code (0 for success, 1 for error)
     """
-    if len(sys.argv) > 1 and sys.argv[1] == "ids":
-        return _run_ids_cli(sys.argv[2:])
-
     parser = _build_parser()
     args = parser.parse_args()
 
-    if args.aimodel is not None:
+    if args.command == "ids":
+        return _run_ids_cli(args)
+    if args.command == "model":
         return _run_model_mode(args)
+    if args.command == "source":
+        return _run_project_mode(args)
+    if args.command == "analyze":
+        return _run_analyze_mode(args)
+    if args.command == "deployed":
+        return _run_deployed_mode(args)
 
-    if args.project_dir is None:
-        print(
-            "Error: project_dir is required unless -m/--aimodel is used.",
-            file=sys.stderr,
+    return 1
+
+
+def _run_deployed_mode(args: argparse.Namespace) -> int:
+    """Generate a Deployed SBOM from the current environment."""
+    from pitloom.assemble import generate_deployed_sbom
+
+    try:
+        pitloom_config = PitloomConfig()
+        creation = _resolve_creation_metadata(args, pitloom_config)
+        effective_pretty = args.pretty if args.pretty is not None else False
+        effective_describe = (
+            bool(args.describe_relationship)
+            if args.describe_relationship is not None
+            else False
         )
+
+        output_path = args.output
+        if output_path is None:
+            output_path = Path.cwd() / f"deployed-environment{_SPDX3_JSON_EXT}"
+
+        if args.verbose:
+            print(f"Pitloom version : {__version__}")
+            print(f"Output path     : {output_path}")
+
+        generate_deployed_sbom(
+            output_path=output_path,
+            creation_metadata=creation.to_creation_metadata(),
+            pretty=effective_pretty,
+            describe_relationship=effective_describe,
+            registry=args.registry,
+        )
+        return 0
+
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print(f"Error generating Deployed SBOM: {e}", file=sys.stderr)
+        traceback.print_exc()
         return 1
 
-    return _run_project_mode(args)
+
+def _run_analyze_mode(args: argparse.Namespace) -> int:
+    """Generate an Analyzed SBOM from a built wheel."""
+    from pitloom.assemble import generate_analyzed_sbom
+
+    try:
+        wheel_path: Path = args.wheel_path.resolve()
+        if not wheel_path.exists():
+            print(f"Error: Wheel file not found: {wheel_path}", file=sys.stderr)
+            return 1
+
+        pitloom_config = PitloomConfig()
+        creation = _resolve_creation_metadata(args, pitloom_config)
+        effective_pretty = args.pretty if args.pretty is not None else False
+        effective_describe = (
+            bool(args.describe_relationship)
+            if args.describe_relationship is not None
+            else False
+        )
+
+        # We don't have project metadata here yet to auto-name,
+        # so we'll just use a fallback or the explicit output
+        output_path = args.output
+        if output_path is None:
+            output_path = Path.cwd() / f"{wheel_path.stem}{_SPDX3_JSON_EXT}"
+
+        if args.verbose:
+            print(f"Pitloom version : {__version__}")
+            print(f"Wheel file      : {wheel_path}")
+            print(f"Output path     : {output_path}")
+
+        generate_analyzed_sbom(
+            wheel_path,
+            output_path=output_path,
+            creation_metadata=creation.to_creation_metadata(),
+            pretty=effective_pretty,
+            describe_relationship=effective_describe,
+            registry=args.registry,
+        )
+        return 0
+
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print(f"Error generating Analyzed SBOM: {e}", file=sys.stderr)
+        traceback.print_exc()
+        return 1
 
 
 # ---------------------------------------------------------------------------
@@ -700,19 +810,20 @@ def main() -> int:
 _DEFAULT_IDS_GENERATE_DIR_NAMES: tuple[str, ...] = ("src", "data", "models")
 
 
-def _build_ids_parser() -> argparse.ArgumentParser:
-    """Build the argument parser for ``pitloom ids <command> ...``."""
-    parser = argparse.ArgumentParser(
-        prog="pitloom ids",
+def _add_ids_subparser(subparsers: Any) -> None:
+    """Add the ``ids`` subcommand to the main parser."""
+    ids_parser = subparsers.add_parser(
+        "ids",
+        help="Manage the Loom ID registry.",
         description=(
             "Manage the Loom ID registry, a stable file/entity -> SPDX ID "
             "registry consulted by 'pitloom.loom', the Hatchling build hook, "
             "and the CLI."
         ),
     )
-    subparsers = parser.add_subparsers(dest="ids_command", required=True)
+    ids_subparsers = ids_parser.add_subparsers(dest="ids_command", required=True)
 
-    generate_parser = subparsers.add_parser(
+    generate_parser = ids_subparsers.add_parser(
         "generate",
         help="Index files (and detected AI models) under PATHs into the registry.",
     )
@@ -759,7 +870,7 @@ def _build_ids_parser() -> argparse.ArgumentParser:
         ),
     )
 
-    import_parser = subparsers.add_parser(
+    import_parser = ids_subparsers.add_parser(
         "import", help="Harvest ids from an existing SPDX 3 JSON-LD SBOM."
     )
     import_parser.add_argument(
@@ -776,8 +887,6 @@ def _build_ids_parser() -> argparse.ArgumentParser:
             f"(default: {DEFAULT_REGISTRY_FILENAME} in the current directory)."
         ),
     )
-
-    return parser
 
 
 def _default_ids_generate_paths(project_dir: Path) -> list[Path]:
@@ -869,19 +978,13 @@ def _run_ids_import(args: argparse.Namespace) -> int:
     return 0
 
 
-def _run_ids_cli(argv: list[str]) -> int:
-    """Parse and dispatch ``pitloom ids <command> ...`` arguments."""
-    parser = _build_ids_parser()
-    args = parser.parse_args(argv)
+def _run_ids_cli(args: argparse.Namespace) -> int:
+    """Dispatch ``pitloom ids <command> ...`` arguments."""
     if args.ids_command == "generate":
         return _run_ids_generate(args)
     if args.ids_command == "import":
         return _run_ids_import(args)
-    parser.error(f"Unknown ids command: {args.ids_command}")  # pragma: no cover
-    # parser.error() always raises SystemExit (argparse's `required=True` on
-    # the subparsers already makes this line unreachable in practice) --
-    # kept only so every code path has an explicit `return int`.
-    return 1  # type: ignore[unreachable] # pragma: no cover
+    return 1  # pragma: no cover
 
 
 def _run_model_mode(args: argparse.Namespace) -> int:

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -16,6 +16,8 @@ from typing import Any
 from pitloom.__about__ import __version__
 from pitloom.assemble import (
     generate_ai_model_sbom,
+    generate_analyzed_sbom,
+    generate_deployed_sbom,
     generate_huggingface_sbom,
     generate_sbom,
 )
@@ -304,15 +306,19 @@ def _build_parser() -> argparse.ArgumentParser:
     analyze_parser = subparsers.add_parser(
         "analyze",
         parents=[parent_parser],
-        help="Generate an Analyzed SBOM from a built wheel, an AI model file, or a Hugging Face repository.",
+        help=(
+            "Generate an Analyzed SBOM from a built wheel, an AI model "
+            "file, or a Hugging Face repository."
+        ),
     )
     analyze_parser.add_argument(
         "target",
         type=str,
         help=(
-            "Path to the .whl file, a local AI model file, or a Hugging Face URL / model ID. "
-            "Local AI formats: GGUF, ONNX, Safetensors, PyTorch, Keras, HDF5, NumPy, fastText. "
-            "Hugging Face: full URL or bare model ID."
+            "Path to the .whl file, a local AI model file, or a Hugging "
+            "Face URL / model ID. Local AI formats: GGUF, ONNX, "
+            "Safetensors, PyTorch, Keras, HDF5, NumPy, fastText. Hugging "
+            "Face: full URL or bare model ID."
         ),
     )
 
@@ -706,8 +712,6 @@ def main() -> int:
 
 def _run_deployed_mode(args: argparse.Namespace) -> int:
     """Generate a Deployed SBOM from the current environment."""
-    from pitloom.assemble import generate_deployed_sbom
-
     try:
         pitloom_config = PitloomConfig()
         creation = _resolve_creation_metadata(args, pitloom_config)
@@ -747,17 +751,15 @@ def _run_analyze_mode(args: argparse.Namespace) -> int:
 
     if target.endswith(".whl"):
         return _run_wheel_analyze_mode(args, target)
-    
+
     if is_huggingface_source(target):
         return _run_hf_model_mode(args, target)
-    
+
     return _run_local_model_mode(args, target)
 
 
 def _run_wheel_analyze_mode(args: argparse.Namespace, target: str) -> int:
     """Generate an Analyzed SBOM from a built wheel."""
-    from pitloom.assemble import generate_analyzed_sbom
-
     try:
         wheel_path: Path = Path(target).resolve()
         if not wheel_path.exists():
@@ -984,9 +986,6 @@ def _run_ids_cli(args: argparse.Namespace) -> int:
     if args.ids_command == "import":
         return _run_ids_import(args)
     return 1  # pragma: no cover
-
-
-
 
 
 def _run_local_model_mode(args: argparse.Namespace, source: str) -> int:

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -775,8 +775,8 @@ def _run_wheel_analyze_mode(args: argparse.Namespace, target: str) -> int:
             else False
         )
 
-        # We don't have project metadata here yet to auto-name,
-        # so we'll just use a fallback or the explicit output
+        # No project metadata is available to auto-name the output from,
+        # so an explicit --output or a wheel-stem-derived fallback is used.
         output_path = args.output
         if output_path is None:
             output_path = Path.cwd() / f"{wheel_path.stem}{_SPDX3_JSON_EXT}"

--- a/src/pitloom/assemble/__init__.py
+++ b/src/pitloom/assemble/__init__.py
@@ -228,4 +228,132 @@ def generate_huggingface_sbom(
     return sbom_json
 
 
-__all__ = ["generate_ai_model_sbom", "generate_huggingface_sbom", "generate_sbom"]
+def generate_analyzed_sbom(
+    wheel_path: Path,
+    *,
+    output_path: Path | None = None,
+    creation_metadata: CreationMetadata | None = None,
+    pretty: bool = False,
+    describe_relationship: bool = False,
+    registry: str | Path | IdRegistry | None = None,
+) -> str:
+    """Generate an Analyzed SPDX 3 SBOM for a built Python wheel.
+
+    Args:
+        wheel_path: Path to the .whl file.
+        output_path: If given, the JSON-LD output is also written to this path.
+        creation_metadata: Creator and timestamp metadata for the SBOM document.
+        pretty: Indent JSON output with 2 spaces when True.
+        describe_relationship: Add human-readable text to SPDX relationships.
+        registry: A stable file/entity id registry (see IdRegistry).
+
+    Returns:
+        JSON-LD string of the generated SPDX 3 SBOM.
+    """
+    from pitloom.extract.binary import find_phantom_dependencies
+    from pitloom.extract.wheel import read_wheel
+
+    project_metadata, project_files = read_wheel(wheel_path)
+
+    # We could theoretically compute a Merkle root for the wheel,
+    # but the wheel file itself is the artifact.
+    merkle_root = None
+
+    # For analyzed SBOMs from wheels, we don't have the source directory to scan for AI models
+    # in the same way, but we could scan the wheel contents.
+    # We will pass an empty list of AI models for now unless we implement AI model scanning from wheels.
+    from typing import Any
+    ai_models: list[Any] = []
+
+    phantom_deps = find_phantom_dependencies(project_files)
+
+    # We don't have a project_dir, so we can't easily auto-discover loom-ids.json
+    # by walking up. We'll use the current directory as a fallback.
+    cwd = Path.cwd()
+    resolved_registry = (
+        registry
+        if isinstance(registry, IdRegistry)
+        else IdRegistry.load(cwd / registry)
+        if registry is not None
+        else resolve_registry(cwd, None)
+    )
+
+    doc = DocumentModel(
+        project=project_metadata,
+        creation_metadata=creation_metadata or CreationMetadata(),
+        ai_models=ai_models,
+        phantom_dependencies=phantom_deps,
+    )
+    exporter = build(doc, merkle_root=merkle_root, registry=resolved_registry)
+
+    sbom_json = exporter.to_json(
+        pretty=pretty,
+        describe_relationship=describe_relationship,
+    )
+
+    if output_path is not None:
+        output_path.write_text(sbom_json, encoding="utf-8")
+
+    return sbom_json
+
+
+def generate_deployed_sbom(
+    *,
+    output_path: Path | None = None,
+    creation_metadata: CreationMetadata | None = None,
+    pretty: bool = False,
+    describe_relationship: bool = False,
+    registry: str | Path | IdRegistry | None = None,
+) -> str:
+    """Generate a Deployed SPDX 3 SBOM for the current Python environment.
+
+    Args:
+        output_path: If given, the JSON-LD output is also written to this path.
+        creation_metadata: Creator and timestamp metadata for the SBOM document.
+        pretty: Indent JSON output with 2 spaces when True.
+        describe_relationship: Add human-readable text to SPDX relationships.
+        registry: A stable file/entity id registry (see IdRegistry).
+
+    Returns:
+        JSON-LD string of the generated SPDX 3 SBOM.
+    """
+    from pitloom.assemble.spdx3.document import build_deployed
+    from pitloom.extract.env import read_environment
+
+    project_metadata, env_tree = read_environment()
+
+    # We don't have a project_dir, so we use the current directory as a fallback.
+    cwd = Path.cwd()
+    resolved_registry = (
+        registry
+        if isinstance(registry, IdRegistry)
+        else IdRegistry.load(cwd / registry)
+        if registry is not None
+        else resolve_registry(cwd, None)
+    )
+
+    doc = DocumentModel(
+        project=project_metadata,
+        creation_metadata=creation_metadata or CreationMetadata(),
+        ai_models=[],
+    )
+    exporter = build_deployed(doc, env_tree=env_tree, registry=resolved_registry)
+
+    sbom_json = exporter.to_json(
+        pretty=pretty,
+        describe_relationship=describe_relationship,
+    )
+
+    if output_path is not None:
+        output_path.write_text(sbom_json, encoding="utf-8")
+
+    return sbom_json
+
+
+__all__ = [
+    "generate_ai_model_sbom",
+    "generate_analyzed_sbom",
+    "generate_deployed_sbom",
+    "generate_huggingface_sbom",
+    "generate_sbom",
+]

--- a/src/pitloom/assemble/__init__.py
+++ b/src/pitloom/assemble/__init__.py
@@ -256,20 +256,18 @@ def generate_analyzed_sbom(
     """
     project_metadata, project_files = read_wheel(wheel_path)
 
-    # We could theoretically compute a Merkle root for the wheel,
-    # but the wheel file itself is the artifact.
+    # The wheel file itself is the artifact identity here; no separate
+    # source-tree Merkle root applies.
     merkle_root = None
 
-    # For analyzed SBOMs from wheels, we don't have the source directory to
-    # scan for AI models in the same way, but we could scan the wheel
-    # contents. Passing an empty list until wheel-content AI model scanning
-    # is implemented.
+    # AI model detection scans a source directory tree; wheel contents are
+    # not scanned for models, so this is always empty for an Analyzed SBOM.
     ai_models: list[Any] = []
 
     phantom_deps = find_phantom_dependencies(project_files)
 
-    # We don't have a project_dir, so we can't easily auto-discover loom-ids.json
-    # by walking up. We'll use the current directory as a fallback.
+    # No project_dir is available to walk up from for loom-ids.json
+    # auto-discovery, so the current directory is used as the search root.
     cwd = Path.cwd()
     resolved_registry = (
         registry
@@ -320,7 +318,8 @@ def generate_deployed_sbom(
     """
     project_metadata, env_tree = read_environment()
 
-    # We don't have a project_dir, so we use the current directory as a fallback.
+    # No project_dir applies to a deployed-environment scan, so the current
+    # directory is used as the loom-ids.json search root.
     cwd = Path.cwd()
     resolved_registry = (
         registry

--- a/src/pitloom/assemble/__init__.py
+++ b/src/pitloom/assemble/__init__.py
@@ -7,8 +7,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
-from pitloom.assemble.spdx3.document import build, build_model
+from pitloom.assemble.spdx3.document import build, build_deployed, build_model
 from pitloom.assemble.spdx3.fragments import merge_fragments
 from pitloom.core.config import PitloomConfig
 from pitloom.core.creation import CreationMetadata
@@ -17,8 +18,11 @@ from pitloom.core.models import get_wheel_files
 from pitloom.core.project import ProjectMetadata
 from pitloom.extract._huggingface import read_huggingface
 from pitloom.extract.ai_model import read_ai_model
+from pitloom.extract.binary import find_phantom_dependencies
+from pitloom.extract.env import read_environment
 from pitloom.extract.project import read_project
 from pitloom.extract.scanner import scan_project_for_ai_models
+from pitloom.extract.wheel import read_wheel
 from pitloom.ids import IdRegistry, resolve_registry
 
 
@@ -250,19 +254,16 @@ def generate_analyzed_sbom(
     Returns:
         JSON-LD string of the generated SPDX 3 SBOM.
     """
-    from pitloom.extract.binary import find_phantom_dependencies
-    from pitloom.extract.wheel import read_wheel
-
     project_metadata, project_files = read_wheel(wheel_path)
 
     # We could theoretically compute a Merkle root for the wheel,
     # but the wheel file itself is the artifact.
     merkle_root = None
 
-    # For analyzed SBOMs from wheels, we don't have the source directory to scan for AI models
-    # in the same way, but we could scan the wheel contents.
-    # We will pass an empty list of AI models for now unless we implement AI model scanning from wheels.
-    from typing import Any
+    # For analyzed SBOMs from wheels, we don't have the source directory to
+    # scan for AI models in the same way, but we could scan the wheel
+    # contents. Passing an empty list until wheel-content AI model scanning
+    # is implemented.
     ai_models: list[Any] = []
 
     phantom_deps = find_phantom_dependencies(project_files)
@@ -317,9 +318,6 @@ def generate_deployed_sbom(
     Returns:
         JSON-LD string of the generated SPDX 3 SBOM.
     """
-    from pitloom.assemble.spdx3.document import build_deployed
-    from pitloom.extract.env import read_environment
-
     project_metadata, env_tree = read_environment()
 
     # We don't have a project_dir, so we use the current directory as a fallback.

--- a/src/pitloom/assemble/spdx3/ai.py
+++ b/src/pitloom/assemble/spdx3/ai.py
@@ -40,7 +40,7 @@ def _lookup_ai_model_entity(
     3. The file stem of ``format_info.file_name`` (e.g. ``"model"`` for
        ``"model.bin"``) -- mirrors the lookup
        :func:`pitloom.assemble.generate_ai_model_sbom` performs for
-       ``loom -m``/``--registry``.
+       ``loom model``/``--registry``.
 
     Returns ``None`` (mint a fresh id, unchanged behaviour) when no registry
     is given or none of the candidates are registered.

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -13,6 +13,7 @@ from importlib.metadata import version as get_package_version
 from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.core.models import build_pypi_purl, generate_spdx_id
+from pitloom.core.project import PhantomDependency
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 
 # Operators used in PEP 508 dependency specifiers, ordered longest-first to
@@ -309,3 +310,63 @@ def add_dependencies(
         )
         dep_rel.comment = f"Metadata provenance: dependencies: {dep_provenance}"
         exporter.add_relationship(dep_rel)
+
+
+def add_phantom_dependencies(
+    phantom_deps: list[PhantomDependency],
+    main_package_spdx_id: str,
+    file_spdx_ids: dict[str, str],
+    creation_info: spdx3.CreationInfo,
+    doc_name: str,
+    doc_uuid: str,
+    exporter: Spdx3JsonExporter,
+) -> None:
+    """Build SPDX elements for bundled phantom binary dependencies.
+
+    Args:
+        phantom_deps: List of PhantomDependency objects discovered in the distribution.
+        main_package_spdx_id: SPDX ID of the parent package for relationships.
+        file_spdx_ids: Mapping of file paths to their SPDX IDs to link packages to files.
+        creation_info: Shared CreationInfo for all new elements.
+        doc_name: Document name (project name) for SPDX ID generation.
+        doc_uuid: Document-scoped UUID used in SPDX ID generation.
+        exporter: Receives the new package and relationship elements.
+    """
+    for dep in phantom_deps:
+        dep_package = spdx3.software_Package(
+            spdxId=generate_spdx_id("Package", doc_name=doc_name, doc_uuid=doc_uuid),
+            name=dep.name,
+            creationInfo=creation_info,
+        )
+        if dep.version:
+            dep_package.software_packageVersion = dep.version
+        else:
+            dep_package.software_packageVersion = "unknown"
+
+        dep_package.software_primaryPurpose = spdx3.software_SoftwarePurpose.library
+        dep_package.comment = "Metadata provenance: Phantom dependency bundled in distribution artifact"
+
+        # We don't have download URLs or licenses for these easily, so they are minimal
+        exporter.add_package(dep_package)
+
+        # The main package depends on this phantom package
+        dep_rel = spdx3.Relationship(
+            spdxId=generate_spdx_id("Relationship", doc_name=doc_name, doc_uuid=doc_uuid),
+            from_=main_package_spdx_id,
+            to=[require_spdx_id(dep_package)],
+            relationshipType=spdx3.RelationshipType.dependsOn,
+            creationInfo=creation_info,
+        )
+        exporter.add_relationship(dep_rel)
+
+        # Link the phantom package to the physical file if it was registered
+        file_spdx_id = file_spdx_ids.get(dep.file_path)
+        if file_spdx_id:
+            file_rel = spdx3.Relationship(
+                spdxId=generate_spdx_id("Relationship", doc_name=doc_name, doc_uuid=doc_uuid),
+                from_=require_spdx_id(dep_package),
+                to=[file_spdx_id],
+                relationshipType=spdx3.RelationshipType.contains,
+                creationInfo=creation_info,
+            )
+            exporter.add_relationship(file_rel)

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -326,7 +326,8 @@ def add_phantom_dependencies(
     Args:
         phantom_deps: List of PhantomDependency objects discovered in the distribution.
         main_package_spdx_id: SPDX ID of the parent package for relationships.
-        file_spdx_ids: Mapping of file paths to their SPDX IDs to link packages to files.
+        file_spdx_ids: Mapping of file paths to their SPDX IDs, to link
+            packages to files.
         creation_info: Shared CreationInfo for all new elements.
         doc_name: Document name (project name) for SPDX ID generation.
         doc_uuid: Document-scoped UUID used in SPDX ID generation.
@@ -344,14 +345,18 @@ def add_phantom_dependencies(
             dep_package.software_packageVersion = "unknown"
 
         dep_package.software_primaryPurpose = spdx3.software_SoftwarePurpose.library
-        dep_package.comment = "Metadata provenance: Phantom dependency bundled in distribution artifact"
+        dep_package.comment = (
+            "Metadata provenance: Phantom dependency bundled in distribution artifact"
+        )
 
         # We don't have download URLs or licenses for these easily, so they are minimal
         exporter.add_package(dep_package)
 
         # The main package depends on this phantom package
         dep_rel = spdx3.Relationship(
-            spdxId=generate_spdx_id("Relationship", doc_name=doc_name, doc_uuid=doc_uuid),
+            spdxId=generate_spdx_id(
+                "Relationship", doc_name=doc_name, doc_uuid=doc_uuid
+            ),
             from_=main_package_spdx_id,
             to=[require_spdx_id(dep_package)],
             relationshipType=spdx3.RelationshipType.dependsOn,
@@ -363,7 +368,9 @@ def add_phantom_dependencies(
         file_spdx_id = file_spdx_ids.get(dep.file_path)
         if file_spdx_id:
             file_rel = spdx3.Relationship(
-                spdxId=generate_spdx_id("Relationship", doc_name=doc_name, doc_uuid=doc_uuid),
+                spdxId=generate_spdx_id(
+                    "Relationship", doc_name=doc_name, doc_uuid=doc_uuid
+                ),
                 from_=require_spdx_id(dep_package),
                 to=[file_spdx_id],
                 relationshipType=spdx3.RelationshipType.contains,

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -220,16 +220,12 @@ def build_license_elements(
         to=[license_spdx_id],
     )
 
-    # The license identified by the SPDX data creator.
-    # This can be more complicated.
-    # For example, if there are mulitple declared licenses,
-    # or if there is no declared licenes but a license
-    # can be concluded from other evidence.
-    # See https://spdx.github.io/spdx-spec/v3.0/model/Licensing/Licensing/
-    # Sort this out in future versions.
-    # Eventually we may need to create the relationships separately,
-    # as hasDeclaredLicense and hasConcludedLicense can be different and
-    # the value of having this helper function will be less clear.
+    # The license identified by the SPDX data creator. Currently set equal to
+    # the declared license; hasDeclaredLicense and hasConcludedLicense are
+    # distinct in the SPDX 3 model (e.g. multiple declared licenses, or a
+    # concluded license inferred from evidence other than the declaration --
+    # see https://spdx.github.io/spdx-spec/v3.0/model/Licensing/Licensing/),
+    # but pitloom does not yet perform that inference.
     rel_has_concluded_license = spdx3.Relationship(
         spdxId=generate_spdx_id("Relationship", doc_name=doc_name, doc_uuid=doc_uuid),
         creationInfo=creation_info,
@@ -349,10 +345,10 @@ def add_phantom_dependencies(
             "Metadata provenance: Phantom dependency bundled in distribution artifact"
         )
 
-        # We don't have download URLs or licenses for these easily, so they are minimal
+        # Download URL and license are not derivable from a bundled binary alone.
         exporter.add_package(dep_package)
 
-        # The main package depends on this phantom package
+        # The main package depends on this phantom package.
         dep_rel = spdx3.Relationship(
             spdxId=generate_spdx_id(
                 "Relationship", doc_name=doc_name, doc_uuid=doc_uuid

--- a/src/pitloom/assemble/spdx3/document.py
+++ b/src/pitloom/assemble/spdx3/document.py
@@ -16,6 +16,7 @@ from pitloom.assemble.spdx3.ai import _build_ai_package, add_ai_models
 from pitloom.assemble.spdx3.creation_info import build_creation_info
 from pitloom.assemble.spdx3.dataset import add_datasets_for_model
 from pitloom.assemble.spdx3.deps import (
+    _enrich_from_installed,
     add_dependencies,
     add_phantom_dependencies,
     build_license_elements,
@@ -455,6 +456,7 @@ def build_model(
     return exporter
 
 
+# pylint: disable=too-many-locals
 def build_deployed(
     doc: DocumentModel,
     env_tree: list[dict[str, Any]],
@@ -466,13 +468,23 @@ def build_deployed(
     Args:
         doc: Format-neutral document model with environment metadata.
         env_tree: Flat JSON list of packages and dependencies from pipdeptree.
-        registry: Optional stable file id registry.
+        registry: Optional stable file id registry. Each installed
+            package's id is looked up by name
+            (:meth:`~pitloom.ids.IdRegistry.lookup_entity`, type
+            ``"software_Package"``); a match reuses the registered
+            ``spdxId`` instead of minting a fresh one, so this element can
+            be unified with the same package referenced elsewhere (e.g. a
+            Source or Analyzed SBOM) once merged. A miss falls back to the
+            existing deterministic minting. A package gets a registry
+            entry either via an explicit ``pitloom ids generate --entity
+            <name>:software_Package``, or in bulk via ``pitloom ids
+            import <existing-sbom>`` (:meth:`~pitloom.ids.IdRegistry.import_sbom`
+            harvests every named element generically, not just files and
+            AI models).
 
     Returns:
         A populated Spdx3JsonExporter.
     """
-    from pitloom.assemble.spdx3.deps import _enrich_from_installed
-
     metadata = doc.project
     exporter = Spdx3JsonExporter()
     doc_uuid = compute_doc_uuid(
@@ -507,21 +519,31 @@ def build_deployed(
 
         dep_version = pkg_info.get("installed_version", "unknown")
 
+        registered_id = (
+            registry.lookup_entity(dep_name, "software_Package")
+            if registry is not None
+            else None
+        )
         dep_package = spdx3.software_Package(
-            spdxId=generate_spdx_id("Package", doc_name=metadata.name, doc_uuid=doc_uuid),
+            spdxId=registered_id
+            or generate_spdx_id("Package", doc_name=metadata.name, doc_uuid=doc_uuid),
             name=dep_name,
             creationInfo=spdx_ci,
         )
         dep_package.software_packageVersion = dep_version
         dep_package.software_primaryPurpose = spdx3.software_SoftwarePurpose.library
-        dep_package.comment = "Metadata provenance: Source: pipdeptree (deployed environment)"
+        dep_package.comment = (
+            "Metadata provenance: Source: pipdeptree (deployed environment)"
+        )
 
         _enrich_from_installed(
             dep_name, dep_package, spdx_ci, metadata.name, doc_uuid, exporter
         )
 
         exporter.add_package(dep_package)
-        package_spdx_ids[pkg_info.get("key", dep_name.lower())] = require_spdx_id(dep_package)
+        package_spdx_ids[pkg_info.get("key", dep_name.lower())] = require_spdx_id(
+            dep_package
+        )
 
     # Second pass: Create relationships
     dep_keys_with_parents = set()
@@ -574,7 +596,9 @@ def build_deployed(
     sbom.software_sbomType = [spdx3.software_SbomType.deployed]
 
     spdx_doc = spdx3.SpdxDocument(
-        spdxId=generate_spdx_id("SpdxDocument", doc_name=metadata.name, doc_uuid=doc_uuid),
+        spdxId=generate_spdx_id(
+            "SpdxDocument", doc_name=metadata.name, doc_uuid=doc_uuid
+        ),
         creationInfo=spdx_ci,
         rootElement=[sbom.spdxId],
     )

--- a/src/pitloom/assemble/spdx3/document.py
+++ b/src/pitloom/assemble/spdx3/document.py
@@ -8,13 +8,18 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.assemble.spdx3.ai import _build_ai_package, add_ai_models
 from pitloom.assemble.spdx3.creation_info import build_creation_info
 from pitloom.assemble.spdx3.dataset import add_datasets_for_model
-from pitloom.assemble.spdx3.deps import add_dependencies, build_license_elements
+from pitloom.assemble.spdx3.deps import (
+    add_dependencies,
+    add_phantom_dependencies,
+    build_license_elements,
+)
 from pitloom.core.ai_metadata import AiModelMetadata
 from pitloom.core.creation import CreationMetadata
 from pitloom.core.document import DocumentModel
@@ -308,6 +313,18 @@ def build(
         doc, main_package, spdx_ci, doc_uuid, exporter, registry
     )
 
+    # --- Phantom Dependencies ---
+    if doc.phantom_dependencies:
+        add_phantom_dependencies(
+            phantom_deps=doc.phantom_dependencies,
+            main_package_spdx_id=require_spdx_id(main_package),
+            file_spdx_ids=file_spdx_ids,
+            creation_info=spdx_ci,
+            doc_name=metadata.name,
+            doc_uuid=doc_uuid,
+            exporter=exporter,
+        )
+
     # --- AI models (and their associated datasets) ---
     if doc.ai_models:
         spdx_doc.profileConformance.append(spdx3.ProfileIdentifierType.ai)
@@ -431,6 +448,145 @@ def build_model(
         spdx_doc.profileConformance.append(spdx3.ProfileIdentifierType.simpleLicensing)
     if model.datasets:
         spdx_doc.profileConformance.append(spdx3.ProfileIdentifierType.dataset)
+
+    exporter.add_document(spdx_doc)
+    exporter.add_sbom(sbom)
+
+    return exporter
+
+
+def build_deployed(
+    doc: DocumentModel,
+    env_tree: list[dict[str, Any]],
+    *,
+    registry: IdRegistry | None = None,
+) -> Spdx3JsonExporter:
+    """Assemble SPDX 3 elements for a deployed environment.
+
+    Args:
+        doc: Format-neutral document model with environment metadata.
+        env_tree: Flat JSON list of packages and dependencies from pipdeptree.
+        registry: Optional stable file id registry.
+
+    Returns:
+        A populated Spdx3JsonExporter.
+    """
+    from pitloom.assemble.spdx3.deps import _enrich_from_installed
+
+    metadata = doc.project
+    exporter = Spdx3JsonExporter()
+    doc_uuid = compute_doc_uuid(
+        name=metadata.name,
+        version=metadata.version or "unknown",
+        dependencies=[],
+        merkle_root=None,
+    )
+    _clear_doc_counters(doc_uuid)
+
+    # --- Creation info ---
+    spdx_ci, agents, tools = _build_creation_bundle(doc, doc_uuid)
+    exporter.add_creation_info(spdx_ci)
+    for agent in agents:
+        exporter.add_agent(agent)
+    for tool in tools:
+        exporter.object_set.add(tool)
+
+    # --- Synthetic Main package representing the environment ---
+    main_package = _build_main_package(doc, spdx_ci, agents, doc_uuid)
+    exporter.add_package(main_package)
+
+    # --- Packages and Relationships ---
+    package_spdx_ids: dict[str, str] = {}
+
+    # First pass: Create all packages
+    for node in env_tree:
+        pkg_info = node.get("package", {})
+        dep_name = pkg_info.get("package_name")
+        if not dep_name:
+            continue
+
+        dep_version = pkg_info.get("installed_version", "unknown")
+
+        dep_package = spdx3.software_Package(
+            spdxId=generate_spdx_id("Package", doc_name=metadata.name, doc_uuid=doc_uuid),
+            name=dep_name,
+            creationInfo=spdx_ci,
+        )
+        dep_package.software_packageVersion = dep_version
+        dep_package.software_primaryPurpose = spdx3.software_SoftwarePurpose.library
+        dep_package.comment = "Metadata provenance: Source: pipdeptree (deployed environment)"
+
+        _enrich_from_installed(
+            dep_name, dep_package, spdx_ci, metadata.name, doc_uuid, exporter
+        )
+
+        exporter.add_package(dep_package)
+        package_spdx_ids[pkg_info.get("key", dep_name.lower())] = require_spdx_id(dep_package)
+
+    # Second pass: Create relationships
+    dep_keys_with_parents = set()
+    for node in env_tree:
+        parent_key = node.get("package", {}).get("key")
+        parent_spdx_id = package_spdx_ids.get(parent_key)
+        if not parent_spdx_id:
+            continue
+
+        for dep in node.get("dependencies", []):
+            child_key = dep.get("key")
+            dep_keys_with_parents.add(child_key)
+            child_spdx_id = package_spdx_ids.get(child_key)
+            if child_spdx_id:
+                dep_rel = spdx3.Relationship(
+                    spdxId=generate_spdx_id(
+                        "Relationship", doc_name=metadata.name, doc_uuid=doc_uuid
+                    ),
+                    from_=parent_spdx_id,
+                    to=[child_spdx_id],
+                    relationshipType=spdx3.RelationshipType.dependsOn,
+                    creationInfo=spdx_ci,
+                )
+                dep_rel.comment = "Metadata provenance: Source: pipdeptree"
+                exporter.add_relationship(dep_rel)
+
+    # Third pass: Link top-level packages to the environment root
+    for node in env_tree:
+        pkg_key = node.get("package", {}).get("key")
+        if pkg_key not in dep_keys_with_parents:
+            child_spdx_id = package_spdx_ids.get(pkg_key)
+            if child_spdx_id:
+                dep_rel = spdx3.Relationship(
+                    spdxId=generate_spdx_id(
+                        "Relationship", doc_name=metadata.name, doc_uuid=doc_uuid
+                    ),
+                    from_=require_spdx_id(main_package),
+                    to=[child_spdx_id],
+                    relationshipType=spdx3.RelationshipType.dependsOn,
+                    creationInfo=spdx_ci,
+                )
+                exporter.add_relationship(dep_rel)
+
+    # --- SBOM and document envelope ---
+    sbom = spdx3.software_Sbom(
+        spdxId=generate_spdx_id("Sbom", doc_name=metadata.name, doc_uuid=doc_uuid),
+        creationInfo=spdx_ci,
+        rootElement=[main_package.spdxId],
+    )
+    sbom.software_sbomType = [spdx3.software_SbomType.deployed]
+
+    spdx_doc = spdx3.SpdxDocument(
+        spdxId=generate_spdx_id("SpdxDocument", doc_name=metadata.name, doc_uuid=doc_uuid),
+        creationInfo=spdx_ci,
+        rootElement=[sbom.spdxId],
+    )
+    spdx_doc.profileConformance = [
+        spdx3.ProfileIdentifierType.core,
+        spdx3.ProfileIdentifierType.software,
+    ]
+    if exporter.find_license("dummy") is not None or any(
+        isinstance(obj, spdx3.simplelicensing_SimpleLicensingText)
+        for obj in exporter.object_set.objects
+    ):
+        spdx_doc.profileConformance.append(spdx3.ProfileIdentifierType.simpleLicensing)
 
     exporter.add_document(spdx_doc)
     exporter.add_sbom(sbom)

--- a/src/pitloom/assemble/spdx3/document.py
+++ b/src/pitloom/assemble/spdx3/document.py
@@ -368,7 +368,7 @@ def build_model(
         model: Extracted AI model metadata.
         creation_metadata: Creator and timestamp metadata for the SBOM document.
         entity_spdx_id: When given, overrides the ``ai_AIPackage``'s minted
-            ``spdxId`` with this one -- used by ``pitloom -m ... --registry``
+            ``spdxId`` with this one -- used by ``pitloom model ... --registry``
             so the resulting element shares its id with any
             ``pitloom.loom`` fragment that registered the same entity name
             (see :meth:`pitloom.ids.IdRegistry.lookup_entity`), letting the

--- a/src/pitloom/assemble/spdx3/fragments.py
+++ b/src/pitloom/assemble/spdx3/fragments.py
@@ -72,20 +72,23 @@ _KEYED_DICT_PROPS = frozenset({"ai_hyperparameter", "ai_metric"})
 
 
 # ---------------------------------------------------------------------------
-# spdx-python-model internals -- single access point
+# spdx-python-model property enumeration -- single access point
 # ---------------------------------------------------------------------------
 #
-# `SHACLObject._OBJ_PY_PROPS` (a dict of Python-attribute-name -> ClassProp
-# descriptor) is not part of spdx-python-model's public API.  Every place in
-# this module that needs to walk "all declared properties of an arbitrary
-# element generically" (reference remapping, property merging, structural
-# equality) goes through this one helper, so an upstream rename or
-# restructuring surfaces as a single, loud failure here rather than silent
-# breakage scattered through the merge logic.
+# Every place in this module that needs to walk "all declared properties of
+# an arbitrary element generically" (reference remapping, property merging,
+# structural equality) goes through this one helper, so an upstream change
+# to ``property_keys()``'s shape surfaces as a single, loud failure here
+# rather than silent breakage scattered through the merge logic.
 def _class_properties(obj: spdx3.SHACLObject) -> Iterable[str]:
-    """Return the declared Python property names on *obj*'s class."""
-    # The spdx-python-model public API for enumerating properties.
-    return [k[0] for k in obj.property_keys()]
+    """Return the declared Python property names on *obj*'s class.
+
+    ``property_keys()`` yields ``(python_name, iri, compact_name)`` triples;
+    ``python_name`` is typed ``Optional[str]`` upstream for properties with
+    no Python-attribute alias, though every property pitloom's model
+    actually declares has one -- filter defensively rather than assume it.
+    """
+    return [k[0] for k in obj.property_keys() if k[0] is not None]
 
 
 def _stable_key(obj: spdx3.SHACLObject) -> tuple[Any, ...]:

--- a/src/pitloom/assemble/spdx3/fragments.py
+++ b/src/pitloom/assemble/spdx3/fragments.py
@@ -84,13 +84,11 @@ _KEYED_DICT_PROPS = frozenset({"ai_hyperparameter", "ai_metric"})
 # breakage scattered through the merge logic.
 def _class_properties(obj: spdx3.SHACLObject) -> Iterable[str]:
     """Return the declared Python property names on *obj*'s class."""
-    # _OBJ_PY_PROPS is not part of the public stub -- see module note above.
-    # pylint: disable=protected-access
-    keys: Iterable[str] = type(obj)._OBJ_PY_PROPS.keys()  # type: ignore[attr-defined]
-    return keys
+    # The spdx-python-model public API for enumerating properties.
+    return [k[0] for k in obj.property_keys()]
 
 
-def _stable_key(obj: spdx3.SHACLObject) -> tuple[str, str]:
+def _stable_key(obj: spdx3.SHACLObject) -> tuple[Any, ...]:
     """Deterministic sort key for iterating a ``SHACLObjectSet``.
 
     ``SHACLObjectSet.objects`` is a plain :class:`set`, so its iteration
@@ -101,8 +99,8 @@ def _stable_key(obj: spdx3.SHACLObject) -> tuple[str, str]:
     ``spdxId`` for Elements and the blank-node label otherwise.
     """
     # pylint: disable=protected-access
-    obj_id: str = obj._id or ""  # type: ignore[attr-defined]
-    return (type(obj).__name__, obj_id)
+    obj_id: str = getattr(obj, "_id", None) or ""
+    return (type(obj).__name__, obj_id, _signature(obj))
 
 
 def _as_element(obj: spdx3.SHACLObject) -> spdx3.Element:
@@ -138,11 +136,15 @@ def _sha256_hash(obj: spdx3.Element) -> str | None:
 def _normalize_value(value: Any) -> Any:
     """Return a comparable, hashable-shaped representation of a property
     value for structural-equality comparison (see :func:`_signature`)."""
+    if value is None:
+        return (0, None)
     if isinstance(value, spdx3.SHACLObject):
-        return _signature(value)
+        return (1, _signature(value))
     if isinstance(value, spdx3.ListProxy):
-        return tuple(_normalize_value(v) for v in value)
-    return value
+        return (2, tuple(_normalize_value(v) for v in value))
+    if isinstance(value, (list, tuple)):
+        return (2, tuple(_normalize_value(v) for v in value))
+    return (3, type(value).__name__, value)
 
 
 def _signature(obj: spdx3.SHACLObject) -> tuple[Any, ...]:
@@ -470,7 +472,7 @@ def _endpoint_id(value: str | spdx3.Element | None) -> str | None:
     -- e.g. an endpoint outside the merged fragments)."""
     if value is None or isinstance(value, str):
         return value
-    return value.spdxId
+    return str(value.spdxId) if value.spdxId else None
 
 
 def _dedupe_relationships(exporter: Spdx3JsonExporter) -> None:
@@ -491,7 +493,7 @@ def _dedupe_relationships(exporter: Spdx3JsonExporter) -> None:
             seen.add(key)
 
     for dup in duplicates:
-        exporter.object_set.remove(dup)
+        exporter.object_set.objects.remove(dup)
 
 
 def _find_main_document(object_set: spdx3.SHACLObjectSet) -> spdx3.SpdxDocument | None:

--- a/src/pitloom/core/document.py
+++ b/src/pitloom/core/document.py
@@ -33,7 +33,8 @@ class DocumentModel:
         project: Python project metadata from ``pyproject.toml``.
         creation_metadata: Creator and timestamp metadata for the SBOM document.
         ai_models: AI model metadata, one entry per model file processed.
-        phantom_dependencies: Bundled binary dependencies discovered inside distribution archives.
+        phantom_dependencies: Bundled binary dependencies discovered inside
+            distribution archives.
     """
 
     project: ProjectMetadata

--- a/src/pitloom/core/document.py
+++ b/src/pitloom/core/document.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass, field
 
 from pitloom.core.ai_metadata import AiModelMetadata
 from pitloom.core.creation import CreationMetadata
-from pitloom.core.project import ProjectMetadata
+from pitloom.core.project import PhantomDependency, ProjectMetadata
 
 
 @dataclass
@@ -33,8 +33,10 @@ class DocumentModel:
         project: Python project metadata from ``pyproject.toml``.
         creation_metadata: Creator and timestamp metadata for the SBOM document.
         ai_models: AI model metadata, one entry per model file processed.
+        phantom_dependencies: Bundled binary dependencies discovered inside distribution archives.
     """
 
     project: ProjectMetadata
     creation_metadata: CreationMetadata = field(default_factory=CreationMetadata)
     ai_models: list[AiModelMetadata] = field(default_factory=list)
+    phantom_dependencies: list[PhantomDependency] = field(default_factory=list)

--- a/src/pitloom/core/project.py
+++ b/src/pitloom/core/project.py
@@ -25,6 +25,26 @@ class ProjectFile:
 
 
 @dataclass
+class PhantomDependency:
+    """A bundled binary dependency not tracked by normal package metadata.
+
+    Examples include bundled shared libraries (.so, .dll, .dylib) inside wheels
+    and pre-compiled extension modules (.pyd) that link to external C/C++ libraries.
+
+    Attributes:
+        name: Name of the binary dependency (e.g., 'libz', 'openssl').
+        file_path: Canonical path to the binary inside the distribution/wheel.
+        digest_sha256: Hex-encoded SHA-256 digest of the binary file contents.
+        version: Inferred version of the binary, if any.
+    """
+
+    name: str
+    file_path: str
+    digest_sha256: str | None = None
+    version: str | None = None
+
+
+@dataclass
 class ProjectMetadata:
     """Format-neutral representation of project metadata with provenance tracking.
 

--- a/src/pitloom/export/spdx3_json.py
+++ b/src/pitloom/export/spdx3_json.py
@@ -44,7 +44,7 @@ def require_spdx_id(element: spdx3.Element) -> str:
     """
     if element.spdxId is None:
         raise ValueError(f"{element!r} has no spdxId assigned")
-    return element.spdxId
+    return str(element.spdxId)
 
 
 def _graph_sort_key(element: dict[str, Any]) -> tuple[int, str, str]:

--- a/src/pitloom/extract/binary.py
+++ b/src/pitloom/extract/binary.py
@@ -104,22 +104,21 @@ def extract_phantom_dependencies(wheel_path: Path | str) -> list[PhantomDependen
 
                 digest = hasher.hexdigest()
 
-                # Derive a plausible name and version from the filename
-                # e.g., libz-1.2.11.so -> name: libz, version: 1.2.11
-                # This is just a simple heuristic.
+                # Derive a plausible name from the filename, e.g.
+                # libz-1.2.11.so -> name: libz. pathlib.Path.stem only
+                # strips the last extension, so a multi-dot name like
+                # libz.so.1.2 won't fully reduce to "libz" -- acceptable
+                # for a heuristic.
                 name = Path(info.filename).stem
-
-                # Remove common suffixes like .so, .dylib, .dll that might still be in stem
-                # if there are multiple dots (e.g. libz.so.1.2)
-                # Actually, pathlib.Path.stem only removes the last extension.
-                # It's better to just use the stem directly.
 
                 phantom_deps.append(
                     PhantomDependency(
                         name=name,
                         file_path=info.filename,
                         digest_sha256=digest,
-                        version=None, # Extracting reliable version from filename is tricky; leave None for now
+                        # Reliably parsing a version out of the filename is
+                        # unreliable across ecosystems; leave unset for now.
+                        version=None,
                     )
                 )
 

--- a/src/pitloom/extract/binary.py
+++ b/src/pitloom/extract/binary.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Heuristics for extracting phantom dependencies from Python wheels."""
+
+from __future__ import annotations
+
+import hashlib
+import zipfile
+from pathlib import Path
+
+from pitloom.core.project import PhantomDependency, ProjectFile
+
+
+def _is_phantom_binary(filename: str) -> bool:
+    """Determine if a filename looks like a bundled third-party binary dependency.
+
+    A binary is considered a "phantom dependency" if it is bundled inside the wheel
+    (e.g., via auditwheel, delocate, delvewheel) rather than being a project-owned
+    extension module (e.g. .cpython-310-x86_64-linux-gnu.so or .pyd).
+    """
+    path = Path(filename)
+    name = path.name
+
+    # Pre-compiled binaries usually have these extensions
+    if not name.endswith((".so", ".dylib", ".dll")):
+        # On Windows, pyd files are extension modules. We exclude them here
+        # unless we specifically want to track them.
+        # Usually, bundled dependencies are .dll.
+        return False
+
+    # Exclude typical Python extension modules (e.g. built by setuptools/hatch)
+    if ".cpython-" in name or ".abi3-" in name:
+        return False
+
+    # On Windows, compiled extensions end with .pyd
+    if name.endswith(".pyd"):
+        return False
+
+    # Check if it is in a known bundled dependency directory
+    # - auditwheel puts them in <package>.libs/
+    # - delocate puts them in <package>/.dylibs/
+    # - delvewheel puts them in <package>.libs/
+    parts = path.parts
+    for part in parts[:-1]:
+        if part.endswith(".libs") or part == ".dylibs":
+            return True
+
+    # As a fallback, any shared library that isn't an extension module
+    # is a strong candidate for being a phantom dependency.
+    return True
+
+
+def find_phantom_dependencies(files: list[ProjectFile]) -> list[PhantomDependency]:
+    """Scan a list of project files (e.g. from Hatchling or a parsed wheel)
+    to find phantom binary dependencies.
+
+    Args:
+        files: List of ProjectFile objects.
+
+    Returns:
+        List of PhantomDependency objects.
+    """
+    phantom_deps: list[PhantomDependency] = []
+
+    for file in files:
+        if _is_phantom_binary(file.distribution_path):
+            name = Path(file.distribution_path).stem
+            phantom_deps.append(
+                PhantomDependency(
+                    name=name,
+                    file_path=file.distribution_path,
+                    digest_sha256=file.digest_sha256,
+                    version=None,
+                )
+            )
+
+    return phantom_deps
+
+
+def extract_phantom_dependencies(wheel_path: Path | str) -> list[PhantomDependency]:
+    """Extract a list of bundled phantom dependencies from a wheel file.
+
+    Args:
+        wheel_path: Path to the .whl file to analyze.
+
+    Returns:
+        List of PhantomDependency objects.
+    """
+    phantom_deps: list[PhantomDependency] = []
+
+    with zipfile.ZipFile(wheel_path, "r") as zf:
+        for info in zf.infolist():
+            if info.is_dir():
+                continue
+
+            if _is_phantom_binary(info.filename):
+                # Calculate SHA-256 digest
+                hasher = hashlib.sha256()
+                with zf.open(info) as f:
+                    while chunk := f.read(8192):
+                        hasher.update(chunk)
+
+                digest = hasher.hexdigest()
+
+                # Derive a plausible name and version from the filename
+                # e.g., libz-1.2.11.so -> name: libz, version: 1.2.11
+                # This is just a simple heuristic.
+                name = Path(info.filename).stem
+
+                # Remove common suffixes like .so, .dylib, .dll that might still be in stem
+                # if there are multiple dots (e.g. libz.so.1.2)
+                # Actually, pathlib.Path.stem only removes the last extension.
+                # It's better to just use the stem directly.
+
+                phantom_deps.append(
+                    PhantomDependency(
+                        name=name,
+                        file_path=info.filename,
+                        digest_sha256=digest,
+                        version=None, # Extracting reliable version from filename is tricky; leave None for now
+                    )
+                )
+
+    return phantom_deps

--- a/src/pitloom/extract/binary.py
+++ b/src/pitloom/extract/binary.py
@@ -23,11 +23,10 @@ def _is_phantom_binary(filename: str) -> bool:
     path = Path(filename)
     name = path.name
 
-    # Pre-compiled binaries usually have these extensions
+    # Pre-compiled binaries usually have these extensions.
     if not name.endswith((".so", ".dylib", ".dll")):
-        # On Windows, pyd files are extension modules. We exclude them here
-        # unless we specifically want to track them.
-        # Usually, bundled dependencies are .dll.
+        # .pyd (Windows extension modules) is deliberately excluded here;
+        # bundled third-party binaries on Windows are .dll.
         return False
 
     # Exclude typical Python extension modules (e.g. built by setuptools/hatch)
@@ -116,8 +115,8 @@ def extract_phantom_dependencies(wheel_path: Path | str) -> list[PhantomDependen
                         name=name,
                         file_path=info.filename,
                         digest_sha256=digest,
-                        # Reliably parsing a version out of the filename is
-                        # unreliable across ecosystems; leave unset for now.
+                        # A version is not reliably parseable from the
+                        # filename across ecosystems, so it is left unset.
                         version=None,
                     )
                 )

--- a/src/pitloom/extract/env.py
+++ b/src/pitloom/extract/env.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Extractor for deployed environments using pipdeptree."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+from typing import Any
+from pitloom.core.project import ProjectMetadata
+
+
+def read_environment() -> tuple[ProjectMetadata, list[dict[str, Any]]]:
+    """Extract metadata for the deployed environment using pipdeptree.
+
+    Returns:
+        A tuple of (ProjectMetadata, list of package nodes from pipdeptree).
+    """
+    try:
+        result = subprocess.run(
+            ["pipdeptree", "--json-tree", "--all"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        tree = json.loads(result.stdout)
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        raise RuntimeError(f"Failed to run pipdeptree: {e}") from e
+
+    # Create a synthetic root package representing the environment
+    metadata = ProjectMetadata(name="deployed-environment", version="0.0.0")
+    metadata.description = "Deployed Python environment"
+
+    provenance = {
+        "name": "Source: pipdeptree",
+        "version": "Source: pipdeptree",
+        "dependencies": "Source: pipdeptree",
+    }
+    metadata.provenance = provenance
+
+    # We will let the specific assembler handle the tree structure.
+    return metadata, tree

--- a/src/pitloom/extract/env.py
+++ b/src/pitloom/extract/env.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 import json
 import subprocess
-
 from typing import Any
+
 from pitloom.core.project import ProjectMetadata
 
 

--- a/src/pitloom/extract/env.py
+++ b/src/pitloom/extract/env.py
@@ -34,12 +34,14 @@ def read_environment() -> tuple[ProjectMetadata, list[dict[str, Any]]]:
     metadata = ProjectMetadata(name="deployed-environment", version="0.0.0")
     metadata.description = "Deployed Python environment"
 
+    # name/version are Pitloom's own placeholder for this synthetic root,
+    # not values pipdeptree reported -- only the dependency tree is.
     provenance = {
-        "name": "Source: pipdeptree",
-        "version": "Source: pipdeptree",
+        "name": "Source: Pitloom generator | Method: synthetic environment root",
+        "version": "Source: Pitloom generator | Method: synthetic environment root",
         "dependencies": "Source: pipdeptree",
     }
     metadata.provenance = provenance
 
-    # We will let the specific assembler handle the tree structure.
+    # The assembler consumes the raw pipdeptree tree structure directly.
     return metadata, tree

--- a/src/pitloom/extract/wheel.py
+++ b/src/pitloom/extract/wheel.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Extractor for Python wheels (Analyzed SBOM)."""
+
+from __future__ import annotations
+
+import email
+import hashlib
+import zipfile
+from pathlib import Path
+
+from pitloom.core.project import ProjectFile, ProjectMetadata
+
+
+def read_wheel(wheel_path: Path | str) -> tuple[ProjectMetadata, list[ProjectFile]]:
+    """Extract project metadata and file records from a built wheel.
+
+    Args:
+        wheel_path: Path to the .whl file.
+
+    Returns:
+        A tuple of (ProjectMetadata, list of ProjectFile).
+        The ProjectMetadata contains core fields extracted from METADATA.
+    """
+    wheel_path_obj = Path(wheel_path)
+    metadata = ProjectMetadata(name="unknown")
+    project_files: list[ProjectFile] = []
+
+    provenance = {
+        "name": f"Source: wheel METADATA | File: {wheel_path_obj.name}",
+        "version": f"Source: wheel METADATA | File: {wheel_path_obj.name}",
+        "dependencies": f"Source: wheel METADATA | File: {wheel_path_obj.name}",
+        "license": f"Source: wheel METADATA | File: {wheel_path_obj.name}",
+    }
+    metadata.provenance = provenance
+
+    with zipfile.ZipFile(wheel_path_obj, "r") as zf:
+        metadata_content = None
+
+        # 1. Collect files and calculate hashes
+        for info in zf.infolist():
+            if info.is_dir():
+                continue
+
+            # Keep an eye out for the METADATA file
+            if info.filename.endswith(".dist-info/METADATA"):
+                metadata_content = zf.read(info).decode("utf-8", errors="replace")
+
+            hasher = hashlib.sha256()
+            with zf.open(info) as f:
+                while chunk := f.read(8192):
+                    hasher.update(chunk)
+
+            project_files.append(
+                ProjectFile(
+                    physical_path=info.filename, # Using archive-relative path for physical path
+                    distribution_path=info.filename,
+                    digest_sha256=hasher.hexdigest(),
+                )
+            )
+
+        # 2. Parse the METADATA file if found
+        if metadata_content:
+            msg = email.message_from_string(metadata_content)
+
+            if msg.get("Name"):
+                metadata.name = msg["Name"]
+            if msg.get("Version"):
+                metadata.version = msg["Version"]
+            if msg.get("Summary"):
+                metadata.description = msg["Summary"]
+            if msg.get("Requires-Python"):
+                metadata.requires_python = msg["Requires-Python"]
+
+            # License-Expression or License
+            license_expr = msg.get("License-Expression")
+            if license_expr:
+                metadata.license_name = license_expr
+            elif msg.get("License"):
+                metadata.license_name = msg["License"]
+
+            # Dependencies
+            reqs = msg.get_all("Requires-Dist")
+            if reqs:
+                # We simply keep the raw PEP 508 strings
+                metadata.dependencies = reqs
+
+            # Authors/Emails
+            authors = []
+            author_name = msg.get("Author")
+            author_email = msg.get("Author-email")
+            if author_name or author_email:
+                author_dict = {}
+                if author_name:
+                    author_dict["name"] = author_name
+                if author_email:
+                    author_dict["email"] = author_email
+                authors.append(author_dict)
+            metadata.authors = authors
+
+            # URLs
+            urls = {}
+            if msg.get("Home-page"):
+                urls["Homepage"] = msg["Home-page"]
+            if msg.get("Download-URL"):
+                urls["Download"] = msg["Download-URL"]
+            project_url_entries = msg.get_all("Project-URL") or []
+            for entry in project_url_entries:
+                if "," in entry:
+                    label, url = entry.split(",", 1)
+                    urls[label.strip()] = url.strip()
+            metadata.urls = urls
+
+    metadata.files = project_files
+    return metadata, project_files

--- a/src/pitloom/extract/wheel.py
+++ b/src/pitloom/extract/wheel.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from pitloom.core.project import ProjectFile, ProjectMetadata
 
 
+# pylint: disable=too-many-locals
 def read_wheel(wheel_path: Path | str) -> tuple[ProjectMetadata, list[ProjectFile]]:
     """Extract project metadata and file records from a built wheel.
 
@@ -55,7 +56,9 @@ def read_wheel(wheel_path: Path | str) -> tuple[ProjectMetadata, list[ProjectFil
 
             project_files.append(
                 ProjectFile(
-                    physical_path=info.filename, # Using archive-relative path for physical path
+                    # No filesystem path outside the archive; use the
+                    # archive-relative path for both fields.
+                    physical_path=info.filename,
                     distribution_path=info.filename,
                     digest_sha256=hasher.hexdigest(),
                 )

--- a/src/pitloom/extract/wheel.py
+++ b/src/pitloom/extract/wheel.py
@@ -28,14 +28,8 @@ def read_wheel(wheel_path: Path | str) -> tuple[ProjectMetadata, list[ProjectFil
     wheel_path_obj = Path(wheel_path)
     metadata = ProjectMetadata(name="unknown")
     project_files: list[ProjectFile] = []
-
-    provenance = {
-        "name": f"Source: wheel METADATA | File: {wheel_path_obj.name}",
-        "version": f"Source: wheel METADATA | File: {wheel_path_obj.name}",
-        "dependencies": f"Source: wheel METADATA | File: {wheel_path_obj.name}",
-        "license": f"Source: wheel METADATA | File: {wheel_path_obj.name}",
-    }
-    metadata.provenance = provenance
+    provenance: dict[str, str] = {}
+    source = f"Source: wheel METADATA | File: {wheel_path_obj.name}"
 
     with zipfile.ZipFile(wheel_path_obj, "r") as zf:
         metadata_content = None
@@ -45,7 +39,7 @@ def read_wheel(wheel_path: Path | str) -> tuple[ProjectMetadata, list[ProjectFil
             if info.is_dir():
                 continue
 
-            # Keep an eye out for the METADATA file
+            # Identify the METADATA file among the wheel's contents.
             if info.filename.endswith(".dist-info/METADATA"):
                 metadata_content = zf.read(info).decode("utf-8", errors="replace")
 
@@ -70,8 +64,10 @@ def read_wheel(wheel_path: Path | str) -> tuple[ProjectMetadata, list[ProjectFil
 
             if msg.get("Name"):
                 metadata.name = msg["Name"]
+                provenance["name"] = source
             if msg.get("Version"):
                 metadata.version = msg["Version"]
+                provenance["version"] = source
             if msg.get("Summary"):
                 metadata.description = msg["Summary"]
             if msg.get("Requires-Python"):
@@ -81,14 +77,17 @@ def read_wheel(wheel_path: Path | str) -> tuple[ProjectMetadata, list[ProjectFil
             license_expr = msg.get("License-Expression")
             if license_expr:
                 metadata.license_name = license_expr
+                provenance["license"] = source
             elif msg.get("License"):
                 metadata.license_name = msg["License"]
+                provenance["license"] = source
 
             # Dependencies
             reqs = msg.get_all("Requires-Dist")
             if reqs:
-                # We simply keep the raw PEP 508 strings
+                # Kept as raw PEP 508 strings, unparsed.
                 metadata.dependencies = reqs
+                provenance["dependencies"] = source
 
             # Authors/Emails
             authors = []
@@ -116,5 +115,6 @@ def read_wheel(wheel_path: Path | str) -> tuple[ProjectMetadata, list[ProjectFil
                     urls[label.strip()] = url.strip()
             metadata.urls = urls
 
+    metadata.provenance = provenance
     metadata.files = project_files
     return metadata, project_files

--- a/src/pitloom/ids.py
+++ b/src/pitloom/ids.py
@@ -78,10 +78,19 @@ _REGISTRY_VERSION = 1
 
 @dataclass
 class FileEntry:
-    """A single registered file: its stable ``spdxId`` and content hash."""
+    """A single registered file: its stable ``spdxId`` and content hash.
+
+    ``sha256`` is normalised to lower-case in ``__post_init__``, so a
+    registry entry loaded from a hand-edited ``loom-ids.json`` or imported
+    from a foreign SBOM (either may use upper-case hex) still compares
+    equal to the lower-case hex :func:`_sha256_file` always produces.
+    """
 
     spdx_id: str
     sha256: str
+
+    def __post_init__(self) -> None:
+        self.sha256 = self.sha256.lower()
 
 
 @dataclass

--- a/src/pitloom/ids.py
+++ b/src/pitloom/ids.py
@@ -331,7 +331,7 @@ class IdRegistry:
         ``entities`` entry keyed by the file's stem -- e.g.
         ``models/sentimentdemo.bin`` registers an ``ai_AIPackage`` entity
         named ``"sentimentdemo"`` -- so a later ``loom.set_model()`` or
-        ``loom -m ... --registry`` invocation can look it up by name and
+        ``loom model ... --registry`` invocation can look it up by name and
         share its ``spdxId`` rather than minting an unrelated one.
 
         Args:

--- a/src/pitloom/ids.py
+++ b/src/pitloom/ids.py
@@ -363,19 +363,24 @@ class IdRegistry:
     def import_sbom(self, sbom_path: Path) -> None:
         """Harvest ids from an existing SPDX 3 JSON-LD SBOM into this registry.
 
-        ``software_File`` and ``dataset_DatasetPackage`` elements with a
-        ``name`` and a SHA-256 ``verifiedUsing`` hash populate ``files``
-        (keyed by ``name`` -- for pitloom-generated SBOMs this is a
-        project-root-relative path).  ``ai_AIPackage`` elements populate
-        ``entities`` (keyed by ``name``).  When this registry is still empty
-        and the SBOM has a main ``SpdxDocument``, its namespace is adopted
-        as this registry's namespace so subsequently minted ids read as part
-        of the same document family as the imported ones.
+        Every element in the graph with both a ``name`` and a ``spdxId`` is
+        importable -- generically, not via a hardcoded type allowlist,
+        since any element (``software_Package``, ``ai_AIPackage``,
+        ``dataset_DatasetPackage``, ``software_File``, or a type pitloom
+        does not otherwise model) can carry a stable id worth reusing. An
+        element that also carries a SHA-256 ``verifiedUsing`` hash
+        populates ``files`` (keyed by ``name`` -- for pitloom-generated
+        SBOMs this is a project-root-relative path); everything else
+        populates ``entities`` (keyed by ``name``, typed by the element's
+        actual SPDX 3 compact type, e.g. ``"software_Package"``).  When
+        this registry is still empty and the SBOM has a main
+        ``SpdxDocument``, its namespace is adopted as this registry's
+        namespace so subsequently minted ids read as part of the same
+        document family as the imported ones.
 
-        Elements missing the fields needed to key or verify them (no
-        ``name``, or no SHA-256 hash for a file/dataset) are skipped with a
-        debug log rather than an error -- a foreign or hand-written SBOM may
-        have gaps.
+        Elements missing the fields needed to key them (no ``name`` or no
+        ``spdxId``) are skipped with a debug log rather than an error -- a
+        foreign or hand-written SBOM may have gaps.
         """
         object_set = spdx3.SHACLObjectSet()
         with open(sbom_path, "rb") as f:
@@ -431,21 +436,25 @@ class IdRegistry:
 
 def _import_sbom_element(registry: IdRegistry, obj: Any) -> None:
     """Harvest a single deserialized SBOM element into *registry*, when it
-    is one of the types :meth:`IdRegistry.import_sbom` knows how to key
-    (``software_File``, ``dataset_DatasetPackage``, ``ai_AIPackage``)."""
+    carries both a ``name`` and a ``spdxId`` -- any SPDX 3 Element
+    qualifies, not just a fixed set of types pitloom happens to name
+    explicitly elsewhere (see :meth:`IdRegistry.import_sbom`)."""
     name = getattr(obj, "name", None)
     spdx_id = getattr(obj, "spdxId", None)
     if not name or not spdx_id:
         return
 
-    if isinstance(obj, (spdx3.software_File, spdx3.dataset_DatasetPackage)):
-        sha256 = _sha256_from_verified_using(obj)
-        if sha256 is None:
-            log.debug("Import: skipping %r (no SHA-256 verifiedUsing hash)", name)
-            return
+    sha256 = _sha256_from_verified_using(obj)
+    if sha256 is not None:
         registry.files[name] = FileEntry(spdx_id=spdx_id, sha256=sha256)
-    elif isinstance(obj, spdx3.ai_AIPackage):
-        registry.entities[name] = EntityEntry(type="ai_AIPackage", spdx_id=spdx_id)
+        return
+
+    get_compact_type = getattr(obj, "get_compact_type", None)
+    compact_type = get_compact_type() if get_compact_type is not None else None
+    if not compact_type:
+        log.debug("Import: skipping %r (no SPDX 3 compact type)", name)
+        return
+    registry.entities[name] = EntityEntry(type=compact_type, spdx_id=spdx_id)
 
 
 def _iter_files(paths: list[Path], project_root: Path) -> Iterator[Path]:

--- a/src/pitloom/plugins/hatch.py
+++ b/src/pitloom/plugins/hatch.py
@@ -24,6 +24,7 @@ from pitloom.core.config import PitloomConfig, read_pitloom_config
 from pitloom.core.creation import CreationMetadata
 from pitloom.core.document import DocumentModel
 from pitloom.core.models import get_wheel_files
+from pitloom.extract.binary import find_phantom_dependencies
 from pitloom.extract.hatchling import metadata_from_hatchling
 from pitloom.extract.scanner import scan_project_for_ai_models
 from pitloom.ids import resolve_registry
@@ -94,10 +95,12 @@ def _build_document_model(
     merkle_root, project_files = get_wheel_files(project_dir)
     metadata.files = project_files
     ai_models = scan_project_for_ai_models(project_dir, project_files)
+    phantom_deps = find_phantom_dependencies(project_files)
     document = DocumentModel(
         project=metadata,
         creation_metadata=creation_metadata,
         ai_models=ai_models,
+        phantom_dependencies=phantom_deps,
     )
     return document, merkle_root
 

--- a/tests/test_extract_binary.py
+++ b/tests/test_extract_binary.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for pitloom.extract.binary phantom-dependency detection."""
+
+import hashlib
+import zipfile
+from pathlib import Path
+
+from pitloom.core.project import ProjectFile
+from pitloom.extract.binary import (
+    _is_phantom_binary,
+    extract_phantom_dependencies,
+    find_phantom_dependencies,
+)
+
+
+def test_libs_directory_so_is_detected() -> None:
+    """A .so bundled under a <package>.libs/ directory (auditwheel
+    convention) is a phantom dependency."""
+    assert _is_phantom_binary("mypkg.libs/libfoo-abc123.so") is True
+
+
+def test_dylibs_directory_dylib_is_detected() -> None:
+    """A .dylib bundled under a .dylibs/ directory (delocate convention) is
+    a phantom dependency."""
+    assert _is_phantom_binary("mypkg/.dylibs/libbar.dylib") is True
+
+
+def test_cpython_extension_module_is_not_detected() -> None:
+    """A project-owned extension module (.cpython-*.so) is excluded."""
+    assert _is_phantom_binary("mypkg/_native.cpython-310-x86_64-linux-gnu.so") is False
+
+
+def test_pyd_file_is_not_detected() -> None:
+    """A Windows extension module (.pyd) is excluded."""
+    assert _is_phantom_binary("mypkg/_native.pyd") is False
+
+
+def test_bare_shared_library_is_detected_as_fallback() -> None:
+    """A shared library that is neither in a known bundled-dependency
+    directory nor an extension module is still flagged, as the documented
+    fallback heuristic."""
+    assert _is_phantom_binary("mypkg/libssl.so") is True
+    assert _is_phantom_binary("mypkg/foo.dll") is True
+    assert _is_phantom_binary("mypkg/foo.dylib") is True
+
+
+def test_non_binary_file_is_not_detected() -> None:
+    """A regular source file is never a phantom dependency."""
+    assert _is_phantom_binary("mypkg/__init__.py") is False
+
+
+def _make_wheel_with_bundled_binary(tmp_path: Path) -> Path:
+    """Build a minimal .whl containing one auditwheel-style bundled .so."""
+    wheel_path = tmp_path / "pkg-1.0.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel_path, "w") as zf:
+        zf.writestr("pkg/__init__.py", "")
+        zf.writestr("pkg.libs/libfoo-abc123.so", b"\x7fELF fake binary content")
+    return wheel_path
+
+
+def test_find_phantom_dependencies_from_project_files() -> None:
+    """find_phantom_dependencies() picks out only the bundled binary among a
+    mix of ProjectFile entries."""
+    files = [
+        ProjectFile(
+            physical_path="pkg/__init__.py",
+            distribution_path="pkg/__init__.py",
+            digest_sha256="a" * 64,
+        ),
+        ProjectFile(
+            physical_path="pkg.libs/libfoo-abc123.so",
+            distribution_path="pkg.libs/libfoo-abc123.so",
+            digest_sha256="b" * 64,
+        ),
+    ]
+
+    phantom_deps = find_phantom_dependencies(files)
+
+    assert len(phantom_deps) == 1
+    assert phantom_deps[0].name == "libfoo-abc123"
+    assert phantom_deps[0].file_path == "pkg.libs/libfoo-abc123.so"
+    assert phantom_deps[0].digest_sha256 == "b" * 64
+
+
+def test_extract_phantom_dependencies_end_to_end(tmp_path: Path) -> None:
+    """extract_phantom_dependencies() finds a bundled .libs/*.so inside a
+    real wheel zip and computes its SHA-256 digest."""
+    wheel_path = _make_wheel_with_bundled_binary(tmp_path)
+
+    phantom_deps = extract_phantom_dependencies(wheel_path)
+
+    assert len(phantom_deps) == 1
+    dep = phantom_deps[0]
+    assert dep.name == "libfoo-abc123"
+    assert dep.file_path == "pkg.libs/libfoo-abc123.so"
+    assert dep.version is None
+
+    expected_digest = hashlib.sha256(b"\x7fELF fake binary content").hexdigest()
+    assert dep.digest_sha256 == expected_digest

--- a/tests/test_extract_env.py
+++ b/tests/test_extract_env.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for pitloom.extract.env.read_environment()."""
+
+import json
+import subprocess
+from unittest.mock import patch
+
+from pitloom.extract.env import read_environment
+
+
+def _fake_pipdeptree_result(tree: list) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=["pipdeptree", "--json-tree", "--all"],
+        returncode=0,
+        stdout=json.dumps(tree),
+        stderr="",
+    )
+
+
+def test_read_environment_provenance_distinguishes_synthetic_from_tool() -> None:
+    """name/version are Pitloom's own synthetic root, not something
+    pipdeptree reported -- only dependencies is genuinely sourced from it."""
+    tree = [{"package": {"key": "requests", "package_name": "requests"}}]
+    with patch("subprocess.run", return_value=_fake_pipdeptree_result(tree)):
+        metadata, returned_tree = read_environment()
+
+    assert metadata.name == "deployed-environment"
+    assert returned_tree == tree
+    assert "pipdeptree" not in metadata.provenance["name"]
+    assert "Pitloom generator" in metadata.provenance["name"]
+    assert "pipdeptree" not in metadata.provenance["version"]
+    assert metadata.provenance["dependencies"] == "Source: pipdeptree"
+
+
+def test_read_environment_pipdeptree_missing_raises() -> None:
+    """A missing pipdeptree executable surfaces as a clear RuntimeError."""
+    with patch("subprocess.run", side_effect=FileNotFoundError("pipdeptree")):
+        try:
+            read_environment()
+        except RuntimeError as exc:
+            assert "pipdeptree" in str(exc)
+        else:
+            raise AssertionError("expected RuntimeError")

--- a/tests/test_extract_env.py
+++ b/tests/test_extract_env.py
@@ -6,12 +6,15 @@
 
 import json
 import subprocess
+from collections.abc import Sequence
 from unittest.mock import patch
 
 from pitloom.extract.env import read_environment
 
 
-def _fake_pipdeptree_result(tree: list) -> subprocess.CompletedProcess:
+def _fake_pipdeptree_result(
+    tree: Sequence[object],
+) -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(
         args=["pipdeptree", "--json-tree", "--all"],
         returncode=0,

--- a/tests/test_extract_wheel.py
+++ b/tests/test_extract_wheel.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for pitloom.extract.wheel.read_wheel()."""
+
+import zipfile
+from pathlib import Path
+
+from pitloom.extract.wheel import read_wheel
+
+
+def _make_wheel(tmp_path: Path, name: str, metadata_body: str | None) -> Path:
+    """Build a minimal .whl containing just a METADATA file (or none)."""
+    wheel_path = tmp_path / f"{name}-1.0.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel_path, "w") as zf:
+        if metadata_body is not None:
+            zf.writestr(f"{name}-1.0.0.dist-info/METADATA", metadata_body)
+        zf.writestr(f"{name}/__init__.py", "")
+    return wheel_path
+
+
+def test_read_wheel_provenance_only_for_present_fields(tmp_path: Path) -> None:
+    """Provenance is recorded only for fields METADATA actually supplies --
+    Summary/Requires-Python/License/Requires-Dist are absent here, so only
+    name/version get a provenance entry."""
+    metadata_body = "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0.0\n"
+    wheel_path = _make_wheel(tmp_path, "pkg", metadata_body)
+
+    metadata, _ = read_wheel(wheel_path)
+
+    assert metadata.name == "pkg"
+    assert metadata.version == "1.0.0"
+    assert metadata.license_name is None
+    assert metadata.dependencies == []
+    assert set(metadata.provenance) == {"name", "version"}
+    assert "wheel METADATA" in metadata.provenance["name"]
+
+
+def test_read_wheel_full_provenance(tmp_path: Path) -> None:
+    """All four provenance-tracked fields (name, version, license,
+    dependencies) are recorded when METADATA supplies them."""
+    metadata_body = (
+        "Metadata-Version: 2.1\n"
+        "Name: pkg\n"
+        "Version: 1.0.0\n"
+        "License-Expression: MIT\n"
+        "Requires-Dist: requests>=2.0\n"
+    )
+    wheel_path = _make_wheel(tmp_path, "pkg", metadata_body)
+
+    metadata, _ = read_wheel(wheel_path)
+
+    assert metadata.license_name == "MIT"
+    assert metadata.dependencies == ["requests>=2.0"]
+    assert set(metadata.provenance) == {"name", "version", "license", "dependencies"}
+
+
+def test_read_wheel_no_metadata_file_has_no_provenance(tmp_path: Path) -> None:
+    """A wheel with no .dist-info/METADATA at all must not claim any field
+    was sourced from it -- name stays the "unknown" default with an empty
+    provenance dict, not a false "Source: wheel METADATA" claim."""
+    wheel_path = _make_wheel(tmp_path, "pkg", metadata_body=None)
+
+    metadata, _ = read_wheel(wheel_path)
+
+    assert metadata.name == "unknown"
+    assert metadata.provenance == {}

--- a/tests/test_extract_wheel.py
+++ b/tests/test_extract_wheel.py
@@ -65,4 +65,4 @@ def test_read_wheel_no_metadata_file_has_no_provenance(tmp_path: Path) -> None:
     metadata, _ = read_wheel(wheel_path)
 
     assert metadata.name == "unknown"
-    assert metadata.provenance == {}
+    assert not metadata.provenance

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -830,7 +830,7 @@ def test_duplicate_relationships_deduplicated(
 
 def test_fragment_envelope_is_dropped(tmp_path: Path) -> None:
     """A fragment carrying its own SpdxDocument/software_Sbom envelope (e.g.
-    from `loom -m`) must not add a second envelope to the merged SBOM."""
+    from `loom model`) must not add a second envelope to the merged SBOM."""
     namespace = "https://spdx.org/spdxdocs/envelope-test"
     envelope_fragment = {
         "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -939,7 +939,7 @@ def test_assembler_ai_model_reuses_registry_entity_by_physical_path() -> None:
 
 def test_assembler_ai_model_reuses_registry_entity_by_file_stem() -> None:
     """Falls back to the model file's stem (mirroring the lookup
-    generate_ai_model_sbom performs for loom -m/--registry) when no
+    generate_ai_model_sbom performs for loom model/--registry) when no
     physical_path or name match is registered."""
     project = ProjectMetadata(name="ai-project", version="0.1.0")
     ai_model = AiModelMetadata(

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -15,7 +15,7 @@ from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.__about__ import __version__
 from pitloom.assemble import generate_sbom
-from pitloom.assemble.spdx3.document import build, build_model
+from pitloom.assemble.spdx3.document import build, build_deployed, build_model
 from pitloom.core.ai_metadata import AiModelFormat, AiModelFormatInfo, AiModelMetadata
 from pitloom.core.config import PitloomConfig
 from pitloom.core.creation import CreationMetadata, Creator, Tool
@@ -987,6 +987,60 @@ def test_assembler_ai_model_no_registry_match_mints_fresh_id() -> None:
     ai_pkgs = [e for e in graph if e.get("type") == "ai_AIPackage"]
     assert len(ai_pkgs) == 1
     assert ai_pkgs[0]["spdxId"] != unrelated_id
+
+
+def test_build_deployed_reuses_registry_entity_by_name() -> None:
+    """A Deployed SBOM's installed packages must reuse a registered
+    ``software_Package`` entity's spdxId (looked up by package name), so
+    the same package referenced elsewhere (e.g. a Source or Analyzed SBOM)
+    unifies with it once merged, instead of always minting a fresh id."""
+    project = ProjectMetadata(name="deployed-environment", version="0.0.0")
+    doc = DocumentModel(project=project, creation_metadata=CreationMetadata())
+    env_tree = [
+        {
+            "package": {
+                "key": "requests",
+                "package_name": "requests",
+                "installed_version": "2.31.0",
+            }
+        }
+    ]
+
+    registry = IdRegistry.new("deployed-environment")
+    registered_id = registry.register_entity("requests", "software_Package")
+
+    exporter = build_deployed(doc, env_tree, registry=registry)
+    graph = json.loads(exporter.to_json())["@graph"]
+
+    packages = [e for e in graph if e.get("type") == "software_Package"]
+    requests_pkg = next(p for p in packages if p["name"] == "requests")
+    assert requests_pkg["spdxId"] == registered_id
+
+
+def test_build_deployed_no_registry_match_mints_fresh_id() -> None:
+    """No matching registry entity -> unchanged behaviour: a fresh id is
+    minted for the installed package."""
+    project = ProjectMetadata(name="deployed-environment", version="0.0.0")
+    doc = DocumentModel(project=project, creation_metadata=CreationMetadata())
+    env_tree = [
+        {
+            "package": {
+                "key": "requests",
+                "package_name": "requests",
+                "installed_version": "2.31.0",
+            }
+        }
+    ]
+
+    registry = IdRegistry.new("deployed-environment")
+    unrelated_id = registry.register_entity("some-other-package", "software_Package")
+
+    exporter = build_deployed(doc, env_tree, registry=registry)
+    graph = json.loads(exporter.to_json())["@graph"]
+
+    packages = [e for e in graph if e.get("type") == "software_Package"]
+    requests_pkg = next(p for p in packages if p["name"] == "requests")
+    assert requests_pkg["spdxId"] != unrelated_id
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -5,23 +5,30 @@
 """Integration tests for SBOM generation."""
 
 import json
+import subprocess
 import tempfile
+import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.__about__ import __version__
-from pitloom.assemble import generate_sbom
+from pitloom.assemble import (
+    generate_analyzed_sbom,
+    generate_deployed_sbom,
+    generate_sbom,
+)
 from pitloom.assemble.spdx3.document import build, build_deployed, build_model
 from pitloom.core.ai_metadata import AiModelFormat, AiModelFormatInfo, AiModelMetadata
 from pitloom.core.config import PitloomConfig
 from pitloom.core.creation import CreationMetadata, Creator, Tool
 from pitloom.core.document import DocumentModel
 from pitloom.core.models import generate_spdx_id
-from pitloom.core.project import ProjectFile, ProjectMetadata
+from pitloom.core.project import PhantomDependency, ProjectFile, ProjectMetadata
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 from pitloom.extract.ai_model import read_ai_model
 from pitloom.ids import IdRegistry
@@ -1044,6 +1051,147 @@ def test_build_deployed_no_registry_match_mints_fresh_id() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Phantom dependency tests (add_phantom_dependencies via build())
+# ---------------------------------------------------------------------------
+
+
+def test_phantom_dependency_creates_package_and_dependency_relationship() -> None:
+    """A phantom dependency produces a software_Package (name/version) and a
+    dependsOn Relationship from the main package to it."""
+    project = ProjectMetadata(name="main-project", version="1.0.0")
+    doc = DocumentModel(
+        project=project,
+        creation_metadata=CreationMetadata(),
+        phantom_dependencies=[
+            PhantomDependency(
+                name="libfoo",
+                file_path="pkg.libs/libfoo.so",
+                digest_sha256="c" * 64,
+                version="1.2.3",
+            )
+        ],
+    )
+
+    exporter = build(doc)
+    graph = json.loads(exporter.to_json())["@graph"]
+
+    packages = [e for e in graph if e.get("type") == "software_Package"]
+    phantom_pkg = next(p for p in packages if p["name"] == "libfoo")
+    assert phantom_pkg["software_packageVersion"] == "1.2.3"
+
+    main_package = next(p for p in packages if p["name"] == "main-project")
+    relationships = [e for e in graph if e.get("type") == "Relationship"]
+    depends_on = [
+        r
+        for r in relationships
+        if r["relationshipType"] == "dependsOn"
+        and r["from"] == main_package["spdxId"]
+        and phantom_pkg["spdxId"] in r["to"]
+    ]
+    assert len(depends_on) == 1
+
+
+def test_phantom_dependency_without_version_is_unknown() -> None:
+    """A phantom dependency with no inferred version gets 'unknown'."""
+    project = ProjectMetadata(name="main-project", version="1.0.0")
+    doc = DocumentModel(
+        project=project,
+        creation_metadata=CreationMetadata(),
+        phantom_dependencies=[
+            PhantomDependency(
+                name="libbar",
+                file_path="pkg.libs/libbar.so",
+                digest_sha256="d" * 64,
+                version=None,
+            )
+        ],
+    )
+
+    exporter = build(doc)
+    graph = json.loads(exporter.to_json())["@graph"]
+
+    packages = [e for e in graph if e.get("type") == "software_Package"]
+    phantom_pkg = next(p for p in packages if p["name"] == "libbar")
+    assert phantom_pkg["software_packageVersion"] == "unknown"
+
+
+def test_phantom_dependency_links_to_matching_file() -> None:
+    """When a phantom dependency's file_path matches a registered project
+    file, a 'contains' Relationship links the phantom package to that file."""
+    files = [
+        ProjectFile(
+            physical_path="src/pkg.libs/libfoo.so",
+            distribution_path="pkg.libs/libfoo.so",
+            digest_sha256="c" * 64,
+        ),
+    ]
+    project = ProjectMetadata(name="main-project", version="1.0.0", files=files)
+    doc = DocumentModel(
+        project=project,
+        creation_metadata=CreationMetadata(),
+        phantom_dependencies=[
+            PhantomDependency(
+                name="libfoo",
+                file_path="pkg.libs/libfoo.so",
+                digest_sha256="c" * 64,
+                version=None,
+            )
+        ],
+    )
+
+    exporter = build(doc)
+    graph = json.loads(exporter.to_json())["@graph"]
+
+    packages = [e for e in graph if e.get("type") == "software_Package"]
+    phantom_pkg = next(p for p in packages if p["name"] == "libfoo")
+    files_elems = [e for e in graph if e.get("type") == "software_File"]
+    file_elem = next(f for f in files_elems if f["name"] == "pkg.libs/libfoo.so")
+
+    relationships = [e for e in graph if e.get("type") == "Relationship"]
+    contains = [
+        r
+        for r in relationships
+        if r["relationshipType"] == "contains"
+        and r["from"] == phantom_pkg["spdxId"]
+        and file_elem["spdxId"] in r["to"]
+    ]
+    assert len(contains) == 1
+
+
+def test_phantom_dependency_no_matching_file_no_link() -> None:
+    """When a phantom dependency's file_path has no matching registered
+    project file, no 'contains' relationship is created and building does
+    not crash."""
+    project = ProjectMetadata(name="main-project", version="1.0.0")
+    doc = DocumentModel(
+        project=project,
+        creation_metadata=CreationMetadata(),
+        phantom_dependencies=[
+            PhantomDependency(
+                name="libfoo",
+                file_path="pkg.libs/libfoo.so",
+                digest_sha256="c" * 64,
+                version=None,
+            )
+        ],
+    )
+
+    exporter = build(doc)
+    graph = json.loads(exporter.to_json())["@graph"]
+
+    packages = [e for e in graph if e.get("type") == "software_Package"]
+    phantom_pkg = next(p for p in packages if p["name"] == "libfoo")
+
+    relationships = [e for e in graph if e.get("type") == "Relationship"]
+    contains_from_phantom = [
+        r
+        for r in relationships
+        if r["relationshipType"] == "contains" and r["from"] == phantom_pkg["spdxId"]
+    ]
+    assert contains_from_phantom == []
+
+
+# ---------------------------------------------------------------------------
 # License relationship tests
 # ---------------------------------------------------------------------------
 # Each (model_name, license_id, hf_id) triple is taken from the model zoo in
@@ -1305,3 +1453,70 @@ def test_fixture_license_export(fixture_path: Path) -> None:
     ai_pkgs = [e for e in graph if e.get("type") == "ai_AIPackage"]
     assert len(ai_pkgs) == 1
     _check_license_relationships(graph, ai_pkgs[0]["spdxId"], meta.license)
+
+
+# ---------------------------------------------------------------------------
+# assemble-layer wiring: generate_analyzed_sbom() / generate_deployed_sbom()
+# ---------------------------------------------------------------------------
+
+
+def _make_wheel(tmp_path: Path, name: str, version: str) -> Path:
+    """Build a minimal .whl with just a METADATA file."""
+    wheel_path = tmp_path / f"{name}-{version}-py3-none-any.whl"
+    metadata_body = f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n"
+    with zipfile.ZipFile(wheel_path, "w") as zf:
+        zf.writestr(f"{name}-{version}.dist-info/METADATA", metadata_body)
+        zf.writestr(f"{name}/__init__.py", "")
+    return wheel_path
+
+
+def test_generate_analyzed_sbom_from_wheel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """generate_analyzed_sbom() wires read_wheel()'s extracted metadata into
+    a valid SPDX 3 JSON-LD document with the expected package name/version."""
+    monkeypatch.chdir(tmp_path)
+    wheel_path = _make_wheel(tmp_path, "analyzed-pkg", "2.3.4")
+
+    sbom_json = generate_analyzed_sbom(wheel_path)
+    data = json.loads(sbom_json)
+
+    assert "@graph" in data
+    graph = data["@graph"]
+    packages = [e for e in graph if e.get("type") == "software_Package"]
+    main_package = next(p for p in packages if p["name"] == "analyzed-pkg")
+    assert main_package["software_packageVersion"] == "2.3.4"
+
+
+def test_generate_deployed_sbom_mocked_pipdeptree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """generate_deployed_sbom() wires read_environment()'s pipdeptree tree
+    into a valid SPDX 3 JSON-LD document containing the installed package."""
+    monkeypatch.chdir(tmp_path)
+    tree = [
+        {
+            "package": {
+                "key": "requests",
+                "package_name": "requests",
+                "installed_version": "2.31.0",
+            }
+        }
+    ]
+    fake_result = subprocess.CompletedProcess(
+        args=["pipdeptree", "--json-tree", "--all"],
+        returncode=0,
+        stdout=json.dumps(tree),
+        stderr="",
+    )
+
+    with patch("subprocess.run", return_value=fake_result):
+        sbom_json = generate_deployed_sbom()
+
+    data = json.loads(sbom_json)
+
+    assert "@graph" in data
+    graph = data["@graph"]
+    packages = [e for e in graph if e.get("type") == "software_Package"]
+    requests_pkg = next(p for p in packages if p["name"] == "requests")
+    assert requests_pkg["software_packageVersion"] == "2.31.0"

--- a/tests/test_hatch_hook.py
+++ b/tests/test_hatch_hook.py
@@ -614,6 +614,53 @@ def test_hook_with_sampleproject_fixture() -> None:
     hook.finalize("standard", build_data, "")
 
 
+def test_hook_bundled_binary_produces_phantom_dependency() -> None:
+    """A wheel containing an auditwheel-style bundled .so (under a
+    <package>.libs/ directory) must produce a phantom-dependency
+    software_Package in the SBOM graph, via find_phantom_dependencies()
+    wired into _build_document_model()."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        write_pyproject_with_pitloom_config(
+            tmp_path,
+            "[tool.hatch.build.targets.wheel]\npackages = "
+            '["testpkg", "testpkg.libs"]\n',
+        )
+        (tmp_path / "testpkg").mkdir()
+        (tmp_path / "testpkg" / "__init__.py").write_text("", encoding="utf-8")
+        (tmp_path / "testpkg.libs").mkdir()
+        (tmp_path / "testpkg.libs" / "libfoo-abc123.so").write_bytes(
+            b"\x7fELF fake binary content"
+        )
+
+        hook = make_hook(tmp, {})
+        build_data: dict[str, Any] = {}
+        hook.initialize("standard", build_data)
+
+        assert hook._sbom_staging_path is not None
+        data = json.loads(hook._sbom_staging_path.read_text(encoding="utf-8"))
+        graph = data["@graph"]
+
+        packages = [e for e in graph if e.get("type") == "software_Package"]
+        phantom_pkg = next(p for p in packages if p["name"] == "libfoo-abc123")
+        assert phantom_pkg["comment"].startswith(
+            "Metadata provenance: Phantom dependency"
+        )
+
+        main_package = next(p for p in packages if p["name"] == "testpkg")
+        relationships = [e for e in graph if e.get("type") == "Relationship"]
+        depends_on = [
+            r
+            for r in relationships
+            if r["relationshipType"] == "dependsOn"
+            and r["from"] == main_package["spdxId"]
+            and phantom_pkg["spdxId"] in r["to"]
+        ]
+        assert len(depends_on) == 1
+
+        hook.finalize("standard", build_data, "")
+
+
 # ---------------------------------------------------------------------------
 # metadata_from_hatchling -- field mapping (lightweight fake objects)
 # ---------------------------------------------------------------------------

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -301,12 +301,18 @@ def _write_sample_sbom(path: Path) -> dict[str, str]:
             spdx3.Hash(algorithm=spdx3.HashAlgorithm.sha256, hashValue=script_hash)
         ],
     )
-    # A file without any hash: must be skipped on import.
+    # A file without any hash: no content to gate on, so it must fall back
+    # to a name-keyed entity rather than being dropped.
     hashless = spdx3.software_File(
         spdxId=f"{namespace}#File-9", name="src/pkg/nohash.py", creationInfo=ci
     )
     model = spdx3.ai_AIPackage(
         spdxId=f"{namespace}#AIPackage-1", name="sentimentdemo", creationInfo=ci
+    )
+    # A dependency package -- not one of the three types the old hardcoded
+    # allowlist handled, but it has a name and spdxId like anything else.
+    dep_package = spdx3.software_Package(
+        spdxId=f"{namespace}#Package-2", name="requests", creationInfo=ci
     )
     sbom = spdx3.software_Sbom(
         spdxId=f"{namespace}#Sbom-1", creationInfo=ci, rootElement=[model.spdxId]
@@ -322,6 +328,7 @@ def _write_sample_sbom(path: Path) -> dict[str, str]:
     exporter.add_file(script)
     exporter.add_file(hashless)
     exporter.add_package(model)
+    exporter.add_package(dep_package)
     exporter.add_sbom(sbom)
     exporter.add_document(doc)
     path.write_text(exporter.to_json(), encoding="utf-8")
@@ -332,7 +339,10 @@ def _write_sample_sbom(path: Path) -> dict[str, str]:
         "dataset_hash": file_hash,
         "script_id": f"{namespace}#File-3",
         "script_hash": script_hash,
+        "hashless_id": f"{namespace}#File-9",
         "model_id": f"{namespace}#AIPackage-1",
+        "dep_package_id": f"{namespace}#Package-2",
+        "agent_id": f"{namespace}#SoftwareAgent-1",
     }
 
 
@@ -350,11 +360,35 @@ def test_import_sbom_harvests_files_and_entities(tmp_path: Path) -> None:
     assert registry.files["src/pkg/train.py"] == FileEntry(
         spdx_id=ids["script_id"], sha256=ids["script_hash"]
     )
-    # hashless file skipped
-    assert "src/pkg/nohash.py" not in registry.files
     # AIPackage harvested into entities
     assert registry.entities["sentimentdemo"] == EntityEntry(
         type="ai_AIPackage", spdx_id=ids["model_id"]
+    )
+
+
+def test_import_sbom_harvests_any_named_element_as_entity(tmp_path: Path) -> None:
+    """Not just the historically-special-cased File/Dataset/AIPackage types
+    -- any element with a name and spdxId is importable, typed by its own
+    SPDX 3 compact type. A hash-less File also falls back here instead of
+    being dropped entirely."""
+    sbom_path = tmp_path / "sample.spdx3.json"
+    ids = _write_sample_sbom(sbom_path)
+
+    registry = IdRegistry.new("proj")
+    registry.import_sbom(sbom_path)
+
+    # A software_Package (not one of the old three hardcoded types).
+    assert registry.entities["requests"] == EntityEntry(
+        type="software_Package", spdx_id=ids["dep_package_id"]
+    )
+    # A hash-less software_File: not dropped, keyed as an entity instead.
+    assert "src/pkg/nohash.py" not in registry.files
+    assert registry.entities["src/pkg/nohash.py"] == EntityEntry(
+        type="software_File", spdx_id=ids["hashless_id"]
+    )
+    # Even a creator Agent, typed by its own compact type.
+    assert registry.entities["Pitloom"] == EntityEntry(
+        type="SoftwareAgent", spdx_id=ids["agent_id"]
     )
 
 

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -150,6 +150,27 @@ def test_lookup_file_requires_path_and_hash_match(tmp_path: Path) -> None:
     assert registry.lookup_file("data/other.txt", good_hash) is None
 
 
+def test_file_entry_normalises_hash_case() -> None:
+    """An upper-case sha256 (e.g. from a hand-edited loom-ids.json or an
+    imported foreign SBOM) still matches the lower-case hex
+    ``hashlib``/``_sha256_file`` always produces, so unchanged content
+    isn't mistaken for changed content on the next scan."""
+    registry = IdRegistry(
+        namespace="https://spdx.org/spdxdocs/x-1",
+        files={
+            "data/x.txt": FileEntry(
+                spdx_id="https://spdx.org/spdxdocs/x-1#File-1",
+                sha256=_sha256(b"hello\n").upper(),
+            )
+        },
+    )
+    assert registry.files["data/x.txt"].sha256 == _sha256(b"hello\n")
+    assert (
+        registry.lookup_file("data/x.txt", _sha256(b"hello\n"))
+        == "https://spdx.org/spdxdocs/x-1#File-1"
+    )
+
+
 def test_lookup_entity_requires_type_match() -> None:
     registry = IdRegistry(
         namespace="https://spdx.org/spdxdocs/x-1",

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import pytest
 from spdx_python_model.bindings import v3_0_1 as spdx3
 
-from pitloom.__main__ import _run_ids_cli
+from pitloom.__main__ import _build_parser, _run_ids_cli
 from pitloom.export.spdx3_json import Spdx3JsonExporter
 from pitloom.ids import (
     DEFAULT_REGISTRY_FILENAME,
@@ -421,8 +421,10 @@ def test_ids_generate_cli_entity_flag(
     (tmp_path / "data" / "raw.txt").write_text("raw\n")
     monkeypatch.chdir(tmp_path)
 
-    exit_code = _run_ids_cli(
+    parser = _build_parser()
+    args = parser.parse_args(
         [
+            "ids",
             "generate",
             "data",
             "--entity",
@@ -431,6 +433,7 @@ def test_ids_generate_cli_entity_flag(
             "other:dataset_DatasetPackage",
         ]
     )
+    exit_code = _run_ids_cli(args)
     assert exit_code == 0
 
     registry = IdRegistry.load(tmp_path / "loom-ids.json")

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -346,7 +346,7 @@ def test_model_mode_no_project_dir_required(
         return "{}"
 
     monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "model", str(SAFETENSORS_FIXTURE)])
+    monkeypatch.setattr(sys, "argv", ["loom", "analyze", str(SAFETENSORS_FIXTURE)])
 
     assert __main__.main() == 0
     assert captured["model_path"] == SAFETENSORS_FIXTURE.resolve()
@@ -374,7 +374,7 @@ def test_model_mode_explicit_output_path(
 
     monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
     monkeypatch.setattr(
-        sys, "argv", ["loom", "model", str(ONNX_FIXTURE), "-o", str(explicit_out)]
+        sys, "argv", ["loom", "analyze", str(ONNX_FIXTURE), "-o", str(explicit_out)]
     )
 
     assert __main__.main() == 0
@@ -400,7 +400,7 @@ def test_model_mode_default_output_path_uses_stem(
         return "{}"
 
     monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "model", str(SAFETENSORS_FIXTURE)])
+    monkeypatch.setattr(sys, "argv", ["loom", "analyze", str(SAFETENSORS_FIXTURE)])
 
     assert __main__.main() == 0
     out = captured["output_path"]
@@ -428,7 +428,7 @@ def test_model_mode_passes_pretty_flag(
         return "{}"
 
     monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "model", str(ONNX_FIXTURE), "--pretty"])
+    monkeypatch.setattr(sys, "argv", ["loom", "analyze", str(ONNX_FIXTURE), "--pretty"])
 
     assert __main__.main() == 0
     assert captured["pretty"] is True
@@ -456,7 +456,7 @@ def test_model_mode_passes_creation_info(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "model", str(SAFETENSORS_FIXTURE), "--creator-name", "TestBot"],
+        ["loom", "analyze", str(SAFETENSORS_FIXTURE), "--creator-name", "TestBot"],
     )
 
     assert __main__.main() == 0
@@ -470,7 +470,7 @@ def test_model_mode_nonexistent_file_returns_error(
     tmp_path: Path,
 ) -> None:
     monkeypatch.setattr(
-        sys, "argv", ["loom", "model", str(tmp_path / "no-such-model.safetensors")]
+        sys, "argv", ["loom", "analyze", str(tmp_path / "no-such-model.safetensors")]
     )
     assert __main__.main() == 1
 
@@ -783,7 +783,7 @@ def test_model_mode_verbose_shows_model_path(
         return "{}"
 
     monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "model", str(ONNX_FIXTURE), "-v"])
+    monkeypatch.setattr(sys, "argv", ["loom", "analyze", str(ONNX_FIXTURE), "-v"])
 
     assert __main__.main() == 0
     out = capsys.readouterr().out
@@ -804,7 +804,7 @@ def test_model_mode_safetensors_produces_ai_package(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "model", str(SAFETENSORS_FIXTURE), "-o", str(out)],
+        ["loom", "analyze", str(SAFETENSORS_FIXTURE), "-o", str(out)],
     )
 
     assert __main__.main() == 0
@@ -824,7 +824,7 @@ def test_model_mode_onnx_produces_ai_package(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "model", str(ONNX_FIXTURE), "-o", str(out)],
+        ["loom", "analyze", str(ONNX_FIXTURE), "-o", str(out)],
     )
 
     assert __main__.main() == 0
@@ -844,7 +844,7 @@ def test_model_mode_safetensors_no_software_package(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "model", str(SAFETENSORS_FIXTURE), "-o", str(out)],
+        ["loom", "analyze", str(SAFETENSORS_FIXTURE), "-o", str(out)],
     )
 
     assert __main__.main() == 0
@@ -863,7 +863,7 @@ def test_model_mode_onnx_sbom_root_is_ai_package(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "model", str(ONNX_FIXTURE), "-o", str(out)],
+        ["loom", "analyze", str(ONNX_FIXTURE), "-o", str(out)],
     )
 
     assert __main__.main() == 0
@@ -902,7 +902,7 @@ def test_hf_url_routes_to_huggingface_sbom(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "model", "https://huggingface.co/mistralai/Mistral-7B-v0.1"],
+        ["loom", "analyze", "https://huggingface.co/mistralai/Mistral-7B-v0.1"],
     )
 
     assert __main__.main() == 0
@@ -926,7 +926,7 @@ def test_hf_model_id_routes_to_huggingface_sbom(
         return "{}"
 
     monkeypatch.setattr(__main__, "generate_huggingface_sbom", _fake_generate_hf_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "model", "Qwen/Qwen3-235B-A22B"])
+    monkeypatch.setattr(sys, "argv", ["loom", "analyze", "Qwen/Qwen3-235B-A22B"])
 
     assert __main__.main() == 0
     assert captured["model_source"] == "Qwen/Qwen3-235B-A22B"
@@ -952,7 +952,7 @@ def test_hf_mode_default_output_uses_model_name(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "model", "https://huggingface.co/mistralai/Mistral-7B-v0.1"],
+        ["loom", "analyze", "https://huggingface.co/mistralai/Mistral-7B-v0.1"],
     )
 
     assert __main__.main() == 0
@@ -986,7 +986,7 @@ def test_hf_mode_explicit_output_path(
         "argv",
         [
             "loom",
-            "model",
+            "analyze",
             "mistralai/Mistral-7B-v0.1",
             "-o",
             str(explicit_out),
@@ -1019,7 +1019,7 @@ def test_hf_mode_passes_creation_info(
         "argv",
         [
             "loom",
-            "model",
+            "analyze",
             "Qwen/Qwen3-235B-A22B",
             "--creator-name",
             "Researcher",
@@ -1052,7 +1052,7 @@ def test_hf_mode_passes_pretty_flag(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "model", "mistralai/Mistral-7B-v0.1", "--pretty"],
+        ["loom", "analyze", "mistralai/Mistral-7B-v0.1", "--pretty"],
     )
 
     assert __main__.main() == 0
@@ -1083,7 +1083,7 @@ def test_hf_mode_verbose_shows_model_id(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "model", "https://huggingface.co/Qwen/Qwen3-235B-A22B", "-v"],
+        ["loom", "analyze", "https://huggingface.co/Qwen/Qwen3-235B-A22B", "-v"],
     )
 
     assert __main__.main() == 0
@@ -1114,7 +1114,7 @@ def test_hf_url_with_tree_path_resolves_correctly(
         "argv",
         [
                 "loom",
-                "model",
+                "analyze",
                 "https://huggingface.co/mistralai/Mistral-7B-v0.1/tree/main",
         ],
     )

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -486,7 +486,9 @@ def test_project_mode_default_creation_comment(
         '[project]\nname = "cli-app"\nversion = "0.1.0"\n', encoding="utf-8"
     )
     out = tmp_path / "cli-app.spdx3.json"
-    monkeypatch.setattr(sys, "argv", ["loom", "source", str(project_dir), "-o", str(out)])
+    monkeypatch.setattr(
+        sys, "argv", ["loom", "source", str(project_dir), "-o", str(out)]
+    )
 
     assert __main__.main() == 0
 
@@ -686,7 +688,8 @@ def test_creator_type_invalid_choice_rejected_by_argparse(
         "argv",
         [
             "loom",
-            "source", ".",
+            "source",
+            ".",
             "--creator-name",
             "Bot",
             "--creator-type",
@@ -703,7 +706,9 @@ def test_creator_type_before_creator_name_errors(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """--creator-type before any --creator-name is a clear argparse error."""
-    monkeypatch.setattr(sys, "argv", ["loom", "source", ".", "--creator-type", "organization"])
+    monkeypatch.setattr(
+        sys, "argv", ["loom", "source", ".", "--creator-type", "organization"]
+    )
     with pytest.raises(SystemExit):
         __main__.main()
     assert "--creator-type must come after a --creator-name" in capsys.readouterr().err
@@ -714,7 +719,9 @@ def test_creator_email_before_creator_name_errors(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """--creator-email before any --creator-name is a clear argparse error."""
-    monkeypatch.setattr(sys, "argv", ["loom", "source", ".", "--creator-email", "a@example.com"])
+    monkeypatch.setattr(
+        sys, "argv", ["loom", "source", ".", "--creator-email", "a@example.com"]
+    )
     with pytest.raises(SystemExit):
         __main__.main()
     assert "--creator-email must come after a --creator-name" in capsys.readouterr().err
@@ -1113,9 +1120,9 @@ def test_hf_url_with_tree_path_resolves_correctly(
         sys,
         "argv",
         [
-                "loom",
-                "analyze",
-                "https://huggingface.co/mistralai/Mistral-7B-v0.1/tree/main",
+            "loom",
+            "analyze",
+            "https://huggingface.co/mistralai/Mistral-7B-v0.1/tree/main",
         ],
     )
 

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -8,12 +8,14 @@ from __future__ import annotations
 
 import json
 import sys
+import zipfile
 from pathlib import Path
 
 import pytest
 
 from pitloom import __main__
 from pitloom.core.creation import CreationMetadata
+from pitloom.ids import IdRegistry
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
 SAFETENSORS_FIXTURE = (
@@ -1129,3 +1131,124 @@ def test_hf_url_with_tree_path_resolves_correctly(
     assert __main__.main() == 0
     # Tree path stripped - only owner/name retained
     assert captured["model_source"] == "mistralai/Mistral-7B-v0.1"
+
+
+# ---------------------------------------------------------------------------
+# `loom analyze <wheel>` / `loom deployed` / `loom ids` dispatch
+# ---------------------------------------------------------------------------
+
+
+def _make_wheel(tmp_path: Path, name: str, version: str) -> Path:
+    """Build a minimal .whl containing just a METADATA file."""
+    wheel_path = tmp_path / f"{name}-{version}-py3-none-any.whl"
+    metadata_body = f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n"
+    with zipfile.ZipFile(wheel_path, "w") as zf:
+        zf.writestr(f"{name}-{version}.dist-info/METADATA", metadata_body)
+    return wheel_path
+
+
+def test_analyze_wheel_dispatches_to_wheel_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`loom analyze foo.whl` must dispatch to generate_analyzed_sbom(),
+    not the AI-model or Hugging Face paths."""
+    monkeypatch.chdir(tmp_path)
+    wheel_path = _make_wheel(tmp_path, "pkg", "1.0.0")
+    captured: dict[str, object] = {}
+
+    def _fake_generate_analyzed_sbom(
+        wheel_path_arg: Path,
+        output_path: object = None,
+        creation_metadata: object = None,
+        pretty: bool = False,
+        describe_relationship: bool = False,
+        registry: object = None,
+    ) -> str:
+        _ = (creation_metadata, pretty, describe_relationship, registry)
+        captured["wheel_path"] = wheel_path_arg
+        captured["output_path"] = output_path
+        return "{}"
+
+    monkeypatch.setattr(
+        __main__, "generate_analyzed_sbom", _fake_generate_analyzed_sbom
+    )
+    monkeypatch.setattr(sys, "argv", ["loom", "analyze", str(wheel_path)])
+
+    assert __main__.main() == 0
+    assert captured["wheel_path"] == wheel_path.resolve()
+
+
+def test_deployed_dispatches_to_generate_deployed_sbom(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`loom deployed` must dispatch to generate_deployed_sbom()."""
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, object] = {}
+
+    def _fake_generate_deployed_sbom(
+        output_path: object = None,
+        creation_metadata: object = None,
+        pretty: bool = False,
+        describe_relationship: bool = False,
+        registry: object = None,
+    ) -> str:
+        _ = (creation_metadata, pretty, describe_relationship, registry)
+        captured["output_path"] = output_path
+        return "{}"
+
+    monkeypatch.setattr(
+        __main__, "generate_deployed_sbom", _fake_generate_deployed_sbom
+    )
+    monkeypatch.setattr(sys, "argv", ["loom", "deployed"])
+
+    assert __main__.main() == 0
+    assert captured["output_path"] == tmp_path / "deployed-environment.spdx3.json"
+
+
+def test_ids_generate_cli_end_to_end(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`loom ids generate` smoke test through main(): real filesystem, no
+    monkeypatching of IdRegistry itself since it is fast and local."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "mod.py").write_text("x = 1\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["loom", "ids", "generate"])
+
+    assert __main__.main() == 0
+
+    registry_path = tmp_path / "loom-ids.json"
+    assert registry_path.exists()
+    registry = IdRegistry.load(registry_path)
+    assert "src/mod.py" in registry.files
+
+
+def test_ids_import_cli_end_to_end(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`loom ids import` smoke test through main(): harvests ids from a real
+    SBOM produced by `loom source`."""
+    pyproject_content = """\
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "importable-pkg"
+version = "1.0.0"
+"""
+    (tmp_path / "pyproject.toml").write_text(pyproject_content, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    sbom_path = tmp_path / "importable-pkg-1.0.0.spdx3.json"
+    monkeypatch.setattr(sys, "argv", ["loom", "source", str(tmp_path)])
+    assert __main__.main() == 0
+    assert sbom_path.exists()
+
+    monkeypatch.setattr(sys, "argv", ["loom", "ids", "import", str(sbom_path)])
+    assert __main__.main() == 0
+
+    registry_path = tmp_path / "loom-ids.json"
+    assert registry_path.exists()
+    registry = IdRegistry.load(registry_path)
+    assert "importable-pkg" in registry.entities

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -69,7 +69,7 @@ pretty = true
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", str(project_dir), "-o", str(output_path)],
+        ["loom", "source", str(project_dir), "-o", str(output_path)],
     )
 
     exit_code = __main__.main()
@@ -124,7 +124,7 @@ creation-datetime = "2026-04-01T00:00:00Z"
         return "{}"
 
     monkeypatch.setattr(__main__, "generate_sbom", _fake_generate_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", str(project_dir)])
+    monkeypatch.setattr(sys, "argv", ["loom", "source", str(project_dir)])
 
     exit_code = __main__.main()
 
@@ -197,7 +197,7 @@ creation-datetime = "2030-01-02T03:04:05Z"
 
     monkeypatch.chdir(current_dir)
     monkeypatch.setattr(__main__, "generate_sbom", _fake_generate_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", str(target_dir)])
+    monkeypatch.setattr(sys, "argv", ["loom", "source", str(target_dir)])
 
     exit_code = __main__.main()
 
@@ -263,7 +263,7 @@ version = "0.1.0"
 
     monkeypatch.chdir(current_dir)
     monkeypatch.setattr(__main__, "generate_sbom", _fake_generate_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", str(target_dir), "-v"])
+    monkeypatch.setattr(sys, "argv", ["loom", "source", str(target_dir), "-v"])
 
     exit_code = __main__.main()
     captured = capsys.readouterr()
@@ -310,7 +310,7 @@ creator-name = 123
         )
 
     monkeypatch.setattr(__main__, "generate_sbom", _fake_generate_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", str(project_dir)])
+    monkeypatch.setattr(sys, "argv", ["loom", "source", str(project_dir)])
 
     exit_code = __main__.main()
     captured = capsys.readouterr()
@@ -346,7 +346,7 @@ def test_model_mode_no_project_dir_required(
         return "{}"
 
     monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "-m", str(SAFETENSORS_FIXTURE)])
+    monkeypatch.setattr(sys, "argv", ["loom", "model", str(SAFETENSORS_FIXTURE)])
 
     assert __main__.main() == 0
     assert captured["model_path"] == SAFETENSORS_FIXTURE.resolve()
@@ -374,7 +374,7 @@ def test_model_mode_explicit_output_path(
 
     monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
     monkeypatch.setattr(
-        sys, "argv", ["loom", "-m", str(ONNX_FIXTURE), "-o", str(explicit_out)]
+        sys, "argv", ["loom", "model", str(ONNX_FIXTURE), "-o", str(explicit_out)]
     )
 
     assert __main__.main() == 0
@@ -400,7 +400,7 @@ def test_model_mode_default_output_path_uses_stem(
         return "{}"
 
     monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "-m", str(SAFETENSORS_FIXTURE)])
+    monkeypatch.setattr(sys, "argv", ["loom", "model", str(SAFETENSORS_FIXTURE)])
 
     assert __main__.main() == 0
     out = captured["output_path"]
@@ -428,7 +428,7 @@ def test_model_mode_passes_pretty_flag(
         return "{}"
 
     monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "-m", str(ONNX_FIXTURE), "--pretty"])
+    monkeypatch.setattr(sys, "argv", ["loom", "model", str(ONNX_FIXTURE), "--pretty"])
 
     assert __main__.main() == 0
     assert captured["pretty"] is True
@@ -456,7 +456,7 @@ def test_model_mode_passes_creation_info(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "-m", str(SAFETENSORS_FIXTURE), "--creator-name", "TestBot"],
+        ["loom", "model", str(SAFETENSORS_FIXTURE), "--creator-name", "TestBot"],
     )
 
     assert __main__.main() == 0
@@ -470,7 +470,7 @@ def test_model_mode_nonexistent_file_returns_error(
     tmp_path: Path,
 ) -> None:
     monkeypatch.setattr(
-        sys, "argv", ["loom", "-m", str(tmp_path / "no-such-model.safetensors")]
+        sys, "argv", ["loom", "model", str(tmp_path / "no-such-model.safetensors")]
     )
     assert __main__.main() == 1
 
@@ -486,7 +486,7 @@ def test_project_mode_default_creation_comment(
         '[project]\nname = "cli-app"\nversion = "0.1.0"\n', encoding="utf-8"
     )
     out = tmp_path / "cli-app.spdx3.json"
-    monkeypatch.setattr(sys, "argv", ["loom", str(project_dir), "-o", str(out)])
+    monkeypatch.setattr(sys, "argv", ["loom", "source", str(project_dir), "-o", str(out)])
 
     assert __main__.main() == 0
 
@@ -512,6 +512,7 @@ def test_project_mode_creator_type_organization(
         "argv",
         [
             "loom",
+            "source",
             str(project_dir),
             "-o",
             str(out),
@@ -555,6 +556,7 @@ def test_project_mode_creator_type_software_agent_and_agent(
         "argv",
         [
             "loom",
+            "source",
             str(project_dir),
             "-o",
             str(out),
@@ -590,6 +592,7 @@ def test_project_mode_multiple_interleaved_creators(
         "argv",
         [
             "loom",
+            "source",
             str(project_dir),
             "-o",
             str(out),
@@ -635,6 +638,7 @@ def test_project_mode_three_creators_type_and_email_bind_to_most_recent(
         "argv",
         [
             "loom",
+            "source",
             str(project_dir),
             "-o",
             str(out),
@@ -682,7 +686,7 @@ def test_creator_type_invalid_choice_rejected_by_argparse(
         "argv",
         [
             "loom",
-            ".",
+            "source", ".",
             "--creator-name",
             "Bot",
             "--creator-type",
@@ -699,7 +703,7 @@ def test_creator_type_before_creator_name_errors(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """--creator-type before any --creator-name is a clear argparse error."""
-    monkeypatch.setattr(sys, "argv", ["loom", ".", "--creator-type", "organization"])
+    monkeypatch.setattr(sys, "argv", ["loom", "source", ".", "--creator-type", "organization"])
     with pytest.raises(SystemExit):
         __main__.main()
     assert "--creator-type must come after a --creator-name" in capsys.readouterr().err
@@ -710,7 +714,7 @@ def test_creator_email_before_creator_name_errors(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """--creator-email before any --creator-name is a clear argparse error."""
-    monkeypatch.setattr(sys, "argv", ["loom", ".", "--creator-email", "a@example.com"])
+    monkeypatch.setattr(sys, "argv", ["loom", "source", ".", "--creator-email", "a@example.com"])
     with pytest.raises(SystemExit):
         __main__.main()
     assert "--creator-email must come after a --creator-name" in capsys.readouterr().err
@@ -733,6 +737,7 @@ def test_project_mode_repeated_creation_tool(
         "argv",
         [
             "loom",
+            "source",
             str(project_dir),
             "-o",
             str(out),
@@ -755,8 +760,10 @@ def test_no_args_returns_error(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     monkeypatch.setattr(sys, "argv", ["loom"])
-    assert __main__.main() == 1
-    assert "project_dir" in capsys.readouterr().err
+    with pytest.raises(SystemExit) as excinfo:
+        __main__.main()
+    assert excinfo.value.code == 2
+    assert "the following arguments are required: command" in capsys.readouterr().err
 
 
 def test_model_mode_verbose_shows_model_path(
@@ -776,7 +783,7 @@ def test_model_mode_verbose_shows_model_path(
         return "{}"
 
     monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "-m", str(ONNX_FIXTURE), "-v"])
+    monkeypatch.setattr(sys, "argv", ["loom", "model", str(ONNX_FIXTURE), "-v"])
 
     assert __main__.main() == 0
     out = capsys.readouterr().out
@@ -797,7 +804,7 @@ def test_model_mode_safetensors_produces_ai_package(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "-m", str(SAFETENSORS_FIXTURE), "-o", str(out)],
+        ["loom", "model", str(SAFETENSORS_FIXTURE), "-o", str(out)],
     )
 
     assert __main__.main() == 0
@@ -817,7 +824,7 @@ def test_model_mode_onnx_produces_ai_package(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "-m", str(ONNX_FIXTURE), "-o", str(out)],
+        ["loom", "model", str(ONNX_FIXTURE), "-o", str(out)],
     )
 
     assert __main__.main() == 0
@@ -837,7 +844,7 @@ def test_model_mode_safetensors_no_software_package(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "-m", str(SAFETENSORS_FIXTURE), "-o", str(out)],
+        ["loom", "model", str(SAFETENSORS_FIXTURE), "-o", str(out)],
     )
 
     assert __main__.main() == 0
@@ -856,7 +863,7 @@ def test_model_mode_onnx_sbom_root_is_ai_package(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "-m", str(ONNX_FIXTURE), "-o", str(out)],
+        ["loom", "model", str(ONNX_FIXTURE), "-o", str(out)],
     )
 
     assert __main__.main() == 0
@@ -895,7 +902,7 @@ def test_hf_url_routes_to_huggingface_sbom(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "-m", "https://huggingface.co/mistralai/Mistral-7B-v0.1"],
+        ["loom", "model", "https://huggingface.co/mistralai/Mistral-7B-v0.1"],
     )
 
     assert __main__.main() == 0
@@ -919,7 +926,7 @@ def test_hf_model_id_routes_to_huggingface_sbom(
         return "{}"
 
     monkeypatch.setattr(__main__, "generate_huggingface_sbom", _fake_generate_hf_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "-m", "Qwen/Qwen3-235B-A22B"])
+    monkeypatch.setattr(sys, "argv", ["loom", "model", "Qwen/Qwen3-235B-A22B"])
 
     assert __main__.main() == 0
     assert captured["model_source"] == "Qwen/Qwen3-235B-A22B"
@@ -945,7 +952,7 @@ def test_hf_mode_default_output_uses_model_name(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "-m", "https://huggingface.co/mistralai/Mistral-7B-v0.1"],
+        ["loom", "model", "https://huggingface.co/mistralai/Mistral-7B-v0.1"],
     )
 
     assert __main__.main() == 0
@@ -979,7 +986,7 @@ def test_hf_mode_explicit_output_path(
         "argv",
         [
             "loom",
-            "-m",
+            "model",
             "mistralai/Mistral-7B-v0.1",
             "-o",
             str(explicit_out),
@@ -1012,7 +1019,7 @@ def test_hf_mode_passes_creation_info(
         "argv",
         [
             "loom",
-            "-m",
+            "model",
             "Qwen/Qwen3-235B-A22B",
             "--creator-name",
             "Researcher",
@@ -1045,7 +1052,7 @@ def test_hf_mode_passes_pretty_flag(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "-m", "mistralai/Mistral-7B-v0.1", "--pretty"],
+        ["loom", "model", "mistralai/Mistral-7B-v0.1", "--pretty"],
     )
 
     assert __main__.main() == 0
@@ -1076,7 +1083,7 @@ def test_hf_mode_verbose_shows_model_id(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "-m", "https://huggingface.co/Qwen/Qwen3-235B-A22B", "-v"],
+        ["loom", "model", "https://huggingface.co/Qwen/Qwen3-235B-A22B", "-v"],
     )
 
     assert __main__.main() == 0
@@ -1106,9 +1113,9 @@ def test_hf_url_with_tree_path_resolves_correctly(
         sys,
         "argv",
         [
-            "loom",
-            "-m",
-            "https://huggingface.co/mistralai/Mistral-7B-v0.1/tree/main",
+                "loom",
+                "model",
+                "https://huggingface.co/mistralai/Mistral-7B-v0.1/tree/main",
         ],
     )
 

--- a/working-docs/design/architecture-overview.md
+++ b/working-docs/design/architecture-overview.md
@@ -215,6 +215,8 @@ standards, and the roadmap for new integrations.
 | :---- | :---- | :---- |
 | `pyproject.toml` | `pitloom.extract.pyproject` | Package identity, version, license, dependencies, authors |
 | `setup.cfg` / `setup.py` | `pitloom.extract.setuptools` | Package identity, version, license, dependencies, authors |
+| Python environment | `pitloom.extract.env` | Deployed environment dependency graph |
+| Built wheel (`.whl`) | `pitloom.extract.wheel` / `binary` | Analyzed wheel metadata, files, and phantom dependencies |
 | AI model files (GGUF, ONNX, SafeTensors, etc.) | `pitloom.extract.ai_model` | Model architecture, format, hyperparameters, framework |
 | Dataset files (Croissant JSON-LD) | `pitloom.extract.dataset` | Dataset identity, schema, license, provenance |
 | MLflow tracking server | `pitloom.extract.mlflow` [planned] | Training run tags, params, metrics, dataset inputs |

--- a/working-docs/design/cli-ux.md
+++ b/working-docs/design/cli-ux.md
@@ -8,11 +8,12 @@ SPDX-License-Identifier: CC0-1.0
 
 # CLI UX Analysis: Consolidating Generation Subcommands
 
-This document analyzes the proposal to consolidate all lifecycle-centric SBOM generation subcommands under a single `from` (or similar) parent subcommand. 
+This document analyzes the proposal to consolidate all lifecycle-centric SBOM generation subcommands under a single `from` (or similar) parent subcommand.
 
 ## Current State
 
 Currently, the CLI exposes generation modes directly at the top level, aligned loosely with CISA SBOM types:
+
 * `loom source .` (Source SBOM)
 * `loom analyze my_wheel.whl` (Analyzed SBOM)
 * `loom deployed` (Deployed SBOM)
@@ -22,6 +23,7 @@ Currently, the CLI exposes generation modes directly at the top level, aligned l
 ## Proposed State
 
 The proposal suggests consolidating the generation commands:
+
 * `loom from source`
 * `loom from deployed`
 * `loom from analyze`
@@ -30,18 +32,22 @@ The proposal suggests consolidating the generation commands:
 ## Analysis of the `loom from` Approach
 
 ### Pros
+
 1. **Namespace Cleanliness**: It keeps the root namespace clean. If `loom` ever gains other top-level features (e.g., `loom verify`, `loom diff`, `loom merge`), pushing all generation into `from` prevents subcommand clutter.
 2. **Mental Model Alignment**: It explicitly communicates to the user that they are generating an artifact *originating from* a specific state or lifecycle stage.
 
 ### Cons
+
 1. **Verbosity**: It requires typing an extra word for every generation command (e.g., `loom source` is faster to type than `loom from source`).
-2. **Grammar and Semantics**: 
-    * "from" usually denotes an *input source* (e.g., "from a wheel", "from an environment"). 
-    * "source", "deployed", and "build" can function as nouns describing the input origin, but "analyze" is an action (verb) or a state (analyzed). 
+2. **Grammar and Semantics**:
+    * "from" usually denotes an *input source* (e.g., "from a wheel", "from an environment").
+    * "source", "deployed", and "build" can function as nouns describing the input origin, but "analyze" is an action (verb) or a state (analyzed).
     * Saying `loom from analyze` reads slightly awkwardly compared to `loom from analyzed` or `loom from wheel`.
 
 ### Alternative: Action-Centric (`loom generate`)
+
 Instead of `from`, using an action verb like `generate` might map more cleanly to CISA SBOM types:
+
 * `loom generate source`
 * `loom generate analyzed`
 * `loom generate deployed`
@@ -50,7 +56,9 @@ Instead of `from`, using an action verb like `generate` might map more cleanly t
 This aligns perfectly with the language: "Generate a Source SBOM", "Generate an Analyzed SBOM".
 
 ### Alternative: Input-Centric (`loom from`)
+
 If we stick to `from`, the targets should describe the *inputs* rather than the output types:
+
 * `loom from source` (Input: source tree)
 * `loom from wheel` (Input: built artifact / Maps to Analyzed)
 * `loom from env` (Input: Python environment / Maps to Deployed)
@@ -58,8 +66,8 @@ If we stick to `from`, the targets should describe the *inputs* rather than the 
 
 ## Conclusion
 
-Consolidating the commands is a solid architectural direction for future-proofing the CLI against bloat. 
+Consolidating the commands is a solid architectural direction for future-proofing the CLI against bloat.
 
-However, if we adopt `loom from <target>`, we should ensure the `<target>` grammatically describes the input (e.g., `wheel`, `env`, `source`). If we want the target to describe the CISA lifecycle stage (Source, Analyzed, Deployed), a verb like `loom generate <stage>` (e.g., `loom generate analyzed`) provides a more natural sentence structure. 
+However, if we adopt `loom from <target>`, we should ensure the `<target>` grammatically describes the input (e.g., `wheel`, `env`, `source`). If we want the target to describe the CISA lifecycle stage (Source, Analyzed, Deployed), a verb like `loom generate <stage>` (e.g., `loom generate analyzed`) provides a more natural sentence structure.
 
 *Recommendation*: Wait until a need for top-level non-generation commands (like `verify` or `merge`) arises before introducing the extra level of nesting, as flat CLI structures are often preferred by users for rapid usage. If consolidation is pursued, `loom generate <lifecycle_stage>` or `loom from <input_source>` are the two most linguistically consistent paths.

--- a/working-docs/design/cli-ux.md
+++ b/working-docs/design/cli-ux.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-07-11
-Last-Modified: 2026-07-11
+Last-Modified: 2026-07-17
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -66,8 +66,8 @@ If we stick to `from`, the targets should describe the *inputs* rather than the 
 
 ## Conclusion
 
-Consolidating the commands is a solid architectural direction for future-proofing the CLI against bloat.
+Neither alternative above was adopted. The shipped CLI (see `src/pitloom/__main__.py`) uses a third scheme: flat, top-level subcommands named directly after the CISA lifecycle stage, with no `from`/`generate` verb prefix -- `loom source`, `loom analyze`, `loom deployed`, plus `loom ids` for registry management.
 
-However, if we adopt `loom from <target>`, we should ensure the `<target>` grammatically describes the input (e.g., `wheel`, `env`, `source`). If we want the target to describe the CISA lifecycle stage (Source, Analyzed, Deployed), a verb like `loom generate <stage>` (e.g., `loom generate analyzed`) provides a more natural sentence structure.
+This avoids the verbosity cost identified as the main con of both `loom from <target>` and `loom generate <stage>` (an extra word on every invocation), while still giving each lifecycle stage its own namespace for stage-specific arguments and flags. In practice this matters because the stages don't share a uniform positional argument: `loom source` takes a `project_dir`, `loom analyze` takes a `target` that dispatches internally to wheel, local-model, or Hugging Face handling depending on its form, and `loom deployed` takes no positional argument at all (it always inspects the current environment). A shared parent verb (`from`/`generate`) would not have simplified this dispatch, since the stage-specific behavior still lives one level below regardless of the prefix.
 
-*Recommendation*: Wait until a need for top-level non-generation commands (like `verify` or `merge`) arises before introducing the extra level of nesting, as flat CLI structures are often preferred by users for rapid usage. If consolidation is pursued, `loom generate <lifecycle_stage>` or `loom from <input_source>` are the two most linguistically consistent paths.
+If `loom` later grows non-generation top-level commands (e.g. `verify`, `merge`), the flat namespace may need revisiting, but no such need has arisen yet.

--- a/working-docs/design/cli-ux.md
+++ b/working-docs/design/cli-ux.md
@@ -1,0 +1,65 @@
+---
+Created: 2026-07-11
+Last-Modified: 2026-07-11
+SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+SPDX-FileType: DOCUMENTATION
+SPDX-License-Identifier: CC0-1.0
+---
+
+# CLI UX Analysis: Consolidating Generation Subcommands
+
+This document analyzes the proposal to consolidate all lifecycle-centric SBOM generation subcommands under a single `from` (or similar) parent subcommand. 
+
+## Current State
+
+Currently, the CLI exposes generation modes directly at the top level, aligned loosely with CISA SBOM types:
+* `loom source .` (Source SBOM)
+* `loom analyze my_wheel.whl` (Analyzed SBOM)
+* `loom deployed` (Deployed SBOM)
+* `loom model model.bin` (AI Analyzed SBOM)
+* `loom ids ...` (Registry management)
+
+## Proposed State
+
+The proposal suggests consolidating the generation commands:
+* `loom from source`
+* `loom from deployed`
+* `loom from analyze`
+* `loom from build`
+
+## Analysis of the `loom from` Approach
+
+### Pros
+1. **Namespace Cleanliness**: It keeps the root namespace clean. If `loom` ever gains other top-level features (e.g., `loom verify`, `loom diff`, `loom merge`), pushing all generation into `from` prevents subcommand clutter.
+2. **Mental Model Alignment**: It explicitly communicates to the user that they are generating an artifact *originating from* a specific state or lifecycle stage.
+
+### Cons
+1. **Verbosity**: It requires typing an extra word for every generation command (e.g., `loom source` is faster to type than `loom from source`).
+2. **Grammar and Semantics**: 
+    * "from" usually denotes an *input source* (e.g., "from a wheel", "from an environment"). 
+    * "source", "deployed", and "build" can function as nouns describing the input origin, but "analyze" is an action (verb) or a state (analyzed). 
+    * Saying `loom from analyze` reads slightly awkwardly compared to `loom from analyzed` or `loom from wheel`.
+
+### Alternative: Action-Centric (`loom generate`)
+Instead of `from`, using an action verb like `generate` might map more cleanly to CISA SBOM types:
+* `loom generate source`
+* `loom generate analyzed`
+* `loom generate deployed`
+* `loom generate build`
+
+This aligns perfectly with the language: "Generate a Source SBOM", "Generate an Analyzed SBOM".
+
+### Alternative: Input-Centric (`loom from`)
+If we stick to `from`, the targets should describe the *inputs* rather than the output types:
+* `loom from source` (Input: source tree)
+* `loom from wheel` (Input: built artifact / Maps to Analyzed)
+* `loom from env` (Input: Python environment / Maps to Deployed)
+* `loom from model` (Input: AI model)
+
+## Conclusion
+
+Consolidating the commands is a solid architectural direction for future-proofing the CLI against bloat. 
+
+However, if we adopt `loom from <target>`, we should ensure the `<target>` grammatically describes the input (e.g., `wheel`, `env`, `source`). If we want the target to describe the CISA lifecycle stage (Source, Analyzed, Deployed), a verb like `loom generate <stage>` (e.g., `loom generate analyzed`) provides a more natural sentence structure. 
+
+*Recommendation*: Wait until a need for top-level non-generation commands (like `verify` or `merge`) arises before introducing the extra level of nesting, as flat CLI structures are often preferred by users for rapid usage. If consolidation is pursued, `loom generate <lifecycle_stage>` or `loom from <input_source>` are the two most linguistically consistent paths.

--- a/working-docs/implementation/agent-skill.md
+++ b/working-docs/implementation/agent-skill.md
@@ -124,10 +124,10 @@ worked fragment example.
 
 ```bash
 # sbom, project mode:
-loom . -o /tmp/sbom.spdx3.json
+loom source . -o /tmp/sbom.spdx3.json
 
 # sbom, model mode (adjust the path to a real model file):
-loom -m tests/fixtures/aimodels/onnx/squeezenet1.1-7.onnx -o /tmp/model.spdx3.json
+loom analyze tests/fixtures/aimodels/onnx/squeezenet1.1-7.onnx -o /tmp/model.spdx3.json
 
 # Both should exit 0 and produce a file containing an "@graph" array.
 ```

--- a/working-docs/implementation/demo.md
+++ b/working-docs/implementation/demo.md
@@ -87,7 +87,7 @@ The reference SBOM at
 ### 1. Working CLI tool
 
 ```bash
-loom /path/to/project -o sbom.spdx3.json
+loom source /path/to/project -o sbom.spdx3.json
 ```
 
 ### 2. Dynamic version extraction
@@ -163,13 +163,13 @@ pip install -e ".[dev]"
 
 ```bash
 # Basic usage
-loom /path/to/project
+loom source /path/to/project
 
 # With custom output
-loom /path/to/project -o custom-sbom.spdx3.json
+loom source /path/to/project -o custom-sbom.spdx3.json
 
 # With creator info
-loom /path/to/project --creator-name "Your Name" --creator-email "your@example.com"
+loom source /path/to/project --creator-name "Your Name" --creator-email "your@example.com"
 ```
 
 ### Run tests

--- a/working-docs/implementation/github-action.md
+++ b/working-docs/implementation/github-action.md
@@ -34,7 +34,7 @@ jobs:
           output: "sbom.spdx3.json"
 ```
 
-This installs Pitloom, runs `loom . -o sbom.spdx3.json`, and uploads the
+This installs Pitloom, runs `loom source . -o sbom.spdx3.json`, and uploads the
 result as a workflow artefact named `sbom` (all defaults; see below to
 change any of it).
 
@@ -43,7 +43,7 @@ change any of it).
 | Input | Default | Purpose |
 | :--- | :--- | :--- |
 | `project-path` | `.` | Directory to scan. Ignored when `model` is set. |
-| `model` | `""` | Local model file path or Hugging Face URL/ID -- runs model mode (`loom -m ...`) instead of project mode. |
+| `model` | `""` | Local model file path or Hugging Face URL/ID -- runs analyze mode (`loom analyze ...`) instead of project mode. |
 | `output` | `sbom.spdx3.json` | SBOM output path. |
 | `extras` | `""` | Comma-separated pip extras, e.g. `aimodel,huggingface`. |
 | `pretty` | `false` | Pretty-print the SBOM JSON. |

--- a/working-docs/implementation/summary.md
+++ b/working-docs/implementation/summary.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-02-06
-Last-Modified: 2026-07-08
+Last-Modified: 2026-07-17
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -233,16 +233,20 @@ pitloom/
 │       │   ├── _pytorch.py         # PyTorch classic (.pt, .pth)
 │       │   ├── _pytorch_pt2.py     # PyTorch PT2 / ExecuTorch (.pt2)
 │       │   ├── _safetensors.py     # Safetensors (.safetensors)
+│       │   ├── binary.py           # Bundled third-party binary ("phantom dependency") detection in a wheel
 │       │   ├── dataset.py          # Dataset metadata extraction (Croissant)
+│       │   ├── env.py              # Deployed SBOM: installed-environment dependency tree via pipdeptree
 │       │   ├── poetry.py           # [tool.poetry] extractor; Poetry -> PEP 440 conversion
 │       │   ├── pyproject.py        # pyproject.toml extractor ([project] + [tool.poetry] merge)
 │       │   ├── scanner.py          # Heuristic scanner for AI model files
-│       │   └── setuptools.py       # setup.cfg + setup.py extractor; backend detection; merge
+│       │   ├── setuptools.py       # setup.cfg + setup.py extractor; backend detection; merge
+│       │   └── wheel.py            # Analyzed SBOM: project metadata + file records from a built .whl
 │       ├── plugins/             # Build-system integrations
 │       │   └── hatch.py         # Hatchling BuildHookInterface (PEP 770)
 │       ├── __about__.py         # Package version (__version__)
 │       ├── __init__.py
 │       ├── __main__.py          # CLI entry point (loom / python -m pitloom)
+│       ├── ids.py               # Loom ID registry (loom-ids.json); stable cross-fragment SPDX ids
 │       ├── loom.py              # ML tracking SDK (Run context manager / decorator)
 │       └── py.typed             # PEP 561 marker
 ├── tests/

--- a/working-docs/implementation/summary.md
+++ b/working-docs/implementation/summary.md
@@ -37,6 +37,9 @@ SPDX 3.0 compliant SBOMs in JSON-LD format.
    - `setuptools.py` -- reads `setup.cfg` and `setup.py` for setuptools projects;
      `detect_build_backend()` auto-selects the right extractor;
      `merge_metadata()` fills gaps across sources (setup.cfg > setup.py)
+   - `wheel.py` -- reads metadata from built `.whl` files (Analyzed SBOM) and computes file-level SHA-256 hashes
+   - `env.py` -- delegates to `pipdeptree` to extract a complete dependency graph of the active installed environment (Deployed SBOM)
+   - `binary.py` -- heuristic scanner that detects bundled third-party binary libraries (e.g. `.so`, `.dylib`) within wheel files (phantom dependencies)
    - Extracts project metadata (name, version, description, authors, URLs)
    - Handles dynamic versions from `__about__.py`
    - Parses dependency specifications with version constraints
@@ -48,9 +51,11 @@ SPDX 3.0 compliant SBOMs in JSON-LD format.
    - Graceful component ingestion via `spdx3.JSONLDDeserializer`
 
 4. **SBOM generator** (`src/pitloom/assemble/`)
-   - `generate_sbom()` orchestrates the full pipeline
+   - `generate_sbom()` orchestrates the full pipeline for source code (Source SBOM)
+   - `generate_analyzed_sbom()` orchestrates the pipeline for built wheels (Analyzed SBOM), utilizing `wheel.py` and `binary.py` to identify phantom dependencies
+   - `generate_deployed_sbom()` orchestrates the pipeline for active environments (Deployed SBOM), mapping the tree using `env.py`
    - Builds `DocumentModel` from extracted metadata
-   - Passes `DocumentModel` to `build()` assembler in `assemble/spdx3/`
+   - Passes `DocumentModel` to assembly functions (`build()`, `build_deployed()`) in `assemble/spdx3/`
    - Merges pre-generated SBOM fragments
    - Generates copyright information from metadata
 
@@ -66,7 +71,8 @@ SPDX 3.0 compliant SBOMs in JSON-LD format.
      `[tool.pitloom.creation]` -- the same settings the CLI uses
 
 6. **Command-line interface** (`src/pitloom/__main__.py`)
-   - User-friendly argparse-based CLI
+   - User-friendly argparse-based CLI with lifecycle-centric subcommands (`source`, `analyze`, `deployed`, `model`, `ids`)
+   - Subcommands map to CISA SBOM types (e.g. `source` -> Source SBOM, `analyze` -> Analyzed SBOM, `deployed` -> Deployed SBOM)
    - Default output filename derived from project metadata (`{name}-{version}.spdx3.json`)
      or `[tool.pitloom] sbom-basename` when set
    - Creator information options


### PR DESCRIPTION
Restructures the CLI around CISA's SBOM lifecycle types via subcommands

- `loom source <dir>` (unbuilt source)
- `loom analyze <wheel|model|HF-repo>` (built artifact — subsumes the old `-m` model-file mode)
- `loom deployed` (installed environment, via `pipdeptree`)