### PR TITLE
Populate SpdxDocument.import_ for merged fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-Last-Modified: 2026-07-21
+Last-Modified: 2026-08-08
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -22,6 +22,11 @@ and this project adheres to
 
 ### Added
 
+- Native-first provenance backfills (Phase 2):
+  - `hasConcludedLicense` vs. `hasDeclaredLicense` separation for detected vs. author-asserted licenses.
+  - Native `ExternalIdentifier` (DOI) and `ExternalRef` (arXiv paper IDs, model page URLs) on `ai_AIPackage`.
+  - Native `Agent` and `publishedBy` relationship for dataset creators on `dataset_DatasetPackage`.
+  - Fragment document origin traceability: populate `SpdxDocument.import_` with `ExternalMap` entries for merged fragments.
 - Record metadata provenance as SPDX 3 Core `Annotation` elements alongside
   the `comment` form, controlled by `[tool.pitloom.provenance] format`.
 - `[tool.pitloom.provenance] detail` (`minimal` default / `full`) to limit
@@ -34,6 +39,7 @@ and this project adheres to
 
 ### Changed
 
+- Concluded licenses are no longer unconditionally mirrored from declared licenses when Pitloom detects a license itself.
 - Provenance is no longer duplicated onto `dependsOn` relationships.
 - Dict-valued AI-model metadata (`properties`, `hyperparameters`) now records
   exact per-key provenance instead of one shared note per dict.

--- a/src/pitloom/assemble/spdx3/fragments.py
+++ b/src/pitloom/assemble/spdx3/fragments.py
@@ -582,6 +582,40 @@ def _mint_extra_id(namespace: str, prefix: str, existing_ids: set[str]) -> str:
         n += 1
 
 
