### PR TITLE
Express base-model lineage via descendantOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,16 @@ and this project adheres to
 ### Added
 
 - Native-first provenance backfills (Phase 2):
-  - `hasConcludedLicense` vs. `hasDeclaredLicense` separation for detected vs. author-asserted licenses.
-  - Native `ExternalIdentifier` (DOI) and `ExternalRef` (arXiv paper IDs, model page URLs) on `ai_AIPackage`.
-  - Native `Agent` and `publishedBy` relationship for dataset creators on `dataset_DatasetPackage`.
-  - Fragment document origin traceability: populate `SpdxDocument.import_` with `ExternalMap` entries for merged fragments.
+  - `hasConcludedLicense` vs. `hasDeclaredLicense` separation
+    for detected vs. author-asserted licenses.
+  - Native `ExternalIdentifier` (DOI) and `ExternalRef`
+    (arXiv paper IDs, model page URLs) on `ai_AIPackage`.
+  - Native `Agent` and `publishedBy` relationship for dataset creators
+    on `dataset_DatasetPackage`.
+  - Fragment document origin traceability: populate `SpdxDocument.import_`
+    with `ExternalMap` entries for merged fragments.
+  - Native `descendantOf` `Relationship` and stub `ai_AIPackage`
+    for AI base-model lineage.
 - Record metadata provenance as SPDX 3 Core `Annotation` elements alongside
   the `comment` form, controlled by `[tool.pitloom.provenance] format`.
 - `[tool.pitloom.provenance] detail` (`minimal` default / `full`) to limit
@@ -39,7 +45,8 @@ and this project adheres to
 
 ### Changed
 
-- Concluded licenses are no longer unconditionally mirrored from declared licenses when Pitloom detects a license itself.
+- Concluded licenses are no longer unconditionally mirrored
+  from declared licenses when Pitloom detects a license itself.
 - Provenance is no longer duplicated onto `dependsOn` relationships.
 - Dict-valued AI-model metadata (`properties`, `hyperparameters`) now records
   exact per-key provenance instead of one shared note per dict.

--- a/src/pitloom/assemble/spdx3/ai.py
+++ b/src/pitloom/assemble/spdx3/ai.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -186,6 +187,86 @@ def _add_external_identifiers_and_refs(
                 comment="Model page URL",
             )
         )
