### PR TITLE
Use hasConcludedLicense for detected licenses

### DIFF
--- a/src/pitloom/assemble/spdx3/ai.py
+++ b/src/pitloom/assemble/spdx3/ai.py
@@ -397,8 +397,10 @@ def add_ai_models(
                 encoder=encoder,
                 provenance_detail=provenance_detail,
             )
-            exporter.add_relationship(rel_declared)
-            exporter.add_relationship(rel_concluded)
+            if rel_declared:
+                exporter.add_relationship(rel_declared)
+            if rel_concluded:
+                exporter.add_relationship(rel_concluded)
 
         rel = spdx3.Relationship(
             spdxId=generate_spdx_id(

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -13,7 +13,12 @@ from importlib.metadata import version as get_package_version
 
 from spdx_python_model.bindings import v3_0_1 as spdx3
 
-from pitloom.assemble.spdx3.provenance import ProvenanceEncoder, emit_provenance
+from pitloom.assemble.spdx3.provenance import (
+    TRANSPARENT_SOURCES,
+    ProvenanceEncoder,
+    emit_provenance,
+    parse_provenance_value,
+)
 from pitloom.core.models import build_pypi_purl, generate_spdx_id
 from pitloom.core.project import PhantomDependency
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
@@ -164,7 +169,23 @@ def _enrich_from_installed(
             encoder=encoder,
             provenance_detail=provenance_detail,
         )
-        exporter.add_relationship(rel_declared)
+        if rel_declared:
+            exporter.add_relationship(rel_declared)
+
+
+def _is_license_concluded(parsed_prov: dict[str, str]) -> bool:
+    """Determine if a license is concluded rather than declared.
+
+    A license is concluded if we used a heuristic/detection method,
+    or if the source is not a transparent manifest (e.g. it was extracted
+    from a LICENSE file directly).
+    """
+    if parsed_prov.get("method"):
+        return True
+    source = parsed_prov.get("source", "").strip().lower()
+    if " (" in source:
+        source = source.split(" (", 1)[0].strip()
+    return not source or source not in TRANSPARENT_SOURCES
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -179,7 +200,7 @@ def build_license_elements(
     provenance_format: str = "both",
     encoder: ProvenanceEncoder | None = None,
     provenance_detail: str = "minimal",
-) -> tuple[spdx3.Relationship, spdx3.Relationship]:
+) -> tuple[spdx3.Relationship | None, spdx3.Relationship | None]:
     """Get or create a SimpleLicensingText element and build its
     hasDeclaredLicense / hasConcludedLicense relationships for a given package.
 
@@ -234,28 +255,38 @@ def build_license_elements(
         )
         license_spdx_id = require_spdx_id(license_text)
 
-    # The license actually found in the Software Artifact.
-    rel_has_declared_license = spdx3.Relationship(
-        spdxId=generate_spdx_id("Relationship", doc_name=doc_name, doc_uuid=doc_uuid),
-        creationInfo=creation_info,
-        from_=package_spdx_id,
-        relationshipType=spdx3.RelationshipType.hasDeclaredLicense,
-        to=[license_spdx_id],
-    )
+    parsed_prov = parse_provenance_value(license_provenance)
+    is_concluded = _is_license_concluded(parsed_prov)
 
-    # The license identified by the SPDX data creator. Currently set equal to
-    # the declared license; hasDeclaredLicense and hasConcludedLicense are
-    # distinct in the SPDX 3 model (e.g. multiple declared licenses, or a
-    # concluded license inferred from evidence other than the declaration --
-    # see https://spdx.github.io/spdx-spec/v3.0/model/Licensing/Licensing/),
-    # but pitloom does not yet perform that inference.
-    rel_has_concluded_license = spdx3.Relationship(
-        spdxId=generate_spdx_id("Relationship", doc_name=doc_name, doc_uuid=doc_uuid),
-        creationInfo=creation_info,
-        from_=package_spdx_id,
-        relationshipType=spdx3.RelationshipType.hasConcludedLicense,
-        to=[license_spdx_id],
-    )
+    rel_has_declared_license: spdx3.Relationship | None = None
+    rel_has_concluded_license: spdx3.Relationship | None = None
+
+    if is_concluded:
+        # The license identified by the SPDX data creator.
+        rel_has_concluded_license = spdx3.Relationship(
+            spdxId=generate_spdx_id(
+                "Relationship",
+                doc_name=doc_name,
+                doc_uuid=doc_uuid,
+            ),
+            creationInfo=creation_info,
+            from_=package_spdx_id,
+            relationshipType=spdx3.RelationshipType.hasConcludedLicense,
+            to=[license_spdx_id],
+        )
+    else:
+        # The license asserted by the author in the Software Artifact.
+        rel_has_declared_license = spdx3.Relationship(
+            spdxId=generate_spdx_id(
+                "Relationship",
+                doc_name=doc_name,
+                doc_uuid=doc_uuid,
+            ),
+            creationInfo=creation_info,
+            from_=package_spdx_id,
+            relationshipType=spdx3.RelationshipType.hasDeclaredLicense,
+            to=[license_spdx_id],
+        )
 
     return rel_has_declared_license, rel_has_concluded_license
 

--- a/src/pitloom/assemble/spdx3/document.py
+++ b/src/pitloom/assemble/spdx3/document.py
@@ -324,8 +324,10 @@ def build(
             encoder=encoder,
             provenance_detail=provenance_detail,
         )
-        exporter.add_relationship(rel_declared)
-        exporter.add_relationship(rel_concluded)
+        if rel_declared:
+            exporter.add_relationship(rel_declared)
+        if rel_concluded:
+            exporter.add_relationship(rel_concluded)
         spdx_doc.profileConformance.append(spdx3.ProfileIdentifierType.simpleLicensing)
 
     # --- Dependencies ---
@@ -497,8 +499,10 @@ def build_model(
             encoder=encoder,
             provenance_detail=provenance_detail,
         )
-        exporter.add_relationship(rel_declared)
-        exporter.add_relationship(rel_concluded)
+        if rel_declared:
+            exporter.add_relationship(rel_declared)
+        if rel_concluded:
+            exporter.add_relationship(rel_concluded)
 
     if model.datasets:
         add_datasets_for_model(

--- a/src/pitloom/assemble/spdx3/provenance.py
+++ b/src/pitloom/assemble/spdx3/provenance.py
@@ -47,7 +47,7 @@ ARTIFACT_METADATA_SCHEMA_URL = "https://pitloom.dev/provenance/artifact-metadata
 #: is already the native SPDX field and the source is trivially re-derivable by
 #: the consumer. Anything else -- an inference, a scan (pipdeptree), a binary
 #: artifact's internal key, a synthesized package -- is kept.
-_TRANSPARENT_SOURCES: frozenset[str] = frozenset(
+TRANSPARENT_SOURCES: frozenset[str] = frozenset(
     {
         "pyproject.toml",
         "hatchling build backend",  # same pyproject.toml data via the build hook
@@ -93,7 +93,7 @@ def _is_high_signal(entry: dict[str, str]) -> bool:
     the native SPDX value (the "minimal" detail boundary).
 
     Low-signal (dropped) only when the value was read *verbatim* from a
-    transparent, re-readable manifest (:data:`_TRANSPARENT_SOURCES`) with no
+    transparent, re-readable manifest (:data:`TRANSPARENT_SOURCES`) with no
     extraction ``method`` -- e.g. ``name`` from ``project.name``, whose value
     is already the native ``Element.name`` and whose source the consumer can
     trivially re-read. Everything else is high-signal and kept:
@@ -108,7 +108,9 @@ def _is_high_signal(entry: dict[str, str]) -> bool:
     if entry.get("method"):
         return True
     source = entry.get("source", "").strip().lower()
-    return source not in _TRANSPARENT_SOURCES
+    if " (" in source:
+        source = source.split(" (", 1)[0].strip()
+    return not source or source not in TRANSPARENT_SOURCES
 
 
 def filter_high_signal(provenance: dict[str, str]) -> dict[str, str]:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1235,7 +1235,7 @@ _AI_LICENSE_CASES: list[tuple[str, str, str]] = [
 def _check_license_relationships(
     graph: list[dict[str, Any]], ai_pkg_id: str, license_id: str
 ) -> None:
-    """Assert hasDeclaredLicense and hasConcludedLicense relationships exist."""
+    """Assert hasDeclaredLicense or hasConcludedLicense relationship exists."""
     rels = [e for e in graph if e.get("type") == "Relationship"]
     declared = [
         r
@@ -1249,10 +1249,14 @@ def _check_license_relationships(
         if r.get("relationshipType") == "hasConcludedLicense"
         and r.get("from") == ai_pkg_id
     ]
-    assert len(declared) == 1, "expected one hasDeclaredLicense relationship"
-    assert len(concluded) == 1, "expected one hasConcludedLicense relationship"
 
-    license_spdx_id = declared[0]["to"][0]
+    assert len(declared) + len(concluded) == 1, (
+        f"expected exactly one license relationship, got {len(declared)} declared "
+        f"and {len(concluded)} concluded"
+    )
+
+    license_rel = declared[0] if declared else concluded[0]
+    license_spdx_id = license_rel["to"][0]
     license_elems = [
         e
         for e in graph


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? -->

emit hasConcludedLicense for Pitloom-detected licenses and hasDeclaredLicense for author-asserted manifests. Stops unconditionally mirroring declared licenses to concluded ones, honoring SPDX 3 semantics.

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`) and lint passes
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [ ] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
