### PR TITLE
Map dataset creator metadata onto native SPDX 3

### DIFF
--- a/src/pitloom/assemble/spdx3/dataset.py
+++ b/src/pitloom/assemble/spdx3/dataset.py
@@ -164,6 +164,35 @@ def _build_dataset_package(
     return dataset_pkg
 
 
+def _add_dataset_creator_agent(
+    dataset_pkg_spdx_id: str,
+    creator_name: str,
+    creation_info: spdx3.CreationInfo,
+    doc_name: str,
+    doc_uuid: str,
+    exporter: Spdx3JsonExporter,
+) -> None:
+    """Create an Agent element for a dataset's creator and wire a publishedBy
+    relationship linking the dataset to the Agent.
+    """
+    creator_agent = spdx3.Agent(
+        spdxId=generate_spdx_id(
+            f"Agent-{creator_name}", doc_name=doc_name, doc_uuid=doc_uuid
+        ),
+        name=creator_name,
+        creationInfo=creation_info,
+    )
+    exporter.add_agent(creator_agent)
+    rel_creator = spdx3.Relationship(
+        spdxId=generate_spdx_id("Relationship", doc_name=doc_name, doc_uuid=doc_uuid),
+        creationInfo=creation_info,
+        from_=dataset_pkg_spdx_id,
+        relationshipType=spdx3.RelationshipType.publishedBy,
+        to=[require_spdx_id(creator_agent)],
+    )
+    exporter.add_relationship(rel_creator)
+
+
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 def add_datasets_for_model(
     ai_package_spdx_id: str,
@@ -224,6 +253,16 @@ def add_datasets_for_model(
             encoder=encoder,
             provenance_detail=provenance_detail,
         )
+
+        if meta.creator:
+            _add_dataset_creator_agent(
+                dataset_pkg_spdx_id=require_spdx_id(dataset_pkg),
+                creator_name=meta.creator,
+                creation_info=creation_info,
+                doc_name=doc_name,
+                doc_uuid=doc_uuid,
+                exporter=exporter,
+            )
 
         rel_type, fallback_comment = _role_to_rel(dataset_ref.role)
         rel = spdx3.Relationship(

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -27,6 +27,7 @@ from pitloom.assemble.spdx3.document import build, build_deployed, build_model
 from pitloom.core.ai_metadata import AiModelFormat, AiModelFormatInfo, AiModelMetadata
 from pitloom.core.config import PitloomConfig
 from pitloom.core.creation import CreationMetadata, Creator, Tool
+from pitloom.core.dataset_metadata import DatasetMetadata, DatasetReference
 from pitloom.core.document import DocumentModel
 from pitloom.core.models import generate_spdx_id
 from pitloom.core.project import PhantomDependency, ProjectFile, ProjectMetadata
@@ -1435,6 +1436,42 @@ def test_build_model_external_identifiers() -> None:
     ]
     assert len(url_refs) == 1
     assert url_refs[0].get("comment") == "Model page URL"
+
+
+def test_build_model_with_dataset_creator() -> None:
+    """build_model() for a model linked to a dataset with creator metadata
+    must emit an Agent element and a publishedBy Relationship (N6).
+    """
+    ds_meta = DatasetMetadata(name="squad", creator="Stanford NLP")
+    ds_ref = DatasetReference(role="trainedOn", metadata=ds_meta)
+    model = AiModelMetadata(
+        format_info=AiModelFormatInfo(model_format=AiModelFormat.SAFETENSORS),
+        name="test-ds-creator",
+        datasets=[ds_ref],
+    )
+
+    exporter = build_model(model, CreationMetadata())
+    data = json.loads(exporter.to_json(pretty=True))
+    graph = data["@graph"]
+
+    agents = [e for e in graph if e.get("type") == "Agent"]
+    creator_agents = [a for a in agents if a.get("name") == "Stanford NLP"]
+    assert len(creator_agents) == 1
+    agent_spdx_id = creator_agents[0]["spdxId"]
+
+    ds_pkgs = [e for e in graph if e.get("type") == "dataset_DatasetPackage"]
+    assert len(ds_pkgs) == 1
+    ds_pkg_id = ds_pkgs[0]["spdxId"]
+
+    rels = [e for e in graph if e.get("type") == "Relationship"]
+    pub_rels = [
+        r
+        for r in rels
+        if r.get("relationshipType") == "publishedBy"
+        and r.get("from") == ds_pkg_id
+        and agent_spdx_id in r.get("to", [])
+    ]
+    assert len(pub_rels) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Map dataset creator metadata onto native SPDX 3 Agent elements linked to dataset_DatasetPackage via publishedBy relationships. Ensures Croissant dataset author attribution is natively represented in SPDX 3.



## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [ ] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