+
+
+@dataclass(frozen=True)
+class _LineageContext:
+    creation_info: spdx3.CreationInfo
+    doc_name: str
+    doc_uuid: str
+    exporter: Spdx3JsonExporter
+    cache: dict[str, str] = field(default_factory=dict)
+
+
+def _add_base_model_lineage(
+    ai_pkg: spdx3.ai_AIPackage,
+    ai_model: AiModelMetadata,
+    ctx: _LineageContext,
+) -> None:
+    """Add native Relationship (descendantOf) linking ai_pkg to its base model (N5)."""
+    base_model_id = ai_model.base_model or ai_model.extra_data.get("hf.base_model")
+    if not base_model_id:
+        return
+
+    base_model_str = str(base_model_id)
+    base_spdx_id = ctx.cache.get(base_model_str)
+    if base_spdx_id is None:
+        pkg_name = (
+            base_model_str.rsplit("/", maxsplit=1)[-1]
+            if "/" in base_model_str
+            else base_model_str
+        )
+        existing_spdx_id = None
+        for obj in ctx.exporter.object_set.objects:
+            if isinstance(obj, spdx3.ai_AIPackage) and obj.name in (
+                base_model_str,
+                pkg_name,
+            ):
+                existing_spdx_id = require_spdx_id(obj)
+                break
+
+        if existing_spdx_id:
+            base_spdx_id = existing_spdx_id
+        else:
+            base_spdx_id = generate_spdx_id(
+                f"AIPackage-{pkg_name}", doc_name=ctx.doc_name, doc_uuid=ctx.doc_uuid
+            )
+            base_pkg = spdx3.ai_AIPackage(
+                spdxId=base_spdx_id,
+                name=pkg_name,
+                creationInfo=ctx.creation_info,
+            )
+            url = (
+                base_model_str
+                if base_model_str.startswith(("http://", "https://"))
+                else f"https://huggingface.co/{base_model_str}"
+            )
+            base_pkg.externalRef.append(
+                spdx3.ExternalRef(
+                    externalRefType=spdx3.ExternalRefType.altWebPage,
+                    locator=[url],
+                    comment="Base model repository",
+                )
+            )
+            ctx.exporter.add_package(base_pkg)
+        ctx.cache[base_model_str] = base_spdx_id
+
+    rel_relation = ai_model.base_model_relation or ai_model.extra_data.get(
+        "hf.base_model_relation"
+    )
+    comment = f"base_model_relation:{rel_relation}" if rel_relation else None
+
+    rel = spdx3.Relationship(
+        spdxId=generate_spdx_id(
+            "Relationship-lineage", doc_name=ctx.doc_name, doc_uuid=ctx.doc_uuid
+        ),
+        from_=require_spdx_id(ai_pkg),
+        relationshipType=spdx3.RelationshipType.descendantOf,
+        to=[base_spdx_id],
+        creationInfo=ctx.creation_info,
+        comment=comment,
+    )
+    ctx.exporter.add_relationship(rel)
 
 
 def _build_ai_package(
@@ -390,12 +471,19 @@ def add_ai_models(
             model file is not shipped in the distribution, else ``"always"``/
             ``"never"``. See :func:`_should_preserve_metadata`.
     """
+    lineage_ctx = _LineageContext(
+        creation_info=creation_info,
+        doc_name=doc_name,
+        doc_uuid=doc_uuid,
+        exporter=exporter,
+    )
     for ai_model in ai_models:
         entity_spdx_id = _lookup_ai_model_entity(ai_model, registry)
         ai_pkg = _build_ai_package(
             ai_model, creation_info, doc_name, doc_uuid, entity_spdx_id=entity_spdx_id
         )
         exporter.add_package(ai_pkg)
+        _add_base_model_lineage(ai_pkg, ai_model, lineage_ctx)
         emit_provenance(
             subject=ai_pkg,
             provenance=ai_model.provenance,

--- a/src/pitloom/assemble/spdx3/document.py
+++ b/src/pitloom/assemble/spdx3/document.py
@@ -14,8 +14,10 @@ from typing import Any
 from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.assemble.spdx3.ai import (
+    _add_base_model_lineage,
     _build_ai_package,
     _emit_source_metadata,
+    _LineageContext,
     add_ai_models,
 )
 from pitloom.assemble.spdx3.creation_info import build_creation_info
@@ -459,6 +461,13 @@ def build_model(
     if entity_spdx_id is not None:
         ai_pkg.spdxId = entity_spdx_id
     exporter.add_package(ai_pkg)
+    lineage_ctx = _LineageContext(
+        creation_info=spdx_ci,
+        doc_name=doc_name,
+        doc_uuid=doc_uuid,
+        exporter=exporter,
+    )
+    _add_base_model_lineage(ai_pkg, model, lineage_ctx)
     emit_provenance(
         subject=ai_pkg,
         provenance=model.provenance,

--- a/src/pitloom/core/ai_metadata.py
+++ b/src/pitloom/core/ai_metadata.py
@@ -173,6 +173,12 @@ class AiModelMetadata:  # pylint: disable=too-many-instance-attributes
     arxiv_ids: list[str] = field(default_factory=list)
     url: str | None = None
 
+    # Base model lineage (parent model ID and relation type e.g. "finetune",
+    # "quantized")
+    # Maps to SPDX 3: Relationship (descendantOf)
+    base_model: str | None = None
+    base_model_relation: str | None = None
+
     # General model metadata
     domain: list[str] = field(default_factory=list)
 

--- a/src/pitloom/extract/_huggingface.py
+++ b/src/pitloom/extract/_huggingface.py
@@ -849,6 +849,8 @@ def read_huggingface(source: str) -> AiModelMetadata:
         doi=tag_data.doi_val,
         arxiv_ids=tag_data.arxiv_ids,
         url=hf_url,
+        base_model=base_model_id,
+        base_model_relation=tag_data.base_model_relation,
         type_of_model=type_of_model,
         architecture=architecture,
         hyperparameters=hyperparameters,

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1615,3 +1615,39 @@ def test_generate_deployed_sbom_mocked_pipdeptree(
     packages = [e for e in graph if e.get("type") == "software_Package"]
     requests_pkg = next(p for p in packages if p["name"] == "requests")
     assert requests_pkg["software_packageVersion"] == "2.31.0"
+
+
+def test_build_model_base_model_lineage() -> None:
+    """build_model() must emit a stub base model ai_AIPackage and a descendantOf
+    Relationship when base_model and base_model_relation are present (N5).
+    """
+    meta = AiModelMetadata(
+        name="my-finetuned-model",
+        base_model="Qwen/Qwen2.5-Math-1.5B",
+        base_model_relation="finetune",
+    )
+    exporter = build_model(meta, CreationMetadata())
+    graph = json.loads(exporter.to_json(pretty=True)).get("@graph", [])
+
+    ai_pkgs = [e for e in graph if e.get("type") == "ai_AIPackage"]
+    assert len(ai_pkgs) == 2
+    derived_pkg = next(p for p in ai_pkgs if p["name"] == "my-finetuned-model")
+    base_pkg = next(p for p in ai_pkgs if p["name"] == "Qwen2.5-Math-1.5B")
+
+    ext_refs = base_pkg.get("externalRef", [])
+    assert any(
+        r.get("externalRefType") == "altWebPage"
+        and "https://huggingface.co/Qwen/Qwen2.5-Math-1.5B" in r.get("locator", [])
+        for r in ext_refs
+    )
+
+    rels = [e for e in graph if e.get("type") == "Relationship"]
+    lineage_rels = [
+        r
+        for r in rels
+        if r.get("relationshipType") == "descendantOf"
+        and r.get("from") == derived_pkg["spdxId"]
+        and base_pkg["spdxId"] in r.get("to", [])
+    ]
+    assert len(lineage_rels) == 1
+    assert lineage_rels[0].get("comment") == "base_model_relation:finetune"


### PR DESCRIPTION
## Summary

Express base-model lineage via native SPDX 3 descendantOf relationships connecting fine-tuned/quantized AI model packages to stub base-model ai_AIPackage elements with repository ExternalRef links and relation type comments.



## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
