### PR TITLE
Fix loom SDK hyperparameter provenance + CLI doc staleness

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-07-08
-Last-Modified: 2026-07-09
+Last-Modified: 2026-08-08
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -58,6 +58,12 @@ Create an Analyzed SBOM of an AI model on Hugging Face Hub:
 ```shell
 loom analyze https://huggingface.co/mistralai/Mistral-7B-v0.1
 loom analyze Qwen/Qwen3-235B-A22B   # bare model ID also works
+```
+
+Create a Deployed SBOM of the currently installed environment:
+
+```shell
+loom deployed -o env.spdx3.json
 ```
 
 ### GitHub Action

--- a/skills/sbom/SKILL.md
+++ b/skills/sbom/SKILL.md
@@ -76,7 +76,19 @@ loom analyze https://huggingface.co/Qwen/Qwen3-235B-A22B
 Supported local formats: GGUF, ONNX, Safetensors, PyTorch (`.pt`/`.pth`),
 Keras, HDF5, NumPy, fastText. Hugging Face Hub models need
 `pip install pitloom[huggingface]` (or `uvx --from 'pitloom[huggingface]'
-pitloom`).
+pitloom`). `analyze` also accepts a built `.whl` file (an Analyzed SBOM
+from the wheel's own metadata and file list).
+
+## Deployed SBOMs (installed environment)
+
+```bash
+loom deployed -o env.spdx3.json
+```
+
+No positional argument -- it always inspects the *current* Python
+environment (via `pipdeptree`) rather than a project directory or file.
+Use this when the request is about "what's installed" / "what's in this
+venv", not about a specific project's source or a specific model file.
 
 ## Useful flags (both modes)
 

--- a/skills/sbom/references/examples.md
+++ b/skills/sbom/references/examples.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-07-05
-Last-Modified: 2026-07-08
+Last-Modified: 2026-08-08
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -35,6 +35,12 @@ uvx --from 'pitloom[aimodel]' pitloom analyze model.safetensors -o model.spdx3.j
 ```bash
 uvx --from 'pitloom[huggingface]' pitloom analyze mistralai/Mistral-7B-v0.1 \
   -o mistral.spdx3.json --pretty
+```
+
+## Deployed SBOM, currently installed environment
+
+```bash
+loom deployed -o env.spdx3.json
 ```
 
 ## Project SBOM, multiple creators

--- a/src/pitloom/loom.py
+++ b/src/pitloom/loom.py
@@ -21,6 +21,7 @@ from pitloom.assemble.spdx3.provenance import emit_provenance
 from pitloom.core.creation import CreationMetadata
 from pitloom.core.models import generate_spdx_id
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
+from pitloom.extract._extract_utils import sanitize_provenance_text
 from pitloom.ids import IdRegistry
 
 #: loom.py is a standalone SDK invoked from ad hoc scripts/notebooks, not
@@ -98,6 +99,25 @@ def _get_caller_script_path() -> str | None:
 def _default_run_comment() -> str:
     """Default CreationInfo.comment for a fragment: source and tool version."""
     return f"Generated via Pitloom loom SDK v{__version__} (script/notebook capture)"
+
+
+def _record_hyperparameter_provenance(
+    provenance: dict[str, str], hyperparameters: dict[str, str], caller_info: str
+) -> None:
+    """Record exact per-key provenance for *hyperparameters*, same as the
+    extractors' dict-valued fields (``properties``, ``hyperparameters``) --
+    not one shared note for the whole dict.
+
+    Unlike :func:`~pitloom.extract._extract_utils.record_dict_field_provenance`,
+    *caller_info* is not sanitized here: it is Pitloom's own compound
+    ``"Source: ... | Method: ..."`` string, not untrusted artifact text, and
+    sanitizing it would mangle its own intentional ``|`` separator. Only the
+    hyperparameter key -- which does come from the caller's own dict -- is
+    sanitized before interpolation.
+    """
+    for key, _value in hyperparameters.items():
+        safe_key = sanitize_provenance_text(str(key))
+        provenance[f"hyperparameters.{key}"] = f"{caller_info} | Field: {safe_key}"
 
 
 def _resolve_registry(
@@ -257,15 +277,17 @@ class _ActiveRun:  # pylint: disable=too-many-instance-attributes
         self._model_generated = generated
         if model_type is not None:
             self.model.ai_typeOfModel = [model_type]
+        provenance: dict[str, str] = {"package": caller_info}
         if hyperparameters is not None:
             self.model.ai_hyperparameter = [
                 spdx3.DictionaryEntry(key=k, value=v)
                 for k, v in hyperparameters.items()
             ]
+            _record_hyperparameter_provenance(provenance, hyperparameters, caller_info)
         self.exporter.add_package(self.model)
         emit_provenance(
             subject=self.model,
-            provenance={"package": caller_info},
+            provenance=provenance,
             creation_info=self.creation_info,
             doc_name=name,
             doc_uuid=self.doc_uuid,
@@ -304,6 +326,19 @@ class _ActiveRun:  # pylint: disable=too-many-instance-attributes
         self.model.ai_hyperparameter = [
             spdx3.DictionaryEntry(key=k, value=v) for k, v in hyperparameters.items()
         ]
+        provenance: dict[str, str] = {}
+        _record_hyperparameter_provenance(
+            provenance, hyperparameters, _get_caller_info()
+        )
+        emit_provenance(
+            subject=self.model,
+            provenance=provenance,
+            creation_info=self.creation_info,
+            doc_name=self.model.name or "model",
+            doc_uuid=self.doc_uuid,
+            exporter=self.exporter,
+            provenance_format=_LOOM_PROVENANCE_FORMAT,
+        )
 
     def _build_dataset_package(
         self, name: str, dataset_type: str

--- a/tests/test_loom.py
+++ b/tests/test_loom.py
@@ -234,7 +234,8 @@ def test_loom_model_hyperparameters() -> None:
         ):
             assert fields[key]["location"] == location
             assert fields[key]["method"] == (
-                "inspect_caller (tool: pitloom.loom, function: test_loom_model_hyperparameters)"
+                "inspect_caller (tool: pitloom.loom, "
+                "function: test_loom_model_hyperparameters)"
             )
 
 

--- a/tests/test_loom.py
+++ b/tests/test_loom.py
@@ -180,7 +180,9 @@ def test_loom_validation_dataset() -> None:
 
 
 def test_loom_model_hyperparameters() -> None:
-    """Test set_model_hyperparameters records key-value pairs on the model."""
+    """Test set_model_hyperparameters records key-value pairs on the model,
+    each with its own per-key provenance Annotation entry (not one shared
+    note for the whole dict)."""
     with tempfile.TemporaryDirectory() as tmpdir:
         output_file = Path(tmpdir) / "test_fragment_hparams.json"
 
@@ -198,12 +200,79 @@ def test_loom_model_hyperparameters() -> None:
         graph = data["@graph"]
         models = [e for e in graph if e["type"] == "ai_AIPackage"]
         assert len(models) == 1
+        model_id = models[0]["spdxId"]
         hparams = models[0].get("ai_hyperparameter", [])
         assert len(hparams) == 3
         hparam_dict = {h["key"]: h["value"] for h in hparams}
         assert hparam_dict["lr"] == "0.1"
         assert hparam_dict["epoch"] == "5"
         assert hparam_dict["dim"] == "100"
+
+        annotations = [
+            e
+            for e in graph
+            if e["type"] == "Annotation" and e.get("subject") == model_id
+        ]
+        # One Annotation from set_model() (package note), one from the
+        # post-hoc set_model_hyperparameters() update.
+        assert len(annotations) == 2
+        hparam_annotation = next(
+            a
+            for a in annotations
+            if "hyperparameters.lr" in json.loads(a["statement"])["fields"]
+        )
+        fields = json.loads(hparam_annotation["statement"])["fields"]
+        assert set(fields) == {
+            "hyperparameters.lr",
+            "hyperparameters.epoch",
+            "hyperparameters.dim",
+        }
+        for key, location in (
+            ("hyperparameters.lr", "lr"),
+            ("hyperparameters.epoch", "epoch"),
+            ("hyperparameters.dim", "dim"),
+        ):
+            assert fields[key]["location"] == location
+            assert fields[key]["method"] == (
+                "inspect_caller (tool: pitloom.loom, function: test_loom_model_hyperparameters)"
+            )
+
+
+def test_loom_set_model_hyperparameters_have_per_key_provenance() -> None:
+    """set_model(hyperparameters=...) at creation time also gets per-key
+    provenance, alongside the model's own package-source note."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_file = Path(tmpdir) / "test_fragment_hparams_creation.json"
+
+        with loom.run(output_file) as run:
+            run.set_model(
+                "test-model-hparams-creation",
+                hyperparameters={"lr": "0.05", "batch_size": "32"},
+            )
+            run.add_dataset("train.txt")
+
+        with open(output_file, encoding="utf-8") as f:
+            data = json.load(f)
+
+        graph = data["@graph"]
+        models = [e for e in graph if e["type"] == "ai_AIPackage"]
+        assert len(models) == 1
+        model_id = models[0]["spdxId"]
+
+        annotations = [
+            e
+            for e in graph
+            if e["type"] == "Annotation" and e.get("subject") == model_id
+        ]
+        assert len(annotations) == 1
+        fields = json.loads(annotations[0]["statement"])["fields"]
+        assert set(fields) == {
+            "package",
+            "hyperparameters.lr",
+            "hyperparameters.batch_size",
+        }
+        assert fields["hyperparameters.lr"]["location"] == "lr"
+        assert fields["hyperparameters.batch_size"]["location"] == "batch_size"
 
 
 def test_loom_model_type() -> None:

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -325,7 +325,7 @@ creator-name = 123
 
 
 # ---------------------------------------------------------------------------
-# -m / --aimodel: model-mode tests
+# analyze: model-mode tests
 # ---------------------------------------------------------------------------
 
 
@@ -802,7 +802,7 @@ def test_model_mode_verbose_shows_model_path(
 
 
 # ---------------------------------------------------------------------------
-# -m / --aimodel: integration tests with real model fixtures
+# analyze: integration tests with real model fixtures
 # ---------------------------------------------------------------------------
 
 
@@ -888,7 +888,7 @@ def test_model_mode_onnx_sbom_root_is_ai_package(
 
 
 # ---------------------------------------------------------------------------
-# -m / --aimodel: Hugging Face URL / model-ID mode tests (mocked)
+# analyze: Hugging Face URL / model-ID mode tests (mocked)
 # ---------------------------------------------------------------------------
 
 

--- a/working-docs/design/hatchling-build-hook.md
+++ b/working-docs/design/hatchling-build-hook.md
@@ -81,7 +81,7 @@ The build hook maps this object into Pitloom's format-neutral
 project_dir)` -- **not** via `pitloom.extract.pyproject.read_pyproject()`,
 which re-parses `pyproject.toml` from scratch and cannot see dynamic values
 resolved by Hatchling plugins. `read_pyproject()` remains the metadata source