+def _find_fragment_document_id(fragment_set: spdx3.SHACLObjectSet) -> str | None:
+    """Return the ``spdxId`` of the ``SpdxDocument`` envelope in *fragment_set*,
+    if present."""
+    for obj in fragment_set.objects:
+        if isinstance(obj, spdx3.SpdxDocument):
+            spdx_id = getattr(obj, "spdxId", None)
+            if spdx_id:
+                return str(spdx_id)
+    return None
+
+
+def _add_fragment_imports(
+    main_doc: spdx3.SpdxDocument,
+    fragment_imports: list[spdx3.ExternalMap],
+) -> None:
+    """Populate ``main_doc.import_`` with ``ExternalMap`` entries for merged
+    fragment documents (N1)."""
+    if not fragment_imports:
+        return
+    existing_imports = list(main_doc.import_ or [])
+    existing_ids: set[str] = set()
+    for item in existing_imports:
+        if isinstance(item, spdx3.ExternalMap) and item.externalSpdxId:
+            existing_ids.add(item.externalSpdxId)
+        elif isinstance(item, str):
+            existing_ids.add(item)
+
+    for ext_map in fragment_imports:
+        if ext_map.externalSpdxId and ext_map.externalSpdxId not in existing_ids:
+            existing_imports.append(ext_map)
+            existing_ids.add(ext_map.externalSpdxId)
+    main_doc.import_ = existing_imports
+
+
 def _emit_unification_annotations(
     events: _UnificationEvents,
     main_doc: spdx3.SpdxDocument,
@@ -684,6 +718,8 @@ def merge_fragments(
     """
     index = _MergeIndex(exporter)
     events: _UnificationEvents = {}
+    fragment_imports: list[spdx3.ExternalMap] = []
+    seen_import_ids: set[str] = set()
 
     for fragment_file in fragment_files:
         fragment_path = project_dir / fragment_file
@@ -698,6 +734,16 @@ def merge_fragments(
             log.warning("Failed to ingest SBOM fragment %s: %s", fragment_path, exc)
             continue
 
+        frag_doc_id = _find_fragment_document_id(fragment_set)
+        if frag_doc_id and frag_doc_id not in seen_import_ids:
+            seen_import_ids.add(frag_doc_id)
+            fragment_imports.append(
+                spdx3.ExternalMap(
+                    externalSpdxId=frag_doc_id,
+                    locationHint=fragment_file,
+                )
+            )
+
         _merge_fragment_set(fragment_set, index, fragment_file, events)
 
     _dedupe_relationships(exporter)
@@ -705,5 +751,6 @@ def merge_fragments(
     main_doc = _find_main_document(exporter.object_set)
     if main_doc is not None:
         _update_profile_conformance(main_doc, exporter)
+        _add_fragment_imports(main_doc, fragment_imports)
         _emit_unification_annotations(events, main_doc, exporter)
         _add_model_sbom(main_doc, exporter)

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -30,11 +30,13 @@ import json
 import logging
 import shutil
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
 import pytest
+from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom import loom
 from pitloom.assemble import generate_sbom
@@ -984,3 +986,78 @@ def test_unification_annotation_records_sha256_merge() -> None:
         assert statement["criterion"] == "sha256"
         assert statement["unified"] == ["https://frag/doc#File-99"]
         assert statement["fragments"] == ["frag.spdx3.json"]
+
+
+def test_merge_fragments_populates_spdx_document_imports(tmp_path: Path) -> None:
+    """merge_fragments() must populate main_doc.import_ with ExternalMap
+    entries naming each merged fragment's SpdxDocument spdxId and location hint (N1).
+    """
+    frag_namespace = "https://spdx.org/spdxdocs/fragment-import-test"
+    envelope_fragment = {
+        "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+        "@graph": [
+            {
+                "type": "CreationInfo",
+                "@id": "_:creationinfo0",
+                "specVersion": "3.0.1",
+                "created": "2026-01-01T00:00:00Z",
+                "createdBy": [f"{frag_namespace}#Agent-1"],
+            },
+            {
+                "type": "SoftwareAgent",
+                "spdxId": f"{frag_namespace}#Agent-1",
+                "creationInfo": "_:creationinfo0",
+                "name": "Pitloom",
+            },
+            {
+                "type": "SpdxDocument",
+                "spdxId": frag_namespace,
+                "creationInfo": "_:creationinfo0",
+                "rootElement": [f"{frag_namespace}#Sbom-1"],
+            },
+            {
+                "type": "software_Sbom",
+                "spdxId": f"{frag_namespace}#Sbom-1",
+                "creationInfo": "_:creationinfo0",
+                "rootElement": [f"{frag_namespace}#AIPackage-1"],
+            },
+            {
+                "type": "ai_AIPackage",
+                "spdxId": f"{frag_namespace}#AIPackage-1",
+                "creationInfo": "_:creationinfo0",
+                "name": "imported-model",
+            },
+        ],
+    }
+    frag_path = tmp_path / "frag-import.spdx3.json"
+    frag_path.write_text(json.dumps(envelope_fragment))
+
+    ci = spdx3.CreationInfo(
+        _id="_:ci",
+        specVersion="3.0.1",
+        created=datetime.now(timezone.utc),
+        createdBy=["https://spdx.org/agent1"],
+    )
+    main_doc = spdx3.SpdxDocument(
+        spdxId="https://spdx.org/spdxdocs/main-doc",
+        name="main-doc",
+        creationInfo=ci,
+    )
+    exporter = Spdx3JsonExporter()
+    exporter.add_document(main_doc)
+
+    merge_fragments(tmp_path, ["frag-import.spdx3.json"], exporter)
+
+    graph = json.loads(exporter.to_json(pretty=True)).get("@graph", [])
+    docs = [e for e in graph if e.get("type") == "SpdxDocument"]
+    assert len(docs) == 1
+    doc = docs[0]
+
+    imports = doc.get("import", [])
+    frag_imports = [
+        m
+        for m in imports
+        if m.get("type") == "ExternalMap" and m.get("externalSpdxId") == frag_namespace
+    ]
+    assert len(frag_imports) == 1
+    assert frag_imports[0].get("locationHint") == "frag-import.spdx3.json"


### PR DESCRIPTION
## Summary

Fragment document origin traceability: populate SpdxDocument.import_ with ExternalMap entries for merged fragments

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