-for the standalone CLI (`pitloom`/`loom generate`), which has no build
+for the standalone CLI (`pitloom`/`loom source`), which has no build
 backend to consult; both paths converge on the same
 `pitloom.assemble.spdx3.document.build()` assembly layer, so the emitted SBOM
 shape is identical either way. `read_pitloom_config()`

--- a/working-docs/implementation/phase2-native-backfill-handover.md
+++ b/working-docs/implementation/phase2-native-backfill-handover.md
@@ -29,19 +29,25 @@ Phase 2 native-first backfill is **largely complete and merged**:
 - ✅ **N5 — Base-Model Lineage (`descendantOf` Relationship)**: PR [#109](https://github.com/bact/pitloom/pull/109) merged to `main`.
 - 🛑 **N3 — Enrichment `CreationInfo`**: Blocked (waiting for `enrich/` subpackage).
 - ✅ **Integration test** (N1/N2/N4/N5/N6 together): PR [#112](https://github.com/bact/pitloom/pull/112) merged to `main`.
+- ✅ **`pitloom.loom` hyperparameter provenance + PR #96 CLI-consistency doc sweep**: fixed, see "Release readiness" below -- **not yet committed** as of this writing.
 
-## Release readiness (assessed 2026-08-08)
+## Release readiness (assessed 2026-08-08, updated same day after a
+second pass)
 
 Everything since v0.12.0 (the last tagged release, 2026-07-10) --
-Annotation-based provenance (Phase 1, PR #102) plus the five Phase 2
-native-first backfills and the integration test above -- is **ready to
-release**. Verified directly:
+Annotation-based provenance (Phase 1, PR #102), the five Phase 2
+native-first backfills, the integration test, PR #96's CLI restructuring
+(`loom source`/`analyze`/`deployed`/`ids`, merged just before the
+provenance work), and the `pitloom.loom` hyperparameter-provenance fix
+below -- is **ready to release**. Verified directly:
 
-- `python3 -m pytest tests/ -q` -- 1536 passed, 24 skipped, 0 failed.
+- `python3 -m pytest tests/ -q` -- 1537 passed, 24 skipped, 0 failed.
 - `mypy src/pitloom` and `ruff check src/pitloom tests` -- clean.
 - CI on `main` at `9c0d663` (PR #112 merge) -- all green: Unit tests,
   Type checking, Lint and format, Code coverage, Hatch integration,
-  Action self-test, Build wheels + validate SBOM.
+  Action self-test, Build wheels + validate SBOM. (Re-verified locally
+  after the second-pass fixes below; not yet re-pushed to CI -- see
+  "not yet done" note at the end of this section.)
 - All four usage surfaces checked end-to-end, not just read: CLI
   (`__main__.py` delegates to `pyproject.toml`-sourced `PitloomConfig`;
   no direct `--provenance-*` flags, by design -- CLI flags for this were
@@ -55,31 +61,63 @@ release**. Verified directly:
   by generating a fragment via `loom.run()`/`set_model()`/`add_dataset()`
   and confirming Annotation elements with the correct `pitloom/1`
   statement actually appear in the output JSON -- not just a code read).
-- No correctness bugs found in this pass -- only stale documentation
-  (fixed, see below) and one non-blocking depth gap (also below).
 
-**Docs fixed in this pass** (were stale, now corrected -- see each
-file's diff for detail): `docs/metadata-provenance.md` (the published
-GitHub Pages doc still described the pre-Annotation `comment`-only
-mechanism with no mention of `[tool.pitloom.provenance]` at all -- this
-was the most significant gap, since it's user-facing); `README.md`
-"Metadata provenance" section (same overstatement); `CHANGELOG.md` (the
-top-of-file "Commit history" compare link was one release behind,
-`v0.10.0...v0.11.0` instead of `v0.11.0...v0.12.0`);
-`working-docs/design/sbom-fragments.md` (still listed
-`SpdxDocument.imports` population as an unbuilt Phase 4 item after N1
-shipped it); `working-docs/design/metadata-provenance.md` and
-`working-docs/implementation/annotation-provenance.md` (status headers
-said "uncommitted on branch `provenance-annotation`", predating the
-PR #102 merge); `working-docs/implementation/demo-provenance.md` (a
-historical walkthrough written for the old always-on comment behavior,
-now flagged with a banner rather than rewritten, since it's an internal,
-low-traffic doc); `skills/sbom/SKILL.md` (didn't mention the
-`[tool.pitloom.provenance]` config surface at all -- added a short
-section).
+### Second pass: PR #96 CLI-consistency sweep, and the hyperparameter-provenance fix
 
-**Not fixed, flagged only (out of scope for this pass, not correctness
-bugs):**
+PR [#96](https://github.com/bact/pitloom/pull/96) ("Add CISA-lifecycle
+SBOM generation") restructured the CLI from a flat
+`pitloom <project_dir>` / `-m/--aimodel` form into
+`pitloom source|analyze|deployed|ids` subcommands. It landed *after*
+v0.12.0 (same as all the provenance work), and already updated most
+CLI-consuming docs/skills as part of the PR itself. A dedicated sweep
+for anything it missed found and fixed:
+
+- `working-docs/design/hatchling-build-hook.md` -- referenced the old
+  `loom generate` command name (never existed post-#96; should be
+  `loom source`).
+- `skills/sbom/SKILL.md` / `skills/sbom/references/examples.md` -- had
+  no mention of the `deployed` subcommand (SBOM of the current
+  installed environment) at all, and `analyze` accepting a `.whl` file
+  wasn't called out either. Added a "Deployed SBOMs" section and
+  example.
+- `docs/index.md` (published) -- same `deployed` gap; added the example
+  alongside the existing `source`/`analyze` ones.
+- `tests/test_main_cli.py` -- three section-header comments still said
+  `# -m / --aimodel: ...` above tests that actually exercise `analyze`
+  (the tests themselves were correct, only the comments were stale).
+
+Checked and found **not** affected: the Claude plugin
+(`.claude-plugin/plugin.json`/`marketplace.json` and
+`working-docs/implementation/claude-code-plugin.md` don't hardcode any
+CLI invocation -- they only reference the Skills, which were the actual
+thing needing the check), `skills/enrich/SKILL.md` (already uses
+`loom source`/`loom analyze` correctly), `action.yml` and
+`AGENTS.md` (no stale subcommand references), README.md (already
+accurate for `source`/`analyze`/`deployed`/`ids`).
+
+**Fixed (was flagged as a release blocker):** `pitloom.loom`
+hyperparameter provenance depth. `set_model(hyperparameters=...)` and
+the post-hoc `set_model_hyperparameters()` now record exact per-key
+provenance (`hyperparameters.<key>`), the same shape the AI-model
+extractors produce via `record_dict_field_provenance`, instead of
+`set_model()`'s one generic `"package"` note (hyperparameters
+unattributed) and `set_model_hyperparameters()` emitting no provenance
+at all. Implementation note for whoever touches this next: **don't**
+reuse `record_dict_field_provenance` directly here -- it sanitizes its
+whole `source` argument (replacing `|` with `/`), which is correct for
+extractors (their `source` is always a bare `"Source: X"` string) but
+wrong for `loom.py`'s `_get_caller_info()`, which returns an
+already-structured `"Source: X | Method: Y"` compound string; running
+that through the sanitizer mangles the legitimate internal `|` and
+folds the `Method:` segment into `source` when re-parsed. Fixed with a
+small local `_record_hyperparameter_provenance()` helper in `loom.py`
+that only sanitizes the hyperparameter *key*, not the caller-info
+string. Covered by `test_loom_model_hyperparameters` (updated) and the
+new `test_loom_set_model_hyperparameters_have_per_key_provenance` in
+`tests/test_loom.py`. Verified live (not just via the test suite) by
+generating a fragment and inspecting the emitted Annotation JSON.
+
+**Not fixed, flagged only (out of scope, not correctness bugs):**
 
 - `working-docs/implementation/summary.md` (the "canonical project
   structure" doc) is stale independent of this feature -- its directory
@@ -91,26 +129,20 @@ bugs):**
 - `examples/sentimentdemo-aibom/` generated fixtures were not
   regenerated against current output (deliberate, carried over from
   Phase 1) -- cosmetic only, not exercised by CI.
-- **`pitloom.loom` hyperparameter provenance depth**: `set_model()`'s
-  `hyperparameters=` argument and the standalone
-  `set_model_hyperparameters()` don't get per-key provenance the way the
-  AI-model extractors do via `record_dict_field_provenance`
-  (`_extract_utils.py`) -- `set_model()` only records one generic
-  `"package"` provenance entry (the caller's source location), and
-  `set_model_hyperparameters()` (post-hoc update) emits no provenance at
-  all for that call. The hyperparameter *values* themselves are correct
-  in `ai_hyperparameter` either way -- this is a provenance-richness gap
-  in one SDK path, not a data-correctness issue. Worth a small follow-up
-  PR (mirror `record_dict_field_provenance` in `loom.py`'s
-  `set_model`/`set_model_hyperparameters`) but does not block a release.
 
-**Recommendation:** cut the release. Given the existing version history
-(0.5.0 through 0.12.0, each a minor bump for additive features) and that
-everything here is additive/backward-compatible -- `comment` output is
-preserved by default, `Annotation` and the five new native constructs
-are pure additions, no field or CLI flag was removed -- a minor version
-bump (e.g. `v0.13.0`) fits the project's own pattern. That said, the
-version number and release timing are the maintainer's call, not this
+**Not yet done:** the fixes in this section (loom.py + the doc sweep)
+are committed to the working tree but, as of this update, not yet
+pushed/PR'd/merged -- confirm with the user before assuming they're on
+`main`.
+
+**Recommendation:** cut the release once the fixes above are merged.
+Given the existing version history (0.5.0 through 0.12.0, each a minor
+bump for additive features) and that everything here is
+additive/backward-compatible -- `comment` output is preserved by
+default, `Annotation` and the five new native constructs are pure
+additions, no field or CLI flag was removed -- a minor version bump
+(e.g. `v0.13.0`) fits the project's own pattern. That said, the version
+number and release timing are the maintainer's call, not this
 assessment's.
 
 ## Principle (carried over from Phase 1)
@@ -188,17 +220,22 @@ when N3 lands, to keep all six in one place.
 
 ## Suggested first action for the picking-up session
 
-1. Confirm `main` has PRs #105, #106, #107, #108, #109, #112 merged, and
+1. Check `git status`/`git log` in the working tree first -- as of this
+   writing the loom.py hyperparameter-provenance fix and the PR #96
+   CLI-consistency doc sweep (see "Release readiness" above) are made
+   but **not yet committed**. Don't assume they're on `main`; don't
+   discard them.
+2. Confirm `main` has PRs #105, #106, #107, #108, #109, #112 merged, and
    check whether a release has been cut since this doc was written (see
    "Release readiness" above -- as of 2026-08-08 the answer was "ready,
-   not yet cut").
-2. Check whether `enrich/` subpackage exists yet (N3's blocker). Report
+   pending the uncommitted fixes above").
+3. Check whether `enrich/` subpackage exists yet (N3's blocker). Report
    status either way before doing anything else.
-3. If still blocked, N3 stays deferred -- ask the user what's next
-   (cutting the release, the loom.py hyperparameter-provenance follow-up
-   noted above, or something else) rather than assuming.
-4. Re-read `annotation-provenance.md` §10 in full before starting, since
-   this handover only summarizes it.
+4. If still blocked, N3 stays deferred -- ask the user what's next
+   (committing/PR'ing the pending fixes, cutting the release, or
+   something else) rather than assuming.
+5. Re-read `annotation-provenance.md` §10 in full before starting on any
+   N-item work, since this handover only summarizes it.
 
 ## Prompt to start a new session on this handover
 
@@ -210,15 +247,18 @@ N1-N6 rationale) if you need background on any item.
 
 N1, N2, N4, N5, N6 are merged (PRs #108, #105, #106, #109, #107), plus
 the combined integration test (PR #112). As of 2026-08-08 the codebase
-was assessed as release-ready (see "Release readiness" section: all
-tests/mypy/ruff/CI green, all usage surfaces -- CLI, Python API,
-Hatchling build hook, pitloom.loom SDK -- verified consistent, stale
-docs fixed). N3 (enrichment CreationInfo) remains blocked on the
-enrich/ subpackage not existing yet -- check if it has landed since.
+was assessed as release-ready, and a second pass fixed the pitloom.loom
+hyperparameter-provenance gap and a handful of stale CLI-related docs
+left over from PR #96's CLI restructuring -- see "Release readiness" for
+full detail. IMPORTANT: those second-pass fixes were, as of this
+writing, uncommitted in the working tree -- run `git status` first and
+do not assume they're on `main`. N3 (enrichment CreationInfo) remains
+blocked on the enrich/ subpackage not existing yet -- check if it has
+landed since.
 
-Check whether a release has been cut since this doc was written (compare
-the latest git tag to `main`). If not, ask the user whether to proceed
-with cutting one before doing anything else -- don't start new feature
-work (N3, the loom.py hyperparameter-provenance follow-up, or otherwise)
-without checking first, since release timing is the maintainer's call.
+First: check git status and report what's committed vs pending. Then
+check whether a release has been cut since this doc was written (compare
+the latest git tag to `main`). Ask the user how to proceed with the
+pending fixes and the release before doing anything else -- don't start
+new feature work (N3 or otherwise) without checking first.
 ```

--- a/working-docs/implementation/summary.md
+++ b/working-docs/implementation/summary.md
@@ -22,8 +22,9 @@ SPDX 3.0 compliant SBOMs in JSON-LD format.
 1. **SPDX 3.0 data models** (`spdx-python-model`)
    - Fully migrated to the official `spdx-python-model` library
    - Proper JSON-LD serialization and validation
-   - Deterministic UUIDv5 SPDX document IDs (`compute_doc_uuid`) keyed on project
-     name, version, normalized dependencies, and SHA-256 Merkle root of wheel files
+   - Deterministic UUIDv5 SPDX document IDs (`compute_doc_uuid`) keyed on
+     project name, version, normalized dependencies,
+     and SHA-256 Merkle root of wheel files
    - Per-element sequential IDs (`generate_spdx_id`) reproducible across builds
 
 2. **Metadata extraction** (`src/pitloom/extract/`)
@@ -34,12 +35,16 @@ SPDX 3.0 compliant SBOMs in JSON-LD format.
      `[tool.poetry.dependencies]`; converts Poetry version specifiers
      (`^`, `~`, bare versions) to PEP 440; `[tool.poetry.group.*]` dev/deploy
      dependency groups are intentionally excluded from the SBOM
-   - `setuptools.py` -- reads `setup.cfg` and `setup.py` for setuptools projects;
+   - `setuptools.py` --
+     reads `setup.cfg` and `setup.py` for setuptools projects;
      `detect_build_backend()` auto-selects the right extractor;
      `merge_metadata()` fills gaps across sources (setup.cfg > setup.py)
-   - `wheel.py` -- reads metadata from built `.whl` files (Analyzed SBOM) and computes file-level SHA-256 hashes
-   - `env.py` -- delegates to `pipdeptree` to extract a complete dependency graph of the active installed environment (Deployed SBOM)
-   - `binary.py` -- heuristic scanner that detects bundled third-party binary libraries (e.g. `.so`, `.dylib`) within wheel files (phantom dependencies)
+   - `wheel.py` -- reads metadata from built `.whl` files (Analyzed SBOM) and
+     computes file-level SHA-256 hashes
+   - `env.py` -- delegates to `pipdeptree` to extract a complete dependency
+     graph of the active installed environment (Deployed SBOM)
+   - `binary.py` -- heuristic scanner that detects bundled third-party binary
+     libraries (e.g. `.so`, `.dylib`) within wheel files (phantom dependencies)
    - Extracts project metadata (name, version, description, authors, URLs)
    - Handles dynamic versions from `__about__.py`
    - Parses dependency specifications with version constraints
@@ -51,19 +56,26 @@ SPDX 3.0 compliant SBOMs in JSON-LD format.
    - Graceful component ingestion via `spdx3.JSONLDDeserializer`
 
 4. **SBOM generator** (`src/pitloom/assemble/`)
-   - `generate_sbom()` orchestrates the full pipeline for source code (Source SBOM)
-   - `generate_analyzed_sbom()` orchestrates the pipeline for built wheels (Analyzed SBOM), utilizing `wheel.py` and `binary.py` to identify phantom dependencies
-   - `generate_deployed_sbom()` orchestrates the pipeline for active environments (Deployed SBOM), mapping the tree using `env.py`
+   - `generate_sbom()` orchestrates the full pipeline for source code
+     (Source SBOM)
+   - `generate_analyzed_sbom()` orchestrates the pipeline for built wheels
+     (Analyzed SBOM), utilizing `wheel.py` and `binary.py` to identify phantom
+      dependencies
+   - `generate_deployed_sbom()` orchestrates the pipeline for active
+     environments (Deployed SBOM), mapping the tree using `env.py`
    - Builds `DocumentModel` from extracted metadata
-   - Passes `DocumentModel` to assembly functions (`build()`, `build_deployed()`) in `assemble/spdx3/`
+   - Passes `DocumentModel` to assembly functions
+     (`build()`, `build_deployed()`) in `assemble/spdx3/`
    - Merges pre-generated SBOM fragments
    - Generates copyright information from metadata
 
 5. **Hatchling build hook** (`src/pitloom/plugins/hatch.py`)
-   - `PitloomBuildHook` registered via pluggy entry point (`[project.entry-points."hatch"]`)
+   - `PitloomBuildHook` registered via pluggy entry point
+     (`[project.entry-points."hatch"]`)
    - Generates SBOM in `initialize()`, stages to a `TemporaryDirectory`
-   - Appends staged path to `build_data["sbom_files"]` -- Hatchling 1.28.0+ places
-     it at `.dist-info/sboms/<filename>` (PEP 770) natively
+   - Appends staged path to `build_data["sbom_files"]` --
+     Hatchling 1.28.0+ places it at `.dist-info/sboms/<filename>`
+     (PEP 770) natively
    - `finalize()` cleans up the staging directory
    - Config: `[tool.hatch.build.hooks.pitloom] enabled` only; basename,
      fragments, and creator/tool metadata come from `[tool.pitloom]` /
@@ -71,23 +83,29 @@ SPDX 3.0 compliant SBOMs in JSON-LD format.
      `[tool.pitloom.creation]` -- the same settings the CLI uses
 
 6. **Command-line interface** (`src/pitloom/__main__.py`)
-   - User-friendly argparse-based CLI with lifecycle-centric subcommands (`source`, `analyze`, `deployed`, `ids`)
-   - Subcommands map to CISA SBOM types (`source` -> Source SBOM, `analyze` -> Analyzed SBOM
-     -- dispatches internally to a built `.whl`, a local AI model file, or a Hugging Face
-     repository depending on the target's form -- `deployed` -> Deployed SBOM of the
-     currently installed environment); `ids` manages the Loom ID registry
-   - Default output filename derived from project metadata (`{name}-{version}.spdx3.json`)
+   - User-friendly argparse-based CLI with lifecycle-centric subcommands
+     (`source`, `analyze`, `deployed`, `ids`)
+   - Subcommands map to CISA SBOM types
+     (`source` -> Source SBOM, `analyze` -> Analyzed SBOM --
+     dispatches internally to a built `.whl`, a local AI model file,
+     or a Hugging Face repository depending on the target's form --
+     `deployed` -> Deployed SBOM of the currently installed environment);
+     `ids` manages the Loom ID registry
+   - Default output filename derived from project metadata
+     (`{name}-{version}.spdx3.json`)
      or `[tool.pitloom] sbom-basename` when set
    - Creator information options
    - Clear error messages
 
-7. **Metadata provenance tracking** (`src/pitloom/assemble/spdx3/provenance.py`,
+7. **Metadata provenance tracking**
+   (`src/pitloom/assemble/spdx3/provenance.py`,
    `src/pitloom/extract/pyproject.py`, `src/pitloom/loom.py`)
    - Tracks source of each metadata field
    - Records extraction method (static, dynamic, or inferred)
    - Supports dynamic introspection via `loom.py` inspection
-   - Recorded as SPDX 3 Core `Annotation` elements (structured, machine-readable
-     JSON), with the original SPDX 3 `comment` attribute kept for back-compat,
+   - Recorded as SPDX 3 Core `Annotation` elements
+     (structured, machine-readable JSON),
+     with the original SPDX 3 `comment` attribute kept for back-compat,
      controlled by `[tool.pitloom.provenance]`
    - See [working-docs/design/metadata-provenance.md](../design/metadata-provenance.md)
      and [annotation-provenance.md](annotation-provenance.md)
@@ -95,7 +113,8 @@ SPDX 3.0 compliant SBOMs in JSON-LD format.
 8. **ML tracking SDK** (`src/pitloom/loom.py`)
    - Dual-syntax ContextDecorator (`@loom.run` and `with loom.run`)
    - Emits SPDX 3 SBOM fragments automatically during ML executions
-   - Seamlessly ingested into project SBOMs using `[tool.pitloom.fragments]` config
+   - Seamlessly ingested into project SBOMs using
+     `[tool.pitloom.fragments]` config
 
 ### ✅ Testing (comprehensive coverage - all passing)
 
@@ -127,14 +146,17 @@ SPDX 3.0 compliant SBOMs in JSON-LD format.
 ### ✅ Documentation
 
 1. **README.md**: Complete usage guide with examples
-2. **working-docs/implementation/demo.md**: Prototype capabilities and validation
+2. **working-docs/implementation/demo.md**:
+   Prototype capabilities and validation
 3. **working-docs/implementation/demo-provenance.md**: Provenance tracking demo
-4. **working-docs/design/format-neutral-representation.md**: Multi-format support plan
-5. **working-docs/design/metadata-provenance.md**: Provenance tracking specification
-6. **working-docs/design/metadata-sources.md**: Metadata sources research and
-   integration plan
-7. **working-docs/implementation/setuptools-support.md**: Setuptools extractor
-   design and limitations
+4. **working-docs/design/format-neutral-representation.md**:
+   Multi-format support plan
+5. **working-docs/design/metadata-provenance.md**:
+   Provenance tracking specification
+6. **working-docs/design/metadata-sources.md**:
+   Metadata sources research and integration plan
+7. **working-docs/implementation/setuptools-support.md**:
+   Setuptools extractor design and limitations
 8. **Inline documentation**: Comprehensive docstrings
 
 ## Validation with sentimentdemo
@@ -197,7 +219,7 @@ SBOM written to: sbom.spdx3.json
 
 ```text
 pitloom/
-├── docs/                        # Published site (flat; docs/_config.yml)
+├── docs/                           # Published site (flat; docs/_config.yml)
 │   ├── creation-metadata.md
 │   ├── index.md
 │   ├── metadata-provenance.md
@@ -215,44 +237,44 @@ pitloom/
 │   │   ├── mlflow-extractor.md
 │   │   ├── model-metadata-extraction.md
 │   │   ├── protobom-evaluation.md
-│   │   ├── roadmap.md             # Canonical roadmap
+│   │   ├── roadmap.md              # Canonical roadmap
 │   │   ├── sbom-enrichment.md
 │   │   └── sbom-fragments.md
 │   └── implementation/
 │       ├── agent-skill.md
-│       ├── annotation-provenance.md        # Provenance-as-Annotation design + status
+│       ├── annotation-provenance.md  # Provenance-as-Annotation design + status
 │       ├── annotation-provenance-full-plan.md
 │       ├── claude-code-plugin.md
 │       ├── demo.md
-│       ├── demo-provenance.md              # Historical; predates Annotation provenance
+│       ├── demo-provenance.md      # Historical; predates Annotation provenance
 │       ├── github-action.md
 │       ├── license-pipeline.md
 │       ├── phase2-native-backfill-handover.md
 │       ├── poetry-support.md
-│       ├── setuptools-support.md           # Setuptools extractor design and limitations
-│       └── summary.md                      # this file; canonical project structure
-├── skills/                      # Claude Code Skills (also bundled by .claude-plugin/)
-│   ├── sbom/                    # Generate an SBOM/AIBOM
-│   └── enrich/                  # Enrich an existing SBOM with agent-inferred facts
+│       ├── setuptools-support.md   # Setuptools extractor design and limitations
+│       └── summary.md              # this file; canonical project structure
+├── skills/                         # Claude Code Skills (also bundled by .claude-plugin/)
+│   ├── sbom/                       # Generate an SBOM/AIBOM
+│   └── enrich/                     # Enrich an existing SBOM with agent-inferred facts
 ├── .claude-plugin/
-│   ├── plugin.json              # Plugin manifest
-│   └── marketplace.json         # Self-hosted marketplace entry
+│   ├── plugin.json                 # Plugin manifest
+│   └── marketplace.json            # Self-hosted marketplace entry
 ├── examples/
-│   └── sentimentdemo-aibom/     # Worked AI-pipeline SBOM example
+│   └── sentimentdemo-aibom/        # Worked AI-pipeline SBOM example
 ├── src/
 │   └── pitloom/
-│       ├── assemble/            # Layers 2+3 -- build DocumentModel + map to spec
-│       │   ├── spdx3/           # SPDX 3 specific (future: spdx23, cyclonedx)
-│       │   │   ├── ai.py         # AI model element assembly
+│       ├── assemble/               # Layers 2+3 -- build DocumentModel + map to spec
+│       │   ├── spdx3/              # SPDX 3 specific (future: spdx23, cyclonedx)
+│       │   │   ├── ai.py           # AI model element assembly
 │       │   │   ├── creation_info.py # Shared CreationInfo construction
-│       │   │   ├── dataset.py    # Dataset element assembly
-│       │   │   ├── deps.py       # Dependency + license element assembly
-│       │   │   ├── document.py   # build(DocumentModel) -> Spdx3JsonExporter
-│       │   │   ├── fragments.py  # Fragment merging + unification provenance
-│       │   │   ├── provenance.py # Provenance Annotation builders/emitter
+│       │   │   ├── dataset.py      # Dataset element assembly
+│       │   │   ├── deps.py         # Dependency + license element assembly
+│       │   │   ├── document.py     # build(DocumentModel) -> Spdx3JsonExporter
+│       │   │   ├── fragments.py    # Fragment merging + unification provenance
+│       │   │   ├── provenance.py   # Provenance Annotation builders/emitter
 │       │   │   └── __init__.py
-│       │   └── __init__.py      # generate_*_sbom() orchestrators + backend routing
-│       ├── core/                # Format-neutral data models (no SBOM lib deps)
+│       │   └── __init__.py         # generate_*_sbom() orchestrators + backend routing
+│       ├── core/                   # Format-neutral data models (no SBOM lib deps)
 │       │   ├── ai_metadata.py      # AiModelMetadata, ModelFormat
 │       │   ├── config.py           # PitloomConfig ([tool.pitloom] settings)
 │       │   ├── creation.py         # CreationMetadata (creator / timestamp)
@@ -260,9 +282,9 @@ pitloom/
 │       │   ├── document.py         # DocumentModel (assembled, pre-serialization)
 │       │   ├── models.py           # Deterministic UUIDs, Merkle root, SPDX ID generation
 │       │   └── project.py          # ProjectMetadata, ProjectFile
-│       ├── export/              # Layer 4 -- serialise to physical format
-│       │   └── spdx3_json.py    # SPDX 3 JSON-LD serialiser
-│       ├── extract/             # Layer 1 -- read from sources
+│       ├── export/                 # Layer 4 -- serialise to physical format
+│       │   └── spdx3_json.py       # SPDX 3 JSON-LD serialiser
+│       ├── extract/                # Layer 1 -- read from sources
 │       │   ├── ai_model.py         # AI model dispatcher + format detection
 │       │   ├── _croissant.py       # Croissant metadata parser
 │       │   ├── _croissant_keys.py  # Croissant JSON-LD key constants
@@ -288,27 +310,27 @@ pitloom/
 │       │   ├── scanner.py          # Heuristic scanner for AI model files
 │       │   ├── setuptools.py       # setup.cfg + setup.py extractor; backend detection; merge
 │       │   └── wheel.py            # Analyzed SBOM: project metadata + file records from a built .whl
-│       ├── plugins/             # Build-system integrations
-│       │   └── hatch.py         # Hatchling BuildHookInterface (PEP 770)
-│       ├── __about__.py         # Package version (__version__)
+│       ├── plugins/                # Build-system integrations
+│       │   └── hatch.py            # Hatchling BuildHookInterface (PEP 770)
+│       ├── __about__.py            # Package version (__version__)
 │       ├── __init__.py
-│       ├── __main__.py          # CLI entry point (loom / python -m pitloom): source|analyze|deployed|ids
-│       ├── ids.py               # Loom ID registry (loom-ids.json); stable cross-fragment SPDX ids
-│       ├── loom.py              # ML tracking SDK (Run context manager / decorator)
-│       └── py.typed             # PEP 561 marker
+│       ├── __main__.py             # CLI entry point (loom / python -m pitloom): source|analyze|deployed|ids
+│       ├── ids.py                  # Loom ID registry (loom-ids.json); stable cross-fragment SPDX ids
+│       ├── loom.py                 # ML tracking SDK (Run context manager / decorator)
+│       └── py.typed                # PEP 561 marker
 ├── tests/
-│   ├── fixtures/                 # Per-format model/project fixtures (see fixtures/README.md)
+│   ├── fixtures/                   # Per-format model/project fixtures (see fixtures/README.md)
 │   ├── conftest.py
 │   ├── test_annotation_provenance.py  # Provenance Annotation builders/emitter
 │   ├── test_provenance_integration.py # N1/N2/N4/N5/N6 native-construct integration
-│   └── test_*.py                 # One file per extractor/assembler/CLI surface
+│   └── test_*.py                   # One file per extractor/assembler/CLI surface
 ├── AGENTS.md
 ├── CHANGELOG.md
 ├── CITATION.cff
 ├── LICENSE
 ├── README.md
 ├── codemeta.json
-└── pyproject.toml               # Project config and Hatchling build settings
+└── pyproject.toml                  # Project config and Hatchling build settings
 ```
 
 ### 2. Extensible design

--- a/working-docs/implementation/summary.md
+++ b/working-docs/implementation/summary.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-02-06
-Last-Modified: 2026-07-17
+Last-Modified: 2026-08-08
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -71,20 +71,26 @@ SPDX 3.0 compliant SBOMs in JSON-LD format.
      `[tool.pitloom.creation]` -- the same settings the CLI uses
 
 6. **Command-line interface** (`src/pitloom/__main__.py`)
-   - User-friendly argparse-based CLI with lifecycle-centric subcommands (`source`, `analyze`, `deployed`, `model`, `ids`)
-   - Subcommands map to CISA SBOM types (e.g. `source` -> Source SBOM, `analyze` -> Analyzed SBOM, `deployed` -> Deployed SBOM)
+   - User-friendly argparse-based CLI with lifecycle-centric subcommands (`source`, `analyze`, `deployed`, `ids`)
+   - Subcommands map to CISA SBOM types (`source` -> Source SBOM, `analyze` -> Analyzed SBOM
+     -- dispatches internally to a built `.whl`, a local AI model file, or a Hugging Face
+     repository depending on the target's form -- `deployed` -> Deployed SBOM of the
+     currently installed environment); `ids` manages the Loom ID registry
    - Default output filename derived from project metadata (`{name}-{version}.spdx3.json`)
      or `[tool.pitloom] sbom-basename` when set
    - Creator information options
    - Clear error messages
 
-7. **Metadata provenance tracking** (`src/pitloom/extract/pyproject.py`,
-   `src/pitloom/loom.py`)
+7. **Metadata provenance tracking** (`src/pitloom/assemble/spdx3/provenance.py`,
+   `src/pitloom/extract/pyproject.py`, `src/pitloom/loom.py`)
    - Tracks source of each metadata field
    - Records extraction method (static, dynamic, or inferred)
    - Supports dynamic introspection via `loom.py` inspection
-   - Uses SPDX 3 comment attribute
+   - Recorded as SPDX 3 Core `Annotation` elements (structured, machine-readable
+     JSON), with the original SPDX 3 `comment` attribute kept for back-compat,
+     controlled by `[tool.pitloom.provenance]`
    - See [working-docs/design/metadata-provenance.md](../design/metadata-provenance.md)
+     and [annotation-provenance.md](annotation-provenance.md)
 
 8. **ML tracking SDK** (`src/pitloom/loom.py`)
    - Dual-syntax ContextDecorator (`@loom.run` and `with loom.run`)
@@ -133,6 +139,16 @@ SPDX 3.0 compliant SBOMs in JSON-LD format.
 
 ## Validation with sentimentdemo
 
+> **Historical snapshot, early prototype.** The invocation and element
+> counts below predate the `source`/`analyze`/`deployed`/`ids` CLI
+> subcommands (PR #96) and provenance-as-Annotation (see
+> [annotation-provenance.md](annotation-provenance.md)) -- a current run
+> uses `loom source <path>`, not the bare positional form shown here, and
+> emits additional `Annotation` elements for provenance. Kept as a record
+> of the initial validation, not a spec for current output shape; see
+> [examples/sentimentdemo-aibom/](../../examples/sentimentdemo-aibom/) for
+> a current, fuller worked example (AI pipeline, fragments, dataset).
+
 Successfully generated SPDX 3 SBOM for the reference repository:
 
 ```text
@@ -175,12 +191,23 @@ SBOM written to: sbom.spdx3.json
 ### 1. Clean architecture
 
 > This tree is the canonical reference; README.md and design docs point here.
+> `docs/` is the published GitHub Pages site (flat, user-facing);
+> `working-docs/design/` and `working-docs/implementation/` are the
+> internal design/progress docs, including this file.
 
 ```text
 pitloom/
-├── docs/
+├── docs/                        # Published site (flat; docs/_config.yml)
+│   ├── creation-metadata.md
+│   ├── index.md
+│   ├── metadata-provenance.md
+│   ├── mascot.png
+│   └── resources.md
+├── working-docs/
 │   ├── design/
+│   │   ├── adoption-surfaces.md
 │   │   ├── architecture-overview.md
+│   │   ├── cli-ux.md
 │   │   ├── format-neutral-representation.md
 │   │   ├── hatchling-build-hook.md
 │   │   ├── metadata-provenance.md
@@ -191,24 +218,40 @@ pitloom/
 │   │   ├── roadmap.md             # Canonical roadmap
 │   │   ├── sbom-enrichment.md
 │   │   └── sbom-fragments.md
-│   ├── implementation/
-│   │   ├── demo.md
-│   │   ├── demo-provenance.md
-│   │   ├── setuptools-support.md  # Setuptools extractor design and limitations
-│   │   └── summary.md             # this file; canonical project structure
-│   ├── mascot.png
-│   └── resources.md
+│   └── implementation/
+│       ├── agent-skill.md
+│       ├── annotation-provenance.md        # Provenance-as-Annotation design + status
+│       ├── annotation-provenance-full-plan.md
+│       ├── claude-code-plugin.md
+│       ├── demo.md
+│       ├── demo-provenance.md              # Historical; predates Annotation provenance
+│       ├── github-action.md
+│       ├── license-pipeline.md
+│       ├── phase2-native-backfill-handover.md
+│       ├── poetry-support.md
+│       ├── setuptools-support.md           # Setuptools extractor design and limitations
+│       └── summary.md                      # this file; canonical project structure
+├── skills/                      # Claude Code Skills (also bundled by .claude-plugin/)
+│   ├── sbom/                    # Generate an SBOM/AIBOM
+│   └── enrich/                  # Enrich an existing SBOM with agent-inferred facts
+├── .claude-plugin/
+│   ├── plugin.json              # Plugin manifest
+│   └── marketplace.json         # Self-hosted marketplace entry
+├── examples/
+│   └── sentimentdemo-aibom/     # Worked AI-pipeline SBOM example
 ├── src/
 │   └── pitloom/
 │       ├── assemble/            # Layers 2+3 -- build DocumentModel + map to spec
 │       │   ├── spdx3/           # SPDX 3 specific (future: spdx23, cyclonedx)
-│       │   │   ├── ai.py        # AI model element assembly
-│       │   │   ├── dataset.py   # Dataset element assembly
-│       │   │   ├── deps.py      # Dependency element assembly
-│       │   │   ├── document.py  # build(DocumentModel) -> Spdx3JsonExporter
-│       │   │   ├── fragments.py # Fragment merging
+│       │   │   ├── ai.py         # AI model element assembly
+│       │   │   ├── creation_info.py # Shared CreationInfo construction
+│       │   │   ├── dataset.py    # Dataset element assembly
+│       │   │   ├── deps.py       # Dependency + license element assembly
+│       │   │   ├── document.py   # build(DocumentModel) -> Spdx3JsonExporter
+│       │   │   ├── fragments.py  # Fragment merging + unification provenance
+│       │   │   ├── provenance.py # Provenance Annotation builders/emitter
 │       │   │   └── __init__.py
-│       │   └── __init__.py      # generate_sbom() orchestrator + backend routing
+│       │   └── __init__.py      # generate_*_sbom() orchestrators + backend routing
 │       ├── core/                # Format-neutral data models (no SBOM lib deps)
 │       │   ├── ai_metadata.py      # AiModelMetadata, ModelFormat
 │       │   ├── config.py           # PitloomConfig ([tool.pitloom] settings)
@@ -223,11 +266,13 @@ pitloom/
 │       │   ├── ai_model.py         # AI model dispatcher + format detection
 │       │   ├── _croissant.py       # Croissant metadata parser
 │       │   ├── _croissant_keys.py  # Croissant JSON-LD key constants
-│       │   ├── _extract_utils.py   # Shared extraction utilities
+│       │   ├── _extract_utils.py   # Shared extraction utilities (incl. provenance sanitization)
 │       │   ├── _fasttext.py        # fastText (.ftz, .bin)
 │       │   ├── _gguf.py            # GGUF (.gguf)
 │       │   ├── _hdf5.py            # HDF5 / Keras v1–v2 (.h5, .hdf5)
+│       │   ├── _huggingface.py     # Hugging Face Hub model extraction
 │       │   ├── _keras.py           # Keras v3 (.keras)
+│       │   ├── _license.py         # License file/id detection
 │       │   ├── _numpy.py           # NumPy (.npy, .npz)
 │       │   ├── _onnx.py            # ONNX (.onnx)
 │       │   ├── _pytorch.py         # PyTorch classic (.pt, .pth)
@@ -236,7 +281,9 @@ pitloom/
 │       │   ├── binary.py           # Bundled third-party binary ("phantom dependency") detection in a wheel
 │       │   ├── dataset.py          # Dataset metadata extraction (Croissant)
 │       │   ├── env.py              # Deployed SBOM: installed-environment dependency tree via pipdeptree
+│       │   ├── hatchling.py        # Metadata from Hatchling's own resolved ProjectMetadata (build hook path)
 │       │   ├── poetry.py           # [tool.poetry] extractor; Poetry -> PEP 440 conversion
+│       │   ├── project.py          # pyproject.toml/setup.cfg/setup.py -> (ProjectMetadata, PitloomConfig) dispatcher
 │       │   ├── pyproject.py        # pyproject.toml extractor ([project] + [tool.poetry] merge)
 │       │   ├── scanner.py          # Heuristic scanner for AI model files
 │       │   ├── setuptools.py       # setup.cfg + setup.py extractor; backend detection; merge
@@ -245,55 +292,16 @@ pitloom/
 │       │   └── hatch.py         # Hatchling BuildHookInterface (PEP 770)
 │       ├── __about__.py         # Package version (__version__)
 │       ├── __init__.py
-│       ├── __main__.py          # CLI entry point (loom / python -m pitloom)
+│       ├── __main__.py          # CLI entry point (loom / python -m pitloom): source|analyze|deployed|ids
 │       ├── ids.py               # Loom ID registry (loom-ids.json); stable cross-fragment SPDX ids
 │       ├── loom.py              # ML tracking SDK (Run context manager / decorator)
 │       └── py.typed             # PEP 561 marker
 ├── tests/
-│   ├── fixtures/
-│   │   ├── croissant/           # Croissant dataset metadata fixtures
-│   │   ├── fasttext/            # fastText model fixtures
-│   │   ├── fragments/           # Pre-generated SPDX 3 fragment fixtures
-│   │   ├── gguf/                # GGUF model fixtures
-│   │   ├── hdf5/                # HDF5 / Keras model fixtures
-│   │   ├── keras/               # Keras v3 model fixtures
-│   │   ├── numpy/               # NumPy array fixtures
-│   │   ├── onnx/                # ONNX model fixtures
-│   │   ├── pytorch/             # PyTorch classic model fixtures
-│   │   ├── pytorch_pt2/         # PyTorch PT2 / ExecuTorch fixtures
-│   │   ├── safetensors/         # Safetensors model fixtures
-│   │   ├── sampleproject-hatchling/   # Minimal Hatchling wheel-build fixture
-│   │   ├── sampleproject-poetry/      # Real-world Poetry fixture (mistral-inference)
-│   │   ├── sampleproject-setuptools/  # Minimal setuptools metadata fixture
-│   │   ├── sentimentdemo-handcrafted.spdx3.json
-│   │   └── README.md
+│   ├── fixtures/                 # Per-format model/project fixtures (see fixtures/README.md)
 │   ├── conftest.py
-│   ├── test_dataset_metadata.py
-│   ├── test_extract_ai_model.py
-│   ├── test_extract_croissant.py
-│   ├── test_extract_fasttext.py
-│   ├── test_extract_gguf.py
-│   ├── test_extract_hdf5.py
-│   ├── test_extract_keras.py
-│   ├── test_extract_numpy.py
-│   ├── test_extract_onnx.py
-│   ├── test_extract_pytorch.py
-│   ├── test_extract_pytorch_pt2.py
-│   ├── test_extract_safetensors.py
-│   ├── test_fragments.py
-│   ├── test_generator.py
-│   ├── test_hatch_hook.py
-│   ├── test_jcs.py
-│   ├── test_loom.py
-│   ├── test_main_cli.py
-│   ├── test_metadata.py
-│   ├── test_models.py
-│   ├── test_provenance.py
-│   ├── test_poetry.py
-│   ├── test_setuptools.py
-│   ├── test_spdx3_compliance.py
-│   ├── test_spdx3_dataset.py
-│   └── test_wheel_integration.py
+│   ├── test_annotation_provenance.py  # Provenance Annotation builders/emitter
+│   ├── test_provenance_integration.py # N1/N2/N4/N5/N6 native-construct integration
+│   └── test_*.py                 # One file per extractor/assembler/CLI surface
 ├── AGENTS.md
 ├── CHANGELOG.md
 ├── CITATION.cff


### PR DESCRIPTION

## Summary

Adds per-key provenance for pitloom.loom hyperparameters (was untracked); fixes stale CLI docs/skills missed by PR #96's source/analyze/deployed restructuring.


## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
