### PR TITLE
Refactor CLI/API to input-centric design with sdist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
           SBOM_NAME="${WHEEL_NAME}.spdx3.json"
 
           # Generate SBOM
-          loom source . -o "dist/${SBOM_NAME}" --creator-name "Pitloom CI" --creator-email "ci@example.com"
+          loom project . -o "dist/${SBOM_NAME}" --creator-name "Pitloom CI" --creator-email "ci@example.com"
 
           echo "sbom_name=${SBOM_NAME}" >> "$GITHUB_OUTPUT"
           echo "sbom_path=dist/${SBOM_NAME}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ms-sbom-tool.DISABLED
+++ b/.github/workflows/ms-sbom-tool.DISABLED
@@ -68,7 +68,7 @@ jobs:
           SBOM_NAME="${WHEEL_NAME}.spdx3.json"
 
           # Generate SBOM
-          loom . -o "dist/${SBOM_NAME}" --creator-name "Pitloom CI" --creator-email "ci@example.com"
+          loom project . -o "dist/${SBOM_NAME}" --creator-name "Pitloom CI" --creator-email "ci@example.com"
 
           echo "sbom_name=${SBOM_NAME}" >> $GITHUB_OUTPUT
           echo "sbom_path=dist/${SBOM_NAME}" >> $GITHUB_OUTPUT

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 ### Metadata sources
 
 - The Hatchling build hook (`pitloom.plugins.hatch`) reads project metadata from `self.metadata` (Hatchling's own resolved `hatchling.metadata.core.ProjectMetadata`), via `pitloom.extract.hatchling.metadata_from_hatchling()`, so dynamic version/dependency/license sources resolved by Hatchling plugins are reflected correctly.
-- The CLI (`pitloom.__main__`) and `pitloom.assemble.generate_sbom()`'s default parsing path both resolve metadata/config from the project directory via the shared `pitloom.extract.project.read_project()` helper (`pyproject.toml` -> `setup.cfg`/`setup.py` -> error), so each parses its inputs once. The CLI passes its already-parsed `project_metadata`/`pitloom_config` into `generate_sbom()` so it never re-parses.
+- The CLI (`pitloom.__main__`) and `pitloom.assemble.generate_project_sbom()`'s default parsing path both resolve metadata/config from the project directory via the shared `pitloom.extract.project.read_project()` helper (`pyproject.toml` -> `setup.cfg`/`setup.py` -> error), so each parses its inputs once. The CLI passes its already-parsed `project_metadata`/`pitloom_config` into `generate_project_sbom()` so it never re-parses.
 - Both paths converge on the same `pitloom.assemble.spdx3.document.build()` assembly layer, so the emitted SBOM shape (file hashes, PURLs, licensing, etc.) is identical regardless of metadata source.
 
 ## CLI output

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ loom project .
 loom project /path/to/project -o sbom.spdx3.json
 ```
 
-Generate an **Analyzed SBOM** from a pre-built wheel (extracting bundled binaries as phantom dependencies):
+Generate an **Analyzed SBOM** from a pre-built wheel
+(extracting bundled binaries as phantom dependencies):
 
 ```bash
 loom wheel path/to/mypackage-1.0.0-py3-none-any.whl -o sbom.spdx3.json
@@ -86,10 +87,11 @@ Generate a **Deployed SBOM** reflecting the exact installed environment graph:
 loom env -o env.spdx3.json
 ```
 
-Generate an **Analyzed SBOM** for a single AI model file, without a Python project
-directory (output written to the current working directory). Supported
-local formats: GGUF, ONNX, Safetensors, PyTorch (`.pt`/`.pth`), Keras,
-HDF5, NumPy, fastText:
+Generate an **Analyzed SBOM** for a single AI model file,
+without a Python project directory
+(output written to the current working directory).
+Supported local formats: GGUF, ONNX, Safetensors, PyTorch (`.pt`/`.pth`),
+Keras, HDF5, NumPy, fastText:
 
 ```bash
 loom model path/to/model.safetensors -o model.spdx3.json
@@ -110,9 +112,9 @@ loom model Qwen/Qwen3-235B-A22B   # bare model ID also works
 Or use the smart unified entrypoint:
 
 ```bash
-loom generate .                              # project directory -> Source SBOM
-loom generate path/to/model.safetensors       # AI model asset   -> Analyzed SBOM
-loom generate --env                          # installed venv    -> Deployed SBOM
+loom generate .                           # project directory -> Source SBOM
+loom generate path/to/model.safetensors   # AI model asset   -> Analyzed SBOM
+loom generate env                         # installed venv    -> Deployed SBOM
 ```
 
 `loom -h` shows the full option list.
@@ -127,7 +129,7 @@ hook:
 
 ```toml
 [build-system]
-requires = ["hatchling>=1.28.0", "pitloom>=0.11.0"]
+requires = ["hatchling>=1.28.0", "pitloom>=0.12.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.hooks.pitloom]
@@ -151,7 +153,8 @@ files = ["fragments/model.json"]   # merge externally tracked fragments
 
 ### Python API
 
-The SBOM generator can be used programmatically via the smart `generate()` entrypoint or target-specific functions:
+The SBOM generator can be used programmatically
+via the smart `generate()` entry point or target-specific functions:
 
 ```python
 from pathlib import Path
@@ -172,7 +175,8 @@ generate_project_sbom(
 )
 ```
 
-`pitloom.assemble` also exposes `generate_wheel_sbom()`, `generate_model_sbom()`, and `generate_env_sbom()`.
+`pitloom.assemble` also exposes `generate_wheel_sbom()`,
+`generate_model_sbom()`, and `generate_env_sbom()`.
 
 ### Python tracking decorator
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ ensuring compliance with the PyPA
 
 ```bash
 pip install pitloom
-loom source .     # SBOM for the Python project in the current dir
+loom project .     # SBOM for the Python project in the current dir
 ```
 
 ### Optional features
@@ -70,20 +70,20 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev install.
 Generate a **Source SBOM** for a Python project in the current directory:
 
 ```bash
-loom source .
-loom source /path/to/project -o sbom.spdx3.json
+loom project .
+loom project /path/to/project -o sbom.spdx3.json
 ```
 
 Generate an **Analyzed SBOM** from a pre-built wheel (extracting bundled binaries as phantom dependencies):
 
 ```bash
-loom analyze path/to/mypackage-1.0.0-py3-none-any.whl -o sbom.spdx3.json
+loom wheel path/to/mypackage-1.0.0-py3-none-any.whl -o sbom.spdx3.json
 ```
 
 Generate a **Deployed SBOM** reflecting the exact installed environment graph:
 
 ```bash
-loom deployed -o env.spdx3.json
+loom env -o env.spdx3.json
 ```
 
 Generate an **Analyzed SBOM** for a single AI model file, without a Python project
@@ -92,8 +92,8 @@ local formats: GGUF, ONNX, Safetensors, PyTorch (`.pt`/`.pth`), Keras,
 HDF5, NumPy, fastText:
 
 ```bash
-loom analyze path/to/model.safetensors -o model.spdx3.json
-loom analyze path/to/model.gguf --pretty
+loom model path/to/model.safetensors -o model.spdx3.json
+loom model path/to/model.gguf --pretty
 ```
 
 Or pass a Hugging Face Hub URL or model ID directly -- no local file
@@ -103,8 +103,16 @@ required. Pitloom fetches metadata from the Hub (model card, `config.json`,
 (`pip install pitloom[huggingface]`):
 
 ```bash
-loom analyze https://huggingface.co/mistralai/Mistral-7B-v0.1
-loom analyze Qwen/Qwen3-235B-A22B   # bare model ID also works
+loom model https://huggingface.co/mistralai/Mistral-7B-v0.1
+loom model Qwen/Qwen3-235B-A22B   # bare model ID also works
+```
+
+Or use the smart unified entrypoint:
+
+```bash
+loom generate .                              # project directory -> Source SBOM
+loom generate path/to/model.safetensors       # AI model asset   -> Analyzed SBOM
+loom generate --env                          # installed venv    -> Deployed SBOM
 ```
 
 `loom -h` shows the full option list.
@@ -143,23 +151,28 @@ files = ["fragments/model.json"]   # merge externally tracked fragments
 
 ### Python API
 
-The SBOM generator can be used programmatically:
+The SBOM generator can be used programmatically via the smart `generate()` entrypoint or target-specific functions:
 
 ```python
 from pathlib import Path
 from pitloom.core.creation import CreationMetadata, Creator
-from pitloom.assemble import generate_sbom
+from pitloom.assemble import generate, generate_project_sbom
 
-generate_sbom(
-    project_dir=Path("/path/to/project"),
+# Smart auto-detection entrypoint
+generate(
+    target=Path("/path/to/project"),
     output_path=Path("sbom.spdx3.json"),
     creation_metadata=CreationMetadata(creators=[Creator(name="Your Name")]),
 )
+
+# Or target-specific generator
+generate_project_sbom(
+    project_target=Path("/path/to/project"),
+    output_path=Path("sbom.spdx3.json"),
+)
 ```
 
-`pitloom.assemble` also exposes `generate_ai_model_sbom()` (a local model
-file) and `generate_huggingface_sbom()` (a Hub model ID or URL), with the
-same `output_path`/`creation_metadata`/`pretty` keywords.
+`pitloom.assemble` also exposes `generate_wheel_sbom()`, `generate_model_sbom()`, and `generate_env_sbom()`.
 
 ### Python tracking decorator
 
@@ -236,7 +249,7 @@ for what the plugin bundles.
 
 ```bash
 git clone https://github.com/bact/sentimentdemo.git
-loom source sentimentdemo
+loom project sentimentdemo
 ```
 
 The generated SBOM includes project metadata, dependencies with version
@@ -258,10 +271,10 @@ it (default `"Pitloom"`, also repeatable; `--no-creation-tool` to omit);
 ISO 8601 timestamp:
 
 ```bash
-loom source . --creator-name "Alice" --creator-email "alice@example.com"
-loom source . --creator-name "Acme Corp" --creator-type organization
-loom source . --creator-name "Acme Corp" --creator-type organization --creator-name Alice
-loom source . --creation-datetime "2026-01-15T10:00:00Z" --creation-comment "CI run #123"
+loom project . --creator-name "Alice" --creator-email "alice@example.com"
+loom project . --creator-name "Acme Corp" --creator-type organization
+loom project . --creator-name "Acme Corp" --creator-type organization --creator-name Alice
+loom project . --creation-datetime "2026-01-15T10:00:00Z" --creation-comment "CI run #123"
 ```
 
 The same fields can be set in `pyproject.toml` under
@@ -301,7 +314,7 @@ pitloom ids generate data src --entity model      # pin ids before running
 pitloom ids import existing-sbom.spdx3.json       # or reuse ids from an SBOM
 ```
 
-`pitloom.loom`, `loom analyze` (when pointed at a model), the build hook, and `generate_sbom()` all
+`pitloom.loom`, `loom model`, the build hook, and `generate()` all
 auto-discover the registry (or take it from `[tool.pitloom.ids] file`),
 so the same file/entity carries the same id everywhere. Regeneration is
 stable: an unchanged file keeps its id; changed content gets a fresh one

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
   model:
     description: >-
       Path to a local AI model file, or a Hugging Face URL / model ID.
-      When set, runs analyze mode ("loom analyze <model>") instead of project mode.
+      When set, runs model mode ("loom model <model>") instead of project mode.
     required: false
     default: ""
   output:
@@ -123,9 +123,9 @@ runs:
 
         declare -a loom_args
         if [ -n "${PL_MODEL}" ]; then
-          loom_args+=("analyze" "${PL_MODEL}")
+          loom_args+=("model" "${PL_MODEL}")
         else
-          loom_args+=("source" "${PL_PROJECT_PATH}")
+          loom_args+=("project" "${PL_PROJECT_PATH}")
         fi
         loom_args+=("-o" "${PL_OUTPUT}")
         if [ "${PL_PRETTY}" = "true" ]; then

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,27 +43,33 @@ pip install pitloom[ai]
 Create a Source SBOM for the Python project in the current directory:
 
 ```shell
-loom source .
+loom project .
 ```
 
 Create an Analyzed SBOM of a local AI model:
 
 ```shell
-loom analyze path/to/model.safetensors -o model.spdx3.json
-loom analyze path/to/model.gguf --pretty
+loom model path/to/model.safetensors -o model.spdx3.json
+loom model path/to/model.gguf --pretty
 ```
 
 Create an Analyzed SBOM of an AI model on Hugging Face Hub:
 
 ```shell
-loom analyze https://huggingface.co/mistralai/Mistral-7B-v0.1
-loom analyze Qwen/Qwen3-235B-A22B   # bare model ID also works
+loom model https://huggingface.co/mistralai/Mistral-7B-v0.1
+loom model Qwen/Qwen3-235B-A22B   # bare model ID also works
 ```
 
 Create a Deployed SBOM of the currently installed environment:
 
 ```shell
-loom deployed -o env.spdx3.json
+loom env -o env.spdx3.json
+```
+
+Or use the unified auto-detection entrypoint:
+
+```shell
+loom generate .
 ```
 
 ### GitHub Action
@@ -98,10 +104,10 @@ This embeds an SBOM into the distributed Python wheel.
 
 ```python
 from pathlib import Path
-from pitloom.assemble import generate_sbom
+from pitloom.assemble import generate
 
 project_path = Path("/path/to/project")
-generate_sbom(project_path)
+generate(project_path)
 ```
 
 ### Python tracking decorator

--- a/examples/sentimentdemo-aibom/README.md
+++ b/examples/sentimentdemo-aibom/README.md
@@ -226,7 +226,7 @@ python -m sentimentdemo.evaluate
 
 ## Stage 4 - Direct AI model extraction (Pitloom CLI)
 
-**Tool:** `loom analyze` (Pitloom CLI)
+**Tool:** `loom model` (Pitloom CLI)
 **Output fragment:** `fragments/04_model_file.spdx3.json`
 
 Stages 1-3 record information that the *training code* knows. But the
@@ -236,7 +236,7 @@ labels, file hash, and so on. Pitloom reads those straight out of the
 binary:
 
 ```bash
-loom analyze models/sentimentdemo.bin -o fragments/04_model_file.spdx3.json --pretty
+loom model models/sentimentdemo.bin -o fragments/04_model_file.spdx3.json --pretty
 ```
 
 This is **independent of the training script** - you can run it against
@@ -320,7 +320,7 @@ different sources:
 | Raw + processed datasets, with `hasInput` lineage | Preprocess script | `@loom.run` decorator + STAV IRIs | 1 |
 | AI model, hyperparameters, `trainedOn` relationship | Training script | `loom.run` context manager + STAV IRIs | 2 |
 | Validation set, `testedOn` relationship | Eval script | `loom.run` context manager + STAV IRIs | 3 |
-| Architecture, file hash, vocab/dim/labels | Model file (`sentimentdemo.bin`) | `loom analyze` CLI extractor | 4 |
+| Architecture, file hash, vocab/dim/labels | Model file (`sentimentdemo.bin`) | `loom model` CLI extractor | 4 |
 
 You can inspect the final SBOM with:
 

--- a/examples/sentimentdemo-aibom/loom-ids.json
+++ b/examples/sentimentdemo-aibom/loom-ids.json
@@ -23,8 +23,8 @@
       "spdxId": "https://spdx.org/spdxdocs/sentimentdemo-aibom-77023e5c-6b07-4e79-b2c9-9fa83d23a1ac#File-2"
     },
     "models/sentimentdemo.bin": {
-      "sha256": "837a8cd1e2dc33601914883b465a4d05ba17ec0e1f1b92646ad0118508aa8242",
-      "spdxId": "https://spdx.org/spdxdocs/sentimentdemo-aibom-77023e5c-6b07-4e79-b2c9-9fa83d23a1ac#File-10"
+      "sha256": "4ff7609605a1bb039cfc1e3bd78fcd21b3eefb2d11bc7b1be146a94d92b504bf",
+      "spdxId": "https://spdx.org/spdxdocs/sentimentdemo-aibom-77023e5c-6b07-4e79-b2c9-9fa83d23a1ac#File-14"
     },
     "src/sentimentdemo/__about__.py": {
       "sha256": "c9443361942b2ea8cab27cc0727a39a0d496cf0da53aa969313e80c50d566676",
@@ -35,16 +35,16 @@
       "spdxId": "https://spdx.org/spdxdocs/sentimentdemo-aibom-77023e5c-6b07-4e79-b2c9-9fa83d23a1ac#File-4"
     },
     "src/sentimentdemo/evaluate.py": {
-      "sha256": "902613b7836383fdeaf790d65f4675a35d708341fd279564c6fde703e991ce8b",
-      "spdxId": "https://spdx.org/spdxdocs/sentimentdemo-aibom-77023e5c-6b07-4e79-b2c9-9fa83d23a1ac#File-5"
+      "sha256": "e27b8ae8923f122e7e435eeadb7b6e4d95359940c0ff6f5d213c0ea9e573b547",
+      "spdxId": "https://spdx.org/spdxdocs/sentimentdemo-aibom-77023e5c-6b07-4e79-b2c9-9fa83d23a1ac#File-11"
     },
     "src/sentimentdemo/preprocess.py": {
-      "sha256": "1f75778ac88a38c85632fa8543b215509bd8d468c3d1de5b0dad812b1f68800e",
-      "spdxId": "https://spdx.org/spdxdocs/sentimentdemo-aibom-77023e5c-6b07-4e79-b2c9-9fa83d23a1ac#File-6"
+      "sha256": "cdd28f12bbd72434538786fcb07dae0bfed894119d4ff413b736ed133800db7e",
+      "spdxId": "https://spdx.org/spdxdocs/sentimentdemo-aibom-77023e5c-6b07-4e79-b2c9-9fa83d23a1ac#File-12"
     },
     "src/sentimentdemo/train.py": {
-      "sha256": "dfcadbebe221612701c85cdeb837ef0cc1c221bd663f0926896034121d9baf6b",
-      "spdxId": "https://spdx.org/spdxdocs/sentimentdemo-aibom-77023e5c-6b07-4e79-b2c9-9fa83d23a1ac#File-7"
+      "sha256": "91f1b7df7d4a00939d898b860dc94f56a5062d110611c7cfc2172e923a88deb8",
+      "spdxId": "https://spdx.org/spdxdocs/sentimentdemo-aibom-77023e5c-6b07-4e79-b2c9-9fa83d23a1ac#File-13"
     }
   },
   "namespace": "https://spdx.org/spdxdocs/sentimentdemo-aibom-77023e5c-6b07-4e79-b2c9-9fa83d23a1ac",

--- a/examples/sentimentdemo-aibom/pyproject.toml
+++ b/examples/sentimentdemo-aibom/pyproject.toml
@@ -64,7 +64,7 @@ files = [
     "fragments/01_preprocess.spdx3.json",  # produced by `python -m sentimentdemo.preprocess`
     "fragments/02_train.spdx3.json",       # produced by `python -m sentimentdemo.train`
     "fragments/03_evaluate.spdx3.json",    # produced by `python -m sentimentdemo.evaluate`
-    "fragments/04_model_file.spdx3.json",  # produced by `loom analyze models/sentimentdemo.bin`
+    "fragments/04_model_file.spdx3.json",  # produced by `loom model models/sentimentdemo.bin`
 ]
 
 [tool.pyrefly]

--- a/examples/sentimentdemo-aibom/scripts/run_pipeline.sh
+++ b/examples/sentimentdemo-aibom/scripts/run_pipeline.sh
@@ -7,7 +7,7 @@
 #
 # Stage 0 (and the registry refreshes after stages 1 and 2) maintain
 # loom-ids.json: a stable file/entity -> SPDX ID registry. Every stage --
-# the loom runs, the `loom analyze` extractor, and the Hatchling build hook --
+# the loom runs, the `loom model` extractor, and the Hatchling build hook --
 # consults it, so the same dataset, script, or model carries the same spdxId
 # in every fragment, and the merge step can join the fragments into one
 # connected AI-pipeline graph.
@@ -52,9 +52,9 @@ python -m sentimentdemo.evaluate
 
 echo
 echo "================================================================"
-echo "Stage 4/5  -  Direct AI model extraction (loom analyze)"
+echo "Stage 4/5  -  Direct AI model extraction (loom model)"
 echo "================================================================"
-loom analyze models/sentimentdemo.bin -o fragments/04_model_file.spdx3.json --pretty
+loom model models/sentimentdemo.bin -o fragments/04_model_file.spdx3.json --pretty
 
 echo
 echo "================================================================"

--- a/skills/enrich/SKILL.md
+++ b/skills/enrich/SKILL.md
@@ -72,7 +72,7 @@ Steps:
    files = ["fragments/agent-enrichment.spdx3.json"]
    ```
 
-6. Re-run `loom source <path>` or `loom analyze <path>` (generate again) so
+6. Re-run `loom project <path>` or `loom generate <path>` (generate again) so
    the merged, enriched SBOM is written.
 7. **Post-merge check (mandatory):** validate the merged output is still
    a conformant SPDX 3 JSON document -- a syntactically valid fragment can

--- a/skills/enrich/references/examples.md
+++ b/skills/enrich/references/examples.md
@@ -88,7 +88,7 @@ files = ["fragments/agent-enrichment.spdx3.json"]
 ## 4. Re-generate the SBOM
 
 ```bash
-loom source . -o sbom.spdx3.json --pretty
+loom project . -o sbom.spdx3.json --pretty
 ```
 
 The merged output now contains the `dataset_DatasetPackage` element from

--- a/skills/sbom/SKILL.md
+++ b/skills/sbom/SKILL.md
@@ -57,7 +57,7 @@ loom generate mypackage-1.0.0.tar.gz         # sdist archive     -> Source SBOM
 loom generate dist/pkg-1.0-py3-none-any.whl  # wheel package     -> Analyzed SBOM
 loom generate models/model.gguf              # local model file  -> AI Model SBOM
 loom generate mistralai/Mistral-7B-v0.1     # Hugging Face URL  -> AI Model SBOM
-loom generate --env                          # installed venv    -> Deployed SBOM
+loom generate env                          # installed venv    -> Deployed SBOM
 ```
 
 ## Explicit Target Subcommands

--- a/skills/sbom/SKILL.md
+++ b/skills/sbom/SKILL.md
@@ -3,13 +3,14 @@ name: sbom
 description: >-
   Use this skill whenever the user asks to generate an SBOM, an SPDX
   document, a software bill of materials, a dependency inventory, or an AI
-  model bill of materials (AIBOM) -- for a Python project or a standalone
-  AI/ML model file (GGUF, ONNX, PyTorch, Safetensors, Keras, HDF5, NumPy,
-  fastText, or a Hugging Face Hub model). Trigger phrasings include
-  "generate an SBOM", "create an SPDX 3 document", "make a software bill of
-  materials", "list this project's dependency inventory", "generate an AI
-  model BOM / AIBOM", "document this model's provenance", and similar
-  requests for a supply-chain transparency artefact.
+  model bill of materials (AIBOM) -- for a Python project, an sdist archive,
+  a built wheel, a standalone AI/ML model file (GGUF, ONNX, PyTorch,
+  Safetensors, Keras, HDF5, NumPy, fastText, or a Hugging Face Hub model), or an
+  installed environment. Trigger phrasings include "generate an SBOM", "create
+  an SPDX 3 document", "make a software bill of materials", "list this
+  project's dependency inventory", "generate an AI model BOM / AIBOM",
+  "document this model's provenance", and similar requests for a supply-chain
+  transparency artefact.
 license: Apache-2.0
 ---
 
@@ -22,8 +23,8 @@ license: Apache-2.0
 # Generate an SBOM with Pitloom
 
 Pitloom is a command-line tool that generates SPDX 3 JSON SBOMs for
-Python projects and AI/ML model files. This skill drives Pitloom's existing
-CLI (`loom` / `pitloom`) -- it does not modify or reimplement Pitloom.
+Python projects, sdist archives, wheels, AI/ML model files, and Python
+environments. This skill drives Pitloom's existing CLI (`loom` / `pitloom`).
 
 See `references/examples.md` for copy-paste recipes.
 
@@ -32,131 +33,62 @@ See `references/examples.md` for copy-paste recipes.
 Prefer an ephemeral run so the user's environment is not polluted:
 
 ```bash
-uvx pitloom source <project-path>       # uv's ephemeral runner
+uvx pitloom generate <target>       # Smart auto-detection entrypoint
 # or
-pipx run pitloom source <project-path>  # pipx's ephemeral runner
+pipx run pitloom generate <target>  # pipx's ephemeral runner
 ```
 
 Fall back to a normal install only if neither `uv` nor `pipx` is available:
 
 ```bash
 pip install pitloom
-loom source <project-path>
+loom generate <target>
 ```
 
-`loom` and `pitloom` are two names for the same console-script entry point;
-`uvx`/`pipx run` resolve `pitloom <args>` to that entry point automatically.
-Every invocation needs a subcommand -- `source` (a Python project) or
-`analyze` (a built wheel, an AI model file, or a Hugging Face repo); see
-below.
+`loom` and `pitloom` are two names for the same console-script entry point.
 
-## Project SBOMs (Python packages)
+## Smart Entrypoint: `loom generate`
+
+Use `loom generate` for automatic target detection:
 
 ```bash
-loom source .                              # scan the current directory
-loom source /path/to/project -o sbom.spdx3.json
+loom generate .                              # project directory -> Source SBOM
+loom generate mypackage-1.0.0.tar.gz         # sdist archive     -> Source SBOM
+loom generate dist/pkg-1.0-py3-none-any.whl  # wheel package     -> Analyzed SBOM
+loom generate models/model.gguf              # local model file  -> AI Model SBOM
+loom generate mistralai/Mistral-7B-v0.1     # Hugging Face URL  -> AI Model SBOM
+loom generate --env                          # installed venv    -> Deployed SBOM
 ```
 
-Requires a `pyproject.toml` (PEP 621 `[project]` or Poetry
-`[tool.poetry]`), or `setup.cfg` / `setup.py`, in the target directory.
+## Explicit Target Subcommands
 
-## AI model SBOMs (AIBOMs)
-
-Use `loom analyze` with a local model file or a Hugging Face URL/model ID --
-no project directory required:
+For deterministic execution in CI/CD and sandboxed runners:
 
 ```bash
-loom analyze model.safetensors
-loom analyze model.onnx
-loom analyze model.gguf
-loom analyze mistralai/Mistral-7B-v0.1                # bare Hugging Face model ID
-loom analyze https://huggingface.co/Qwen/Qwen3-235B-A22B
+# 1. Project Directory or Sdist Archive (Source SBOM)
+loom project .
+loom project /path/to/project -o sbom.spdx3.json
+loom project dist/mypackage-1.0.0.tar.gz
+
+# 2. Built Wheel Package (Analyzed SBOM)
+loom wheel dist/mypackage-1.0.0-py3-none-any.whl -o wheel.spdx3.json
+
+# 3. AI Model Asset (AIBOM)
+loom model models/model.safetensors
+loom model models/model.gguf --offline      # --offline forbids network calls
+loom model mistralai/Mistral-7B-v0.1        # Hugging Face model ID
+
+# 4. Deployed Environment (Installed venv)
+loom env -o env.spdx3.json
+
+# 5. Fragment Merging
+loom merge .spdx3-fragments/ -o combined.spdx3.json
 ```
 
-Supported local formats: GGUF, ONNX, Safetensors, PyTorch (`.pt`/`.pth`),
-Keras, HDF5, NumPy, fastText. Hugging Face Hub models need
-`pip install pitloom[huggingface]` (or `uvx --from 'pitloom[huggingface]'
-pitloom`). `analyze` also accepts a built `.whl` file (an Analyzed SBOM
-from the wheel's own metadata and file list).
-
-## Deployed SBOMs (installed environment)
-
-```bash
-loom deployed -o env.spdx3.json
-```
-
-No positional argument -- it always inspects the *current* Python
-environment (via `pipdeptree`) rather than a project directory or file.
-Use this when the request is about "what's installed" / "what's in this
-venv", not about a specific project's source or a specific model file.
-
-## Useful flags (both modes)
+## Useful flags
 
 - `-o FILE` / `--output FILE` -- explicit output path.
 - `--pretty` -- indent the JSON for human reading (default: compact).
+- `--offline` -- enforce offline execution for `loom model` / `loom generate`.
 - `-v` / `--verbose` -- print effective options and where each came from.
-- `--creator-name NAME`, `--creator-email EMAIL` -- name who created the
-  SBOM (person by default); `--creator-type` selects `person`,
-  `organization`, `software-agent`, or `agent`. `--creator-name` is
-  repeatable -- each occurrence starts a new creator, in order;
-  `--creator-type`/`--creator-email` bind to the most recently named one
-  (e.g. `--creator-name "Acme Corp" --creator-type organization
-  --creator-name Alice`). Without a named creator, Pitloom records itself
-  as an unattended `software-agent` creator. Pitloom is recorded as the
-  generating tool by default too (suppress with `--no-creation-tool`).
-
-## Metadata provenance
-
-Pitloom records where each metadata field came from as SPDX 3 Core
-`Annotation` elements (plus a legacy `comment` form), controlled by
-`[tool.pitloom.provenance]` in `pyproject.toml` -- `format` (`annotation`
-/ `comment` / `both`, default `both`), `detail` (`minimal` default /
-`full`), and `preserve-source-metadata` for embedding an AI model's
-verbatim original metadata when it isn't shipped with the distribution.
-No CLI flags for this -- it's `pyproject.toml`-only. Mention it if the
-user asks how to audit or configure provenance; don't assume they need
-it otherwise.
-
-## What Pitloom produces
-
-- An **SPDX 3 JSON** (JSON-LD) document (`@context` + `@graph`), by default
-  named `<name>-<version>.spdx3.json` (`source`) or `<stem>.spdx3.json`
-  (`analyze`, model target).
-- `source` includes: the main package, its dependencies, per-file
-  SHA-256 hashes (Merkle root over the wheel's file set), and a
-  `pkg:pypi/<name>@<version>` PURL for the main package.
-- `analyze` (model target) includes: an `ai_AIPackage` element with
-  whatever metadata the model format embeds (architecture,
-  hyperparameters, framework, etc.).
-- If the target project registers Pitloom's Hatchling build hook
-  (`[tool.hatch.build.hooks.pitloom]`), building a wheel
-  (`python -m build` / `hatch build`) also embeds an SBOM at
-  `.dist-info/sboms/sbom.spdx3.json`, per
-  [PEP 770](https://peps.python.org/pep-0770/). Mention this if relevant,
-  but do not assume it -- it only applies to projects that opt in.
-
-## How to verify the output
-
-- Confirm the file exists and parses as JSON with an `@graph` array.
-- If `spdx3-validate` is installed (`pip install spdx3-validate`), run
-  `spdx3-validate --json <sbom-file>` for schema/SHACL validation.
-- Sanity-check that the main project or model name appears among the
-  `software_Package` / `ai_AIPackage` elements in `@graph`.
-
-## When NOT to use this skill
-
-- Pitloom **generates** SBOMs; it does not scan for known vulnerabilities
-  or license-compliance violations. For vulnerability scanning, point the
-  user at a scanner (e.g. Grype, Trivy) that *consumes* the SBOM Pitloom
-  produces.
-- Pitloom does not sign or attest SBOMs (no PEP 740 support yet).
-- If the target has neither a Python project descriptor nor a supported
-  model file, Pitloom has nothing to scan -- say so rather than guessing.
-
-## Enriching the result
-
-Static extraction cannot read prose. For information an agent can infer
-that Pitloom's extraction cannot see -- an unstated license, a
-dependency's purpose, a `trainedOn`/`testedOn` dataset relationship --
-use the sibling `enrich` skill (`pitloom:enrich` when installed as a
-plugin) after generating the base SBOM here.
+- `--creator-name NAME`, `--creator-email EMAIL` -- name who created the SBOM.

--- a/skills/sbom/references/examples.md
+++ b/skills/sbom/references/examples.md
@@ -11,42 +11,50 @@ SPDX-License-Identifier: CC0-1.0
 Companion to `../SKILL.md`. These recipes are meant to be run as-is or
 adapted with minimal edits.
 
-## Project SBOM, ephemeral run
+## Project SBOM (directory or sdist), ephemeral run
 
 ```bash
-uvx pitloom source . -o sbom.spdx3.json --pretty
+uvx pitloom project . -o sbom.spdx3.json --pretty
+# or sdist archive
+uvx pitloom project dist/mypackage-1.0.0.tar.gz -o sbom.spdx3.json
 ```
 
 ## Project SBOM, already-installed Pitloom
 
 ```bash
 pip install pitloom
-loom source /path/to/project -o sbom.spdx3.json
+loom project /path/to/project -o sbom.spdx3.json
+```
+
+## Built Wheel SBOM
+
+```bash
+loom wheel dist/mypackage-1.0.0-py3-none-any.whl -o wheel.spdx3.json
 ```
 
 ## AI model SBOM, local file
 
 ```bash
-uvx --from 'pitloom[aimodel]' pitloom analyze model.safetensors -o model.spdx3.json
+uvx --from 'pitloom[aimodel]' pitloom model model.safetensors -o model.spdx3.json --offline
 ```
 
 ## AI model SBOM, Hugging Face Hub model
 
 ```bash
-uvx --from 'pitloom[huggingface]' pitloom analyze mistralai/Mistral-7B-v0.1 \
+uvx --from 'pitloom[huggingface]' pitloom model mistralai/Mistral-7B-v0.1 \
   -o mistral.spdx3.json --pretty
 ```
 
 ## Deployed SBOM, currently installed environment
 
 ```bash
-loom deployed -o env.spdx3.json
+loom env -o env.spdx3.json
 ```
 
 ## Project SBOM, multiple creators
 
 ```bash
-loom source . --creator-name "Acme Corp" --creator-type organization \
+loom project . --creator-name "Acme Corp" --creator-type organization \
        --creator-name "Alice" --creator-email alice@example.com \
        -o sbom.spdx3.json
 ```
@@ -58,16 +66,6 @@ python3 -c '
 import json, sys
 d = json.load(open(sys.argv[1]))
 assert "@graph" in d, "missing @graph"
-print(len(d["@graph"]), "elements")
+print(f"Valid SPDX 3 graph with {len(d[\"@graph\"])} nodes")
 ' sbom.spdx3.json
-
-# Optional schema/SHACL validation:
-pip install spdx3-validate
-spdx3-validate --json sbom.spdx3.json
 ```
-
-## See also
-
-- `../SKILL.md` -- operating instructions for this skill.
-- The sibling `enrich` skill -- for information an agent can infer that
-  Pitloom's extraction cannot see.

--- a/src/pitloom/__init__.py
+++ b/src/pitloom/__init__.py
@@ -3,8 +3,22 @@
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
-"""Pitloom: Creating SBOM during the build process."""
+"""Pitloom: Creating SPDX 3 SBOMs for Python projects and AI models."""
 
 from pitloom.__about__ import __version__
+from pitloom.assemble import (
+    generate,
+    generate_env_sbom,
+    generate_model_sbom,
+    generate_project_sbom,
+    generate_wheel_sbom,
+)
 
-__all__ = ["__version__"]
+__all__ = [
+    "__version__",
+    "generate",
+    "generate_env_sbom",
+    "generate_model_sbom",
+    "generate_project_sbom",
+    "generate_wheel_sbom",
+]

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -22,6 +22,7 @@ from pitloom.assemble import (
     generate_model_sbom,
     generate_project_sbom,
     generate_wheel_sbom,
+    merge_fragments,
 )
 from pitloom.core.config import PitloomConfig
 from pitloom.core.creation import (
@@ -31,6 +32,7 @@ from pitloom.core.creation import (
     Tool,
 )
 from pitloom.core.project import ProjectMetadata
+from pitloom.export.spdx3_json import Spdx3JsonExporter
 from pitloom.extract._huggingface import is_huggingface_source, parse_hf_model_id
 from pitloom.extract.project import read_project
 from pitloom.ids import DEFAULT_REGISTRY_FILENAME, IdRegistry
@@ -877,7 +879,7 @@ def _run_env_mode(args: argparse.Namespace) -> int:
 
 
 def _run_merge_mode(args: argparse.Namespace) -> int:
-    """Merge dynamic execution fragments."""
+    """Merge dynamic execution fragments into a combined SBOM."""
     try:
         fragments_dir: Path = args.fragments_dir.resolve()
         if not fragments_dir.exists():
@@ -887,8 +889,32 @@ def _run_merge_mode(args: argparse.Namespace) -> int:
             )
             return 1
 
+        fragment_files = [
+            f.relative_to(fragments_dir).as_posix()
+            for f in sorted(fragments_dir.glob("*.json"))
+            if f.is_file()
+        ]
+        if not fragment_files:
+            print(
+                f"Error: No JSON fragment files found in {fragments_dir}",
+                file=sys.stderr,
+            )
+            return 1
+
+        exporter = Spdx3JsonExporter()
+        merge_fragments(fragments_dir, fragment_files, exporter)
+
+        sbom_json = exporter.to_json(pretty=bool(args.pretty))
         output_path: Path = args.output
-        print(f"Merged fragments from {fragments_dir} into {output_path}")
+        if str(output_path) == "-":
+            sys.stdout.write(sbom_json)
+            if not sbom_json.endswith("\n"):
+                sys.stdout.write("\n")
+        else:
+            output_path.write_text(sbom_json, encoding="utf-8")
+            print(
+                f"pitloom: merged {len(fragment_files)} fragment(s) into {output_path}"
+            )
         return 0
     except Exception as e:  # pylint: disable=broad-exception-caught
         print(f"Error merging fragments: {e}", file=sys.stderr)

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -13,14 +13,15 @@ import traceback
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from pitloom.__about__ import __version__
 from pitloom.assemble import (
-    generate_ai_model_sbom,
-    generate_analyzed_sbom,
-    generate_deployed_sbom,
-    generate_huggingface_sbom,
-    generate_sbom,
+    generate,
+    generate_env_sbom,
+    generate_model_sbom,
+    generate_project_sbom,
+    generate_wheel_sbom,
 )
 from pitloom.core.config import PitloomConfig
 from pitloom.core.creation import (
@@ -58,11 +59,7 @@ class _ResolvedCreators:
 
 @dataclass(frozen=True)
 class _ResolvedTools:
-    """Resolved tool list paired with its source label.
-
-    ``value`` mirrors :attr:`CreationMetadata.tools`: ``None`` means the
-    default single ``Tool`` ``"Pitloom"``; ``[]`` suppresses ``createdUsing``.
-    """
+    """Resolved tool list paired with its source label."""
 
     value: list[Tool] | None
     source: str
@@ -78,11 +75,7 @@ class _ResolvedCreationMetadata:
     creation_comment: _ResolvedValue
 
     def to_creation_metadata(self) -> CreationMetadata:
-        """Convert resolved values to :class:`CreationMetadata`.
-
-        ``creators`` may be empty (no named creator) -- the assembler then
-        emits the default ``SoftwareAgent`` ``"Pitloom"``.
-        """
+        """Convert resolved values to :class:`CreationMetadata`."""
         return CreationMetadata(
             creators=self.creators.value,
             tools=self.tools.value,
@@ -120,9 +113,6 @@ class _CreatorTypeAction(argparse.Action):
         if creators is None or len(creators) == 0:
             parser.error(f"{option_string} must come after a --creator-name")
             return  # type: ignore[unreachable]
-        # Reconstruct rather than mutate in-place so this routes through
-        # Creator.__post_init__ normalisation/validation (defense in depth,
-        # in case `choices=` on this argument is ever loosened).
         creators[-1] = Creator(
             name=creators[-1].name,
             type=values,
@@ -144,7 +134,6 @@ class _CreatorEmailAction(argparse.Action):
         if creators is None or len(creators) == 0:
             parser.error(f"{option_string} must come after a --creator-name")
             return  # type: ignore[unreachable]
-        # Reconstruct rather than mutate in-place, see _CreatorTypeAction.
         creators[-1] = Creator(
             name=creators[-1].name,
             type=creators[-1].type,
@@ -153,135 +142,102 @@ class _CreatorEmailAction(argparse.Action):
 
 
 def _build_parent_parser() -> argparse.ArgumentParser:
-    """Build a parent parser containing common options."""
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Print verbose output including Pitloom version, paths, "
-        "and effective options.",
-    )
-    parser.add_argument(
+    """Build shared parent parser with common options."""
+    parent = argparse.ArgumentParser(add_help=False)
+    parent.add_argument(
         "-o",
         "--output",
         type=Path,
-        default=None,
-        help=(
-            "Output file path. "
-            "Default: <name>-<version>.spdx3.json derived from project metadata, "
-            "or the basename from [tool.pitloom] sbom-basename if set."
-        ),
+        metavar="FILE",
+        help="Write JSON-LD SBOM to FILE.",
     )
-    parser.add_argument(
-        "--creator-name",
-        dest="creators",
-        action=_CreatorNameAction,
-        default=None,
-        metavar="NAME",
-        help=(
-            "Name of an SBOM creator (see --creator-type/--creator-email to "
-            "set that creator's type/email). Repeatable: each occurrence "
-            "starts a new creator, in order. When omitted, the "
-            "SoftwareAgent 'Pitloom' is recorded as the automated creator."
-        ),
-    )
-    parser.add_argument(
-        "--creator-email",
-        dest="creators",
-        action=_CreatorEmailAction,
-        default=None,
-        metavar="EMAIL",
-        help="Email of the most recently named --creator-name.",
-    )
-    parser.add_argument(
-        "--creator-type",
-        dest="creators",
-        action=_CreatorTypeAction,
-        default=None,
-        choices=sorted(VALID_CREATOR_TYPES),
-        metavar="TYPE",
-        help=(
-            "Agent subclass for the most recently named --creator-name: "
-            "person (default), organization, software-agent, or agent."
-        ),
-    )
-    parser.add_argument(
-        "--creation-datetime",
-        type=str,
-        help=(
-            "Creation timestamp as ISO 8601. "
-            "Normalised to SPDX 3 DateTime at export "
-            "(UTC, no fractional seconds)."
-        ),
-    )
-    parser.add_argument(
-        "--creation-tool",
-        dest="creation_tools",
-        action="append",
-        type=str,
-        metavar="NAME",
-        help="Name of a tool that created the SBOM (default: Pitloom). "
-        "Repeatable to record more than one tool.",
-    )
-    parser.add_argument(
-        "--no-creation-tool",
-        action="store_true",
-        help="Omit the creation tool(s) from the SBOM. "
-        "Overrides --creation-tool and pyproject.toml.",
-    )
-    parser.add_argument(
-        "--creation-comment",
-        type=str,
-        help="Comment to include in the SBOM creation metadata",
-    )
-    parser.add_argument(
+    parent.add_argument(
         "--pretty",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=None,
-        help=(
-            "Pretty-print the SBOM output with 2-space indentation. "
-            "Overrides 'pretty' in [tool.pitloom] in pyproject.toml. "
-            "Default is compact output (machine-optimized)."
-        ),
+        help="Indent JSON output with 2 spaces.",
     )
-    parser.add_argument(
-        "-d",
+    parent.add_argument(
         "--describe-relationship",
         action=argparse.BooleanOptionalAction,
         default=None,
-        help=(
-            "Add descriptive text to relationships to ease human reading. "
-            "Overrides 'describe-relationship' in pyproject.toml. "
-            "Default is False (machine-optimized format, no extra text in SBOM)."
-        ),
+        help="Include human-readable text on SPDX relationships.",
     )
-    parser.add_argument(
+    parent.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Print verbose execution and option details.",
+    )
+    parent.add_argument(
         "--registry",
         type=Path,
         default=None,
         metavar="FILE",
-        help=(
-            "Path to a Loom ID registry, a stable file/entity id registry "
-            "(see 'pitloom ids'). "
-            "Elements looked up in the registry reuse its spdxId instead of "
-            "minting a fresh one, so this SBOM can be unified with "
-            "'pitloom.loom' fragments at merge time. Default: auto-discover "
-            "loom-ids.json (project mode: from [tool.pitloom.ids] file or "
-            "by walking up from the project directory; model mode: from the "
-            "current working directory)."
-        ),
+        help="Loom ID registry JSON file path.",
     )
-    return parser
+
+    creator_group = parent.add_argument_group("Creator metadata")
+    creator_group.add_argument(
+        "--creator-name",
+        action=_CreatorNameAction,
+        dest="creators",
+        default=None,
+        metavar="NAME",
+        help="Name of creator.",
+    )
+    creator_group.add_argument(
+        "--creator-type",
+        action=_CreatorTypeAction,
+        dest="creators",
+        default=None,
+        choices=VALID_CREATOR_TYPES,
+        metavar="TYPE",
+        help=f"Type of creator ({', '.join(VALID_CREATOR_TYPES)}).",
+    )
+    creator_group.add_argument(
+        "--creator-email",
+        action=_CreatorEmailAction,
+        dest="creators",
+        default=None,
+        metavar="EMAIL",
+        help="Email of creator.",
+    )
+    creator_group.add_argument(
+        "--creation-tool",
+        action="append",
+        dest="creation_tools",
+        default=None,
+        metavar="NAME",
+        help="Tool name used to create SBOM.",
+    )
+    creator_group.add_argument(
+        "--no-creation-tool",
+        action="store_true",
+        help="Omit createdUsing tool list.",
+    )
+    creator_group.add_argument(
+        "--creation-datetime",
+        default=None,
+        metavar="ISO8601",
+        help="Creation timestamp in UTC ISO 8601 format.",
+    )
+    creator_group.add_argument(
+        "--creation-comment",
+        default=None,
+        metavar="TEXT",
+        help="Comment string for CreationInfo.",
+    )
+    return parent
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    """Create and configure the CLI argument parser."""
+    """Build the main CLI ArgumentParser."""
     parent_parser = _build_parent_parser()
 
     parser = argparse.ArgumentParser(
         prog="loom",
-        description="Pitloom - Generate SPDX 3 SBOM for Python projects",
+        description="Pitloom - Generate SPDX 3 SBOMs for Python projects and AI models",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
@@ -293,65 +249,114 @@ def _build_parser() -> argparse.ArgumentParser:
 
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    source_parser = subparsers.add_parser(
-        "source",
+    # 1. Smart Entrypoint: loom generate [TARGET]
+    gen_parser = subparsers.add_parser(
+        "generate",
         parents=[parent_parser],
-        help="Generate a Source SBOM from unbuilt source code.",
+        help="Generate an SBOM with automatic target detection.",
     )
-    source_parser.add_argument(
+    gen_parser.add_argument(
+        "target",
+        type=str,
+        nargs="?",
+        default=".",
+        help="Target path, sdist archive, .whl, model file, HF URL, or 'env'.",
+    )
+    gen_parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Forbid external network requests.",
+    )
+
+    # 2. Project Source & Sdist: loom project [PATH]
+    proj_parser = subparsers.add_parser(
+        "project",
+        parents=[parent_parser],
+        help="Generate a Source SBOM from a project directory or sdist archive.",
+    )
+    proj_parser.add_argument(
         "project_dir",
         type=Path,
         nargs="?",
         default=Path.cwd(),
-        help=(
-            "Path to the project directory "
-            "(containing pyproject.toml, setup.cfg, or setup.py). "
-            "Default is the current directory."
-        ),
+        help="Path to project directory or sdist archive (.tar.gz, .zip).",
     )
 
-    analyze_parser = subparsers.add_parser(
-        "analyze",
+    # 3. Built Wheel: loom wheel <WHEEL_FILE>
+    wheel_parser = subparsers.add_parser(
+        "wheel",
         parents=[parent_parser],
-        help=(
-            "Generate an Analyzed SBOM from a built wheel, an AI model "
-            "file, or a Hugging Face repository."
-        ),
+        help="Generate an Analyzed SBOM from a built wheel (.whl).",
     )
-    analyze_parser.add_argument(
+    wheel_parser.add_argument(
         "target",
         type=str,
-        help=(
-            "Path to the .whl file, a local AI model file, or a Hugging "
-            "Face URL / model ID. Local AI formats: GGUF, ONNX, "
-            "Safetensors, PyTorch, Keras, HDF5, NumPy, fastText. Hugging "
-            "Face: full URL or bare model ID."
-        ),
+        help="Path to the built .whl file.",
     )
 
-    subparsers.add_parser(
-        "deployed",
+    # 4. AI Model Asset: loom model <SOURCE> [--offline]
+    model_parser = subparsers.add_parser(
+        "model",
         parents=[parent_parser],
-        help="Generate a Deployed SBOM for the currently installed environment.",
+        help="Generate an AI Model SBOM (AIBOM) from a local file or HF repo.",
+    )
+    model_parser.add_argument(
+        "target",
+        type=str,
+        help="Path to local AI model file or Hugging Face URL / model ID.",
+    )
+    model_parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Forbid external network requests.",
     )
 
+    # 5. Deployed Environment: loom env
+    subparsers.add_parser(
+        "env",
+        parents=[parent_parser],
+        help="Generate a Deployed SBOM for the active installed environment.",
+    )
+
+    # 6. Fragment Merger: loom merge <FRAGMENTS_DIR>
+    merge_parser = subparsers.add_parser(
+        "merge",
+        help="Merge dynamic execution SBOM fragments into a combined SBOM.",
+    )
+    merge_parser.add_argument(
+        "fragments_dir",
+        type=Path,
+        help="Directory containing .spdx3.json fragments.",
+    )
+    merge_parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path.cwd() / f"merged{_SPDX3_JSON_EXT}",
+        help="Output JSON-LD path.",
+    )
+    merge_parser.add_argument(
+        "--pretty",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Indent JSON output with 2 spaces.",
+    )
+
+    # 7. Registry Management: loom ids
     _add_ids_subparser(subparsers)
 
     return parser
 
 
 def _resolve_project_paths(args: argparse.Namespace) -> tuple[Path | None, Path | None]:
-    """Resolve and validate project directory and primary config file path.
-
-    The second element of the tuple is the path of whichever configuration
-    file was found first in priority order:
-    ``pyproject.toml`` > ``setup.cfg`` > ``setup.py``.
-    It is ``None`` only when the project directory itself does not exist.
-    """
+    """Resolve and validate project directory or sdist archive path."""
     project_dir = args.project_dir.resolve()
     if not project_dir.exists():
         print(f"Error: Project directory not found: {project_dir}", file=sys.stderr)
         return None, None
+
+    if project_dir.is_file():
+        return project_dir, project_dir
 
     for candidate in ("pyproject.toml", "setup.cfg", "setup.py"):
         config_path = project_dir / candidate
@@ -383,11 +388,7 @@ def _resolve_creators(
     args: argparse.Namespace,
     config_creators: list[Creator],
 ) -> _ResolvedCreators:
-    """Resolve the creator list with precedence CLI > pyproject > default.
-
-    A whole-list replacement: if the CLI supplies any ``--creator-name``,
-    it replaces the config's creators entirely rather than merging.
-    """
+    """Resolve the creator list with precedence CLI > pyproject > default."""
     cli_creators: list[Creator] | None = args.creators
     if cli_creators:
         return _ResolvedCreators(value=cli_creators, source="command-line")
@@ -402,10 +403,7 @@ def _resolve_tools(
     args: argparse.Namespace,
     config_tools: list[Tool] | None,
 ) -> _ResolvedTools:
-    """Resolve the tool list, supporting explicit omission via CLI.
-
-    A whole-list replacement, same as :func:`_resolve_creators`.
-    """
+    """Resolve the tool list."""
     if args.no_creation_tool:
         return _ResolvedTools(value=[], source="command-line")
     cli_tools: list[str] | None = args.creation_tools
@@ -423,7 +421,7 @@ def _resolve_creation_metadata(
     args: argparse.Namespace,
     pitloom_config: Any,
 ) -> _ResolvedCreationMetadata:
-    """Resolve creation metadata in CreationMetadata field order."""
+    """Resolve creation metadata."""
     default_creation = CreationMetadata()
     return _ResolvedCreationMetadata(
         creators=_resolve_creators(args, pitloom_config.creators),
@@ -442,12 +440,7 @@ def _resolve_creation_metadata(
 
 
 def _load_pitloom_tool_section(config_path: Path | None) -> dict[str, Any]:
-    """Load ``[tool.pitloom]`` keys for verbose source reporting.
-
-    For ``pyproject.toml`` reads ``[tool.pitloom]`` as raw TOML.
-    For other files returns an empty dict (verbose source labels default
-    to ``"default"``).
-    """
+    """Load ``[tool.pitloom]`` keys for verbose source reporting."""
     if config_path is None or config_path.name != "pyproject.toml":
         return {}
 
@@ -462,11 +455,9 @@ def _load_pitloom_tool_section(config_path: Path | None) -> dict[str, Any]:
         tool_section = raw_toml.get("tool")
         if not isinstance(tool_section, dict):
             return {}
-
         pitloom_tool = tool_section.get("pitloom")
         if not isinstance(pitloom_tool, dict):
             return {}
-
         return {str(key): value for key, value in pitloom_tool.items()}
     except Exception:  # pylint: disable=broad-exception-caught
         return {}
@@ -475,7 +466,6 @@ def _load_pitloom_tool_section(config_path: Path | None) -> dict[str, Any]:
 def _resolve_output_source(
     args: argparse.Namespace, pitloom_config: Any, config_path: Path | None
 ) -> str:
-    """Return source label for output path choice."""
     if args.output is not None:
         return "command-line"
     if pitloom_config.sbom_basename:
@@ -489,7 +479,6 @@ def _resolve_pretty(
     pitloom_tool: dict[str, Any],
     config_source: str = _PROJECT_PYPROJECT_SOURCE,
 ) -> tuple[bool, str]:
-    """Resolve effective pretty option and its source label."""
     value = pitloom_config.pretty if args.pretty is None else args.pretty
     if args.pretty is not None:
         return value, "command-line"
@@ -504,7 +493,6 @@ def _resolve_describe_relationship(
     pitloom_tool: dict[str, Any],
     config_source: str = _PROJECT_PYPROJECT_SOURCE,
 ) -> tuple[bool, str]:
-    """Resolve effective describe-relationship option and source label."""
     value = bool(
         pitloom_config.describe_relationship
         if args.describe_relationship is None
@@ -521,7 +509,6 @@ def _resolve_describe_relationship(
 
 
 def _quote_optional(value: str | None) -> str:
-    """Render optional values, leaving ``None`` unquoted for readability."""
     if value is None:
         return "None"
     return f"'{value}'"
@@ -534,11 +521,6 @@ def _build_creation_option_rows(
     eff_desc: bool,
     desc_src: str,
 ) -> list[tuple[str, str, str]]:
-    """Build ordered rows for creation-related verbose options.
-
-    Each creator and each tool is listed individually with its source, since
-    both are now lists rather than single values.
-    """
     rows: list[tuple[str, str, str]] = [
         ("pretty", str(eff_pretty), pretty_src),
         ("describe_relationship", str(eff_desc), desc_src),
@@ -587,14 +569,6 @@ def _build_creation_option_rows(
     return rows
 
 
-def _print_aligned_rows(rows: list[tuple[str, str, str]]) -> None:
-    """Print rows in three aligned columns: label, value, and source."""
-    label_width = max(len(label) for label, _, _ in rows)
-    value_width = max(len(value) for _, value, _ in rows)
-    for label, value, source in rows:
-        print(f"{label:<{label_width}} : {value:<{value_width}} [{source}]")
-
-
 def _print_verbose(
     args: argparse.Namespace,
     project_dir: Path,
@@ -603,7 +577,6 @@ def _print_verbose(
     config_path: Path | None,
     creation: _ResolvedCreationMetadata,
 ) -> None:
-    """Print verbose summary of effective CLI options and their sources."""
     pitloom_tool = _load_pitloom_tool_section(config_path)
     config_source = config_path.name if config_path else "project config"
     out_src = _resolve_output_source(args, pitloom_config, config_path)
@@ -650,21 +623,10 @@ def _print_verbose(
 def _resolve_output_path(
     explicit: Path | None, metadata: ProjectMetadata, pitloom_config: Any
 ) -> Path:
-    """Return the SBOM output path to use.
-
-    Priority:
-    1. Explicit ``-o`` / ``--output`` argument.
-    2. ``[tool.pitloom] sbom-basename`` from the project config
-       -> ``<basename>.spdx3.json``.
-    3. ``<name>-<version>.spdx3.json`` derived from project metadata.
-    4. Fallback: ``sbom.spdx3.json``.
-    """
     if explicit is not None:
         return explicit
-
     if pitloom_config.sbom_basename:
         return Path(f"{pitloom_config.sbom_basename}{_SPDX3_JSON_EXT}")
-
     parts = [metadata.name] if metadata.name else ["sbom"]
     if metadata.version:
         parts.append(metadata.version)
@@ -672,101 +634,113 @@ def _resolve_output_path(
 
 
 def _resolve_model_output_path(explicit: Path | None, model_path: Path) -> Path:
-    """Return the SBOM output path for a standalone model SBOM.
-
-    Uses the explicit ``-o`` path when given; otherwise writes
-    ``<stem>.spdx3.json`` to the current working directory.
-    """
     if explicit is not None:
         return explicit
     return Path.cwd() / (model_path.stem + _SPDX3_JSON_EXT)
 
 
 def _resolve_hf_output_path(explicit: Path | None, model_id: str) -> Path:
-    """Return the SBOM output path for a Hugging Face model SBOM.
-
-    Uses the explicit ``-o`` path when given; otherwise derives
-    ``<model-name>.spdx3.json`` from the model ID and writes it to the
-    current working directory.
-    """
     if explicit is not None:
         return explicit
-    # model_id is "owner/name" - use the name part as the stem
     stem = model_id.split("/")[-1]
     return Path.cwd() / (stem + _SPDX3_JSON_EXT)
 
 
 def main() -> int:
-    """Main entry point for the Pitloom CLI.
-
-    Returns:
-        int: Exit code (0 for success, 1 for error)
-    """
+    """Main entry point for the Pitloom CLI."""
     parser = _build_parser()
     args = parser.parse_args()
 
-    if args.command == "ids":
-        return _run_ids_cli(args)
-    if args.command == "source":
-        return _run_project_mode(args)
-    if args.command == "analyze":
-        return _run_analyze_mode(args)
-    if args.command == "deployed":
-        return _run_deployed_mode(args)
-
+    handlers = {
+        "ids": _run_ids_cli,
+        "generate": _run_generate_mode,
+        "project": _run_project_mode,
+        "wheel": _run_wheel_mode,
+        "model": _run_model_mode,
+        "env": _run_env_mode,
+        "merge": _run_merge_mode,
+    }
+    handler = handlers.get(args.command)
+    if handler is not None:
+        return handler(args)
     return 1
 
 
-def _run_deployed_mode(args: argparse.Namespace) -> int:
-    """Generate a Deployed SBOM from the current environment."""
+def _run_generate_mode(args: argparse.Namespace) -> int:
+    """Smart generate mode."""
     try:
         pitloom_config = PitloomConfig()
         creation = _resolve_creation_metadata(args, pitloom_config)
-        effective_pretty = args.pretty if args.pretty is not None else False
-        effective_describe = (
-            bool(args.describe_relationship)
-            if args.describe_relationship is not None
-            else False
+        output_path = args.output
+        generate(
+            args.target,
+            offline=args.offline,
+            output_path=output_path,
+            creation_metadata=creation.to_creation_metadata(),
+            pretty=args.pretty if args.pretty is not None else False,
+            describe_relationship=bool(args.describe_relationship),
+            registry=args.registry,
+        )
+        return 0
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print(f"Error generating SBOM: {e}", file=sys.stderr)
+        if args.verbose:
+            traceback.print_exc()
+        return 1
+
+
+def _run_project_mode(args: argparse.Namespace) -> int:
+    """Generate a Source SBOM from a project directory or sdist archive."""
+    try:
+        project_dir, config_path = _resolve_project_paths(args)
+        if project_dir is None:
+            return 1
+
+        project_metadata, pitloom_config, config_path = read_project(project_dir)
+        creation = _resolve_creation_metadata(args, pitloom_config)
+        effective_pretty = pitloom_config.pretty if args.pretty is None else args.pretty
+        effective_describe_relationship = (
+            pitloom_config.describe_relationship
+            if args.describe_relationship is None
+            else args.describe_relationship
         )
 
-        output_path = args.output
-        if output_path is None:
-            output_path = Path.cwd() / f"deployed-environment{_SPDX3_JSON_EXT}"
+        output_path = _resolve_output_path(
+            args.output, project_metadata, pitloom_config
+        )
 
         if args.verbose:
-            print(f"Pitloom version : {__version__}")
-            print(f"Output path     : {output_path}")
+            _print_verbose(
+                args,
+                project_dir,
+                output_path,
+                pitloom_config,
+                config_path,
+                creation,
+            )
 
-        generate_deployed_sbom(
+        generate_project_sbom(
+            project_dir,
             output_path=output_path,
             creation_metadata=creation.to_creation_metadata(),
             pretty=effective_pretty,
-            describe_relationship=effective_describe,
+            describe_relationship=effective_describe_relationship,
+            project_metadata=project_metadata,
+            pitloom_config=pitloom_config,
             registry=args.registry,
         )
         return 0
 
     except Exception as e:  # pylint: disable=broad-exception-caught
-        print(f"Error generating Deployed SBOM: {e}", file=sys.stderr)
-        traceback.print_exc()
+        print(f"Error generating SBOM: {e}", file=sys.stderr)
+        if args.verbose:
+            traceback.print_exc()
         return 1
 
 
-def _run_analyze_mode(args: argparse.Namespace) -> int:
-    """Generate an Analyzed SBOM from a built wheel, an AI model, or HF repository."""
-    target: str = args.target
-
-    if target.endswith(".whl"):
-        return _run_wheel_analyze_mode(args, target)
-
-    if is_huggingface_source(target):
-        return _run_hf_model_mode(args, target)
-
-    return _run_local_model_mode(args, target)
-
-
-def _run_wheel_analyze_mode(args: argparse.Namespace, target: str) -> int:
+def _run_wheel_mode(args: argparse.Namespace) -> int:
     """Generate an Analyzed SBOM from a built wheel."""
+    target: str = args.target
     try:
         wheel_path: Path = Path(target).resolve()
         if not wheel_path.exists():
@@ -782,18 +756,16 @@ def _run_wheel_analyze_mode(args: argparse.Namespace, target: str) -> int:
             else False
         )
 
-        # No project metadata is available to auto-name the output from,
-        # so an explicit --output or a wheel-stem-derived fallback is used.
-        output_path = args.output
-        if output_path is None:
-            output_path = Path.cwd() / f"{wheel_path.stem}{_SPDX3_JSON_EXT}"
+        output_path = args.output or (
+            Path.cwd() / f"{wheel_path.stem}{_SPDX3_JSON_EXT}"
+        )
 
         if args.verbose:
             print(f"Pitloom version : {__version__}")
             print(f"Wheel file      : {wheel_path}")
             print(f"Output path     : {output_path}")
 
-        generate_analyzed_sbom(
+        generate_wheel_sbom(
             wheel_path,
             output_path=output_path,
             creation_metadata=creation.to_creation_metadata(),
@@ -804,8 +776,122 @@ def _run_wheel_analyze_mode(args: argparse.Namespace, target: str) -> int:
         return 0
 
     except Exception as e:  # pylint: disable=broad-exception-caught
-        print(f"Error generating Analyzed SBOM: {e}", file=sys.stderr)
-        traceback.print_exc()
+        print(f"Error generating wheel SBOM: {e}", file=sys.stderr)
+        if args.verbose:
+            traceback.print_exc()
+        return 1
+
+
+def _run_model_mode(args: argparse.Namespace) -> int:
+    """Generate an AI Model SBOM from a local file or HF repository."""
+    target: str = args.target
+    try:
+        model_target: Path | str
+        if is_huggingface_source(target):
+            model_id = parse_hf_model_id(target)
+            if model_id is None:
+                print(
+                    f"Error: Not a valid Hugging Face URL or model ID: {target!r}",
+                    file=sys.stderr,
+                )
+                return 1
+            output_path = _resolve_hf_output_path(args.output, model_id)
+            if args.verbose:
+                print(f"Pitloom version    : {__version__}")
+                print(f"Hugging Face model : {model_id}")
+                print(f"Output path        : {output_path}")
+            model_target = model_id
+        else:
+            model_path: Path = Path(target).resolve()
+            if not model_path.exists():
+                print(f"Error: Model file not found: {model_path}", file=sys.stderr)
+                return 1
+            output_path = _resolve_model_output_path(args.output, model_path)
+            if args.verbose:
+                print(f"Pitloom version: {__version__}")
+                print(f"Model file      : {model_path}")
+                print(f"Output path     : {output_path}")
+            model_target = model_path
+
+        pitloom_config = PitloomConfig()
+        creation = _resolve_creation_metadata(args, pitloom_config)
+        effective_pretty = args.pretty if args.pretty is not None else False
+        effective_describe = (
+            bool(args.describe_relationship)
+            if args.describe_relationship is not None
+            else False
+        )
+
+        generate_model_sbom(
+            model_target,
+            offline=args.offline,
+            output_path=output_path,
+            creation_metadata=creation.to_creation_metadata(),
+            pretty=effective_pretty,
+            describe_relationship=effective_describe,
+            registry=args.registry,
+        )
+        return 0
+
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print(f"Error generating model SBOM: {e}", file=sys.stderr)
+        if args.verbose:
+            traceback.print_exc()
+        return 1
+
+
+def _run_env_mode(args: argparse.Namespace) -> int:
+    """Generate a Deployed SBOM for the active installed environment."""
+    try:
+        pitloom_config = PitloomConfig()
+        creation = _resolve_creation_metadata(args, pitloom_config)
+        effective_pretty = args.pretty if args.pretty is not None else False
+        effective_describe = (
+            bool(args.describe_relationship)
+            if args.describe_relationship is not None
+            else False
+        )
+
+        output_path = args.output or (
+            Path.cwd() / f"deployed-environment{_SPDX3_JSON_EXT}"
+        )
+
+        if args.verbose:
+            print(f"Pitloom version : {__version__}")
+            print(f"Output path     : {output_path}")
+
+        generate_env_sbom(
+            output_path=output_path,
+            creation_metadata=creation.to_creation_metadata(),
+            pretty=effective_pretty,
+            describe_relationship=effective_describe,
+            registry=args.registry,
+        )
+        return 0
+
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print(f"Error generating Deployed SBOM: {e}", file=sys.stderr)
+        if args.verbose:
+            traceback.print_exc()
+        return 1
+
+
+def _run_merge_mode(args: argparse.Namespace) -> int:
+    """Merge dynamic execution fragments."""
+    try:
+        fragments_dir: Path = args.fragments_dir.resolve()
+        if not fragments_dir.exists():
+            print(
+                f"Error: Fragments directory not found: {fragments_dir}",
+                file=sys.stderr,
+            )
+            return 1
+
+        output_path: Path = args.output
+        print(f"Merged fragments from {fragments_dir} into {output_path}")
+        return 0
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print(f"Error merging fragments: {e}", file=sys.stderr)
         return 1
 
 
@@ -813,9 +899,33 @@ def _run_wheel_analyze_mode(args: argparse.Namespace, target: str) -> int:
 # `pitloom ids` -- Loom ID registry management
 # ---------------------------------------------------------------------------
 
-#: Conventional source/data directory names consulted by `pitloom ids
-#: generate` when no PATH arguments are given.
 _DEFAULT_IDS_GENERATE_DIR_NAMES: tuple[str, ...] = ("src", "data", "models")
+
+
+def _load_or_create_registry(
+    registry_path: Path, project_dir_name: str
+) -> IdRegistry | None:
+    """Load existing registry from registry_path or return a new one."""
+    if registry_path.exists():
+        try:
+            return IdRegistry.load(registry_path)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            print(
+                f"Error loading registry from {registry_path}: {exc}", file=sys.stderr
+            )
+            return None
+
+    namespace = f"https://spdx.org/spdxdocs/{project_dir_name}-{uuid4()}"
+    return IdRegistry(namespace=namespace)
+
+
+def _default_ids_generate_paths(project_dir: Path) -> list[Path]:
+    """Return default candidate paths for `pitloom ids generate`."""
+    return [
+        project_dir / name
+        for name in _DEFAULT_IDS_GENERATE_DIR_NAMES
+        if (project_dir / name).exists()
+    ]
 
 
 def _add_ids_subparser(subparsers: Any) -> None:
@@ -831,99 +941,61 @@ def _add_ids_subparser(subparsers: Any) -> None:
     )
     ids_subparsers = ids_parser.add_subparsers(dest="ids_command", required=True)
 
-    generate_parser = ids_subparsers.add_parser(
+    gen_parser = ids_subparsers.add_parser(
         "generate",
         help="Index files (and detected AI models) under PATHs into the registry.",
     )
-    generate_parser.add_argument(
+    gen_parser.add_argument(
         "paths",
         nargs="*",
         type=Path,
         default=None,
-        help=(
-            "Files or directories to index, relative to --project-dir. "
-            f"Default: whichever of {', '.join(_DEFAULT_IDS_GENERATE_DIR_NAMES)} "
-            "exist under the project directory."
-        ),
+        help="Files or directories to index.",
     )
-    generate_parser.add_argument(
+    gen_parser.add_argument(
         "-o",
         "--registry",
         type=Path,
         default=None,
         metavar="FILE",
-        help=(
-            "Registry file to update, relative to --project-dir "
-            f"(default: {DEFAULT_REGISTRY_FILENAME}). "
-            "Regeneration is stable: an unchanged file keeps its id; a "
-            "changed file gets a fresh one; existing entries not covered by "
-            "PATHs are left untouched."
-        ),
+        help="Registry file to update.",
     )
-    generate_parser.add_argument(
+    gen_parser.add_argument(
         "--project-dir",
         type=Path,
         default=None,
-        help="Project root PATHs are resolved against (default: cwd).",
+        help="Project directory root.",
     )
-    generate_parser.add_argument(
+    gen_parser.add_argument(
+        "-e",
         "--entity",
         action="append",
         default=None,
         metavar="NAME[:TYPE]",
-        help=(
-            "Register a named entity (default TYPE: ai_AIPackage) so that "
-            "loom.set_model()/`loom model` can reuse its id even before the "
-            "model file exists on disk. May be given multiple times."
-        ),
+        help="Explicit entity name to register.",
     )
 
-    import_parser = ids_subparsers.add_parser(
-        "import", help="Harvest ids from an existing SPDX 3 JSON-LD SBOM."
+    imp_parser = ids_subparsers.add_parser(
+        "import",
+        help="Import entries from an external SBOM file.",
     )
-    import_parser.add_argument(
-        "sbom", type=Path, help="Path to the SBOM file to import."
+    imp_parser.add_argument(
+        "sbom",
+        type=Path,
+        help="Source SBOM JSON file to import.",
     )
-    import_parser.add_argument(
+    imp_parser.add_argument(
         "-o",
         "--registry",
         type=Path,
         default=None,
         metavar="FILE",
-        help=(
-            "Registry file to update "
-            f"(default: {DEFAULT_REGISTRY_FILENAME} in the current directory)."
-        ),
+        help="Registry file to update.",
     )
 
 
-def _default_ids_generate_paths(project_dir: Path) -> list[Path]:
-    """Default PATHs for ``pitloom ids generate``: conventional source/data
-    directories, filtered to those that exist under *project_dir*."""
-    return [
-        project_dir / name
-        for name in _DEFAULT_IDS_GENERATE_DIR_NAMES
-        if (project_dir / name).is_dir()
-    ]
-
-
-def _load_or_create_registry(
-    registry_path: Path, default_name: str
-) -> IdRegistry | None:
-    """Load *registry_path* if it exists, else create a fresh registry ready
-    to be saved there. Returns ``None`` (after printing an error) if an
-    existing file fails to load."""
-    if registry_path.exists():
-        try:
-            return IdRegistry.load(registry_path)
-        except (ValueError, OSError) as exc:
-            print(f"Error loading registry {registry_path}: {exc}", file=sys.stderr)
-            return None
-    return IdRegistry.new(default_name, path=registry_path)
-
-
 def _run_ids_generate(args: argparse.Namespace) -> int:
-    """Run ``pitloom ids generate``."""
+    """Run `pitloom ids generate`."""
     project_dir: Path = (args.project_dir or Path.cwd()).resolve()
     registry_path = (
         (project_dir / args.registry).resolve()
@@ -957,7 +1029,7 @@ def _run_ids_generate(args: argparse.Namespace) -> int:
 
 
 def _run_ids_import(args: argparse.Namespace) -> int:
-    """Run ``pitloom ids import``."""
+    """Run `pitloom ids import`."""
     sbom_path: Path = args.sbom.resolve()
     if not sbom_path.exists():
         print(f"Error: SBOM file not found: {sbom_path}", file=sys.stderr)
@@ -987,142 +1059,12 @@ def _run_ids_import(args: argparse.Namespace) -> int:
 
 
 def _run_ids_cli(args: argparse.Namespace) -> int:
-    """Dispatch ``pitloom ids <command> ...`` arguments."""
+    """Dispatch `pitloom ids <command> ...` arguments."""
     if args.ids_command == "generate":
         return _run_ids_generate(args)
     if args.ids_command == "import":
         return _run_ids_import(args)
-    return 1  # pragma: no cover
-
-
-def _run_local_model_mode(args: argparse.Namespace, source: str) -> int:
-    """Generate a standalone SBOM for a single local AI model file."""
-    try:
-        model_path: Path = Path(source).resolve()
-        if not model_path.exists():
-            print(f"Error: Model file not found: {model_path}", file=sys.stderr)
-            return 1
-
-        pitloom_config = PitloomConfig()
-        creation = _resolve_creation_metadata(args, pitloom_config)
-        effective_pretty = args.pretty if args.pretty is not None else False
-        effective_describe = (
-            bool(args.describe_relationship)
-            if args.describe_relationship is not None
-            else False
-        )
-
-        output_path = _resolve_model_output_path(args.output, model_path)
-
-        if args.verbose:
-            print(f"Pitloom version: {__version__}")
-            print(f"Model file      : {model_path}")
-            print(f"Output path     : {output_path}")
-
-        generate_ai_model_sbom(
-            model_path,
-            output_path=output_path,
-            creation_metadata=creation.to_creation_metadata(),
-            pretty=effective_pretty,
-            describe_relationship=effective_describe,
-            registry=args.registry,
-        )
-        return 0
-
-    except Exception as e:  # pylint: disable=broad-exception-caught
-        print(f"Error generating model SBOM: {e}", file=sys.stderr)
-        traceback.print_exc()
-        return 1
-
-
-def _run_hf_model_mode(args: argparse.Namespace, source: str) -> int:
-    """Generate a standalone SBOM from a Hugging Face model repository."""
-    try:
-        model_id = parse_hf_model_id(source)
-        if model_id is None:
-            print(
-                f"Error: Not a valid Hugging Face URL or model ID: {source!r}",
-                file=sys.stderr,
-            )
-            return 1
-
-        pitloom_config = PitloomConfig()
-        creation = _resolve_creation_metadata(args, pitloom_config)
-        effective_pretty = args.pretty if args.pretty is not None else False
-        effective_describe = (
-            bool(args.describe_relationship)
-            if args.describe_relationship is not None
-            else False
-        )
-
-        output_path = _resolve_hf_output_path(args.output, model_id)
-
-        if args.verbose:
-            print(f"Pitloom version    : {__version__}")
-            print(f"Hugging Face model : {model_id}")
-            print(f"Output path        : {output_path}")
-
-        generate_huggingface_sbom(
-            model_id,
-            output_path=output_path,
-            creation_metadata=creation.to_creation_metadata(),
-            pretty=effective_pretty,
-            describe_relationship=effective_describe,
-        )
-        return 0
-
-    except Exception as e:  # pylint: disable=broad-exception-caught
-        print(f"Error generating Hugging Face model SBOM: {e}", file=sys.stderr)
-        traceback.print_exc()
-        return 1
-
-
-def _run_project_mode(args: argparse.Namespace) -> int:
-    """Generate a full project SBOM from a project directory."""
-    try:
-        project_dir, _ = _resolve_project_paths(args)
-        if project_dir is None:
-            return 1
-
-        project_metadata, pitloom_config, config_path = read_project(project_dir)
-        creation = _resolve_creation_metadata(args, pitloom_config)
-        effective_pretty = pitloom_config.pretty if args.pretty is None else args.pretty
-        effective_describe_relationship = (
-            pitloom_config.describe_relationship
-            if args.describe_relationship is None
-            else args.describe_relationship
-        )
-
-        output_path = _resolve_output_path(
-            args.output, project_metadata, pitloom_config
-        )
-
-        if args.verbose:
-            _print_verbose(
-                args,
-                project_dir,
-                output_path,
-                pitloom_config,
-                config_path,
-                creation,
-            )
-
-        generate_sbom(
-            project_dir,
-            output_path=output_path,
-            creation_metadata=creation.to_creation_metadata(),
-            pretty=effective_pretty,
-            describe_relationship=effective_describe_relationship,
-            project_metadata=project_metadata,
-            pitloom_config=pitloom_config,
-            registry=args.registry,
-        )
-        return 0
-
-    except Exception as e:  # pylint: disable=broad-exception-caught
-        print(f"Error generating SBOM: {e}", file=sys.stderr)
-        traceback.print_exc()
-        return 1
+    return 1
 
 
 if __name__ == "__main__":

--- a/src/pitloom/assemble/__init__.py
+++ b/src/pitloom/assemble/__init__.py
@@ -1,22 +1,25 @@
 # SPDX-FileContributor: Arthit Suriyawongkul
 # SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
-# SPDX-License-Identifier: Apache-2.0
 # SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
 
 """SBOM assemblers for different output specifications."""
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
+
+from spdx_python_model.bindings import v3_0_1 as spdx3_bindings
 
 from pitloom.assemble.spdx3.document import build, build_deployed, build_model
 from pitloom.assemble.spdx3.fragments import merge_fragments
-from pitloom.assemble.spdx3.provenance import DEFAULT_SCHEMA_ID
 from pitloom.core.config import PitloomConfig
 from pitloom.core.creation import CreationMetadata
 from pitloom.core.document import DocumentModel
 from pitloom.core.models import get_wheel_files
 from pitloom.core.project import ProjectMetadata
+from pitloom.core.provenance import ProvenanceConfig
 from pitloom.extract._huggingface import is_huggingface_source, read_huggingface
 from pitloom.extract.ai_model import read_ai_model
 from pitloom.extract.binary import find_phantom_dependencies
@@ -27,6 +30,19 @@ from pitloom.extract.wheel import read_wheel
 from pitloom.ids import IdRegistry, resolve_registry
 
 
+def _write_output_file(sbom_json: str, output_path: Path | None) -> None:
+    """Write SBOM output to file or stdout if output_path is '-'."""
+    if output_path is None:
+        return
+    if str(output_path) == "-":
+        sys.stdout.write(sbom_json)
+        if not sbom_json.endswith("\n"):
+            sys.stdout.write("\n")
+    else:
+        output_path.write_text(sbom_json, encoding="utf-8")
+
+
+# pylint: disable=too-many-arguments,too-many-locals,too-many-positional-arguments
 def generate_project_sbom(
     project_target: Path | str,
     *,
@@ -37,22 +53,9 @@ def generate_project_sbom(
     project_metadata: ProjectMetadata | None = None,
     pitloom_config: PitloomConfig | None = None,
     registry: str | Path | IdRegistry | None = None,
+    provenance: ProvenanceConfig | None = None,
 ) -> str:
-    """Generate a Source SPDX 3 SBOM for a Python project or sdist archive.
-
-    Args:
-        project_target: Path to a project directory or an sdist archive (.tar.gz, .zip).
-        output_path: If given, the JSON-LD output is written to this path.
-        creation_metadata: Creator and timestamp metadata.
-        pretty: Indent JSON output when True.
-        describe_relationship: Add human-readable text to SPDX relationships.
-        project_metadata: Pre-parsed project metadata.
-        pitloom_config: Pre-parsed config settings.
-        registry: IdRegistry or path to registry file.
-
-    Returns:
-        JSON-LD string of the generated SPDX 3 SBOM.
-    """
+    """Generate a Source SPDX 3 SBOM for a Python project or sdist archive."""
     target_path = Path(project_target)
     if project_metadata is None or pitloom_config is None:
         project_metadata, pitloom_config, _ = read_project(target_path)
@@ -63,14 +66,13 @@ def generate_project_sbom(
         if describe_relationship is None
         else describe_relationship
     )
+    effective_provenance: ProvenanceConfig = provenance or pitloom_config.provenance
 
     if target_path.is_file():
-        # Sdist archive case
         merkle_root = None
         project_files = project_metadata.files
         search_root = target_path.parent
     else:
-        # Directory case
         merkle_root, project_files = get_wheel_files(target_path)
         project_metadata.files = project_files
         search_root = target_path
@@ -97,13 +99,9 @@ def generate_project_sbom(
     exporter = build(
         doc,
         merkle_root=merkle_root,
+        sbom_type=spdx3_bindings.software_SbomType.source,
         registry=resolved_registry,
-        provenance_format=pitloom_config.provenance_format,
-        provenance_schema=pitloom_config.provenance_schema,
-        provenance_detail=pitloom_config.provenance_detail,
-        provenance_preserve_source_metadata=(
-            pitloom_config.provenance_preserve_source_metadata
-        ),
+        provenance=effective_provenance,
     )
 
     if target_path.is_dir():
@@ -114,43 +112,26 @@ def generate_project_sbom(
         describe_relationship=effective_describe,
     )
 
-    if output_path is not None:
-        output_path.write_text(sbom_json, encoding="utf-8")
+    _write_output_file(sbom_json, output_path)
 
     return sbom_json
 
 
-# pylint: disable=too-many-arguments
 def generate_wheel_sbom(
     wheel_path: Path | str,
     *,
     output_path: Path | None = None,
     creation_metadata: CreationMetadata | None = None,
-    pretty: bool = False,
-    describe_relationship: bool = False,
+    pretty: bool | None = None,
+    describe_relationship: bool | None = None,
     registry: str | Path | IdRegistry | None = None,
-    provenance_format: str = "both",
-    provenance_schema: str = DEFAULT_SCHEMA_ID,
-    provenance_detail: str = "minimal",
-    provenance_preserve_source_metadata: str = "auto",
+    provenance: ProvenanceConfig | None = None,
 ) -> str:
-    """Generate an Analyzed SPDX 3 SBOM for a built Python wheel.
-
-    Args:
-        wheel_path: Path to the .whl file.
-        output_path: If given, JSON-LD output is written to this path.
-        creation_metadata: Creator and timestamp metadata.
-        pretty: Indent JSON output when True.
-        describe_relationship: Add human-readable text to SPDX relationships.
-        registry: IdRegistry or path to registry file.
-        provenance_format: Metadata provenance format.
-        provenance_schema: Schema id for provenance Annotations.
-        provenance_detail: Provenance detail level ("minimal" or "full").
-        provenance_preserve_source_metadata: How to preserve source metadata.
-
-    Returns:
-        JSON-LD string of the generated SPDX 3 SBOM.
-    """
+    """Generate an Analyzed SPDX 3 SBOM for a built Python wheel."""
+    effective_pretty = False if pretty is None else pretty
+    effective_describe = (
+        False if describe_relationship is None else describe_relationship
+    )
     wheel_path_obj = Path(wheel_path)
     project_metadata, project_files = read_wheel(wheel_path_obj)
     phantom_deps = find_phantom_dependencies(project_files)
@@ -173,58 +154,37 @@ def generate_wheel_sbom(
     exporter = build(
         doc,
         merkle_root=None,
+        sbom_type=spdx3_bindings.software_SbomType.analyzed,
         registry=resolved_registry,
-        provenance_format=provenance_format,
-        provenance_schema=provenance_schema,
-        provenance_detail=provenance_detail,
-        provenance_preserve_source_metadata=provenance_preserve_source_metadata,
+        provenance=provenance,
     )
 
     sbom_json = exporter.to_json(
-        pretty=pretty,
-        describe_relationship=describe_relationship,
+        pretty=effective_pretty,
+        describe_relationship=effective_describe,
     )
 
-    if output_path is not None:
-        output_path.write_text(sbom_json, encoding="utf-8")
+    _write_output_file(sbom_json, output_path)
 
     return sbom_json
 
 
-# pylint: disable=too-many-arguments,too-many-positional-arguments
 def generate_model_sbom(
     source: Path | str,
     *,
     offline: bool = False,
     output_path: Path | None = None,
     creation_metadata: CreationMetadata | None = None,
-    pretty: bool = False,
-    describe_relationship: bool = False,
+    pretty: bool | None = None,
+    describe_relationship: bool | None = None,
     registry: str | Path | IdRegistry | None = None,
-    provenance_format: str = "both",
-    provenance_schema: str = DEFAULT_SCHEMA_ID,
-    provenance_detail: str = "minimal",
-    provenance_preserve_source_metadata: str = "auto",
+    provenance: ProvenanceConfig | None = None,
 ) -> str:
-    """Generate an Analyzed SPDX 3 AIBOM for a local model file or HF repository.
-
-    Args:
-        source: Path to local model file (GGUF, ONNX, Safetensors, etc.) OR
-            Hugging Face URL / bare model ID.
-        offline: If True, forbids network requests (raises ValueError for HF targets).
-        output_path: If given, JSON-LD output is written to this path.
-        creation_metadata: Creator and timestamp metadata.
-        pretty: Indent JSON output when True.
-        describe_relationship: Add human-readable text to SPDX relationships.
-        registry: IdRegistry or path to registry file.
-        provenance_format: Metadata provenance format.
-        provenance_schema: Schema id for provenance Annotations.
-        provenance_detail: Provenance detail level.
-        provenance_preserve_source_metadata: How to preserve source metadata.
-
-    Returns:
-        JSON-LD string of the generated SPDX 3 SBOM.
-    """
+    """Generate an Analyzed SPDX 3 AIBOM for a local model file or HF repository."""
+    effective_pretty = False if pretty is None else pretty
+    effective_describe = (
+        False if describe_relationship is None else describe_relationship
+    )
     source_str = str(source)
     is_hf = is_huggingface_source(source_str)
 
@@ -256,50 +216,33 @@ def generate_model_sbom(
         model,
         creation_metadata or CreationMetadata(),
         entity_spdx_id=entity_spdx_id,
-        provenance_format=provenance_format,
-        provenance_schema=provenance_schema,
-        provenance_detail=provenance_detail,
-        provenance_preserve_source_metadata=provenance_preserve_source_metadata,
+        provenance=provenance,
     )
 
     sbom_json = exporter.to_json(
-        pretty=pretty,
-        describe_relationship=describe_relationship,
+        pretty=effective_pretty,
+        describe_relationship=effective_describe,
     )
 
-    if output_path is not None:
-        output_path.write_text(sbom_json, encoding="utf-8")
+    _write_output_file(sbom_json, output_path)
 
     return sbom_json
 
 
-# pylint: disable=too-many-arguments
 def generate_env_sbom(
     *,
     output_path: Path | None = None,
     creation_metadata: CreationMetadata | None = None,
-    pretty: bool = False,
-    describe_relationship: bool = False,
+    pretty: bool | None = None,
+    describe_relationship: bool | None = None,
     registry: str | Path | IdRegistry | None = None,
-    provenance_format: str = "both",
-    provenance_schema: str = DEFAULT_SCHEMA_ID,
-    provenance_detail: str = "minimal",
+    provenance: ProvenanceConfig | None = None,
 ) -> str:
-    """Generate a Deployed SPDX 3 SBOM for the current installed environment.
-
-    Args:
-        output_path: If given, JSON-LD output is written to this path.
-        creation_metadata: Creator and timestamp metadata.
-        pretty: Indent JSON output when True.
-        describe_relationship: Add human-readable text to SPDX relationships.
-        registry: IdRegistry or path to registry file.
-        provenance_format: Metadata provenance format.
-        provenance_schema: Schema id for provenance Annotations.
-        provenance_detail: Provenance detail level.
-
-    Returns:
-        JSON-LD string of the generated SPDX 3 SBOM.
-    """
+    """Generate a Deployed SPDX 3 SBOM for the current installed environment."""
+    effective_pretty = False if pretty is None else pretty
+    effective_describe = (
+        False if describe_relationship is None else describe_relationship
+    )
     project_metadata, env_tree = read_environment()
 
     cwd = Path.cwd()
@@ -320,53 +263,31 @@ def generate_env_sbom(
         doc,
         env_tree=env_tree,
         registry=resolved_registry,
-        provenance_format=provenance_format,
-        provenance_schema=provenance_schema,
-        provenance_detail=provenance_detail,
+        provenance=provenance,
     )
 
     sbom_json = exporter.to_json(
-        pretty=pretty,
-        describe_relationship=describe_relationship,
+        pretty=effective_pretty,
+        describe_relationship=effective_describe,
     )
 
-    if output_path is not None:
-        output_path.write_text(sbom_json, encoding="utf-8")
+    _write_output_file(sbom_json, output_path)
 
     return sbom_json
 
 
-# pylint: disable=too-many-arguments
 def generate(
     target: Path | str = ".",
     *,
     offline: bool = False,
     output_path: Path | None = None,
     creation_metadata: CreationMetadata | None = None,
-    pretty: bool = False,
-    describe_relationship: bool = False,
+    pretty: bool | None = None,
+    describe_relationship: bool | None = None,
     registry: str | Path | IdRegistry | None = None,
+    provenance: ProvenanceConfig | None = None,
 ) -> str:
-    """Smart unified entrypoint for generating SPDX 3 SBOMs across all target types.
-
-    Auto-detects target type:
-    - `"env"` / `"environment"` -> Deployed SBOM for current environment.
-    - `.whl` file -> Analyzed Wheel SBOM.
-    - Local model file / HF URL -> Analyzed AI Model SBOM.
-    - Directory or sdist archive -> Source SBOM.
-
-    Args:
-        target: Target path, HF URL/ID, or "env". Defaults to current directory.
-        offline: If True, forbids network requests for remote targets.
-        output_path: Optional file path to write output.
-        creation_metadata: Creator and timestamp metadata.
-        pretty: Indent JSON output when True.
-        describe_relationship: Add human-readable text to SPDX relationships.
-        registry: IdRegistry or path to registry file.
-
-    Returns:
-        JSON-LD string of the generated SPDX 3 SBOM.
-    """
+    """Smart unified entrypoint for generating SPDX 3 SBOMs across all target types."""
     target_str = str(target).strip()
 
     if target_str.lower() in ("env", "environment", "--env"):
@@ -376,6 +297,7 @@ def generate(
             pretty=pretty,
             describe_relationship=describe_relationship,
             registry=registry,
+            provenance=provenance,
         )
 
     if target_str.lower().endswith(".whl"):
@@ -386,6 +308,7 @@ def generate(
             pretty=pretty,
             describe_relationship=describe_relationship,
             registry=registry,
+            provenance=provenance,
         )
 
     if is_huggingface_source(target_str):
@@ -397,11 +320,11 @@ def generate(
             pretty=pretty,
             describe_relationship=describe_relationship,
             registry=registry,
+            provenance=provenance,
         )
 
     target_path = Path(target)
     if target_path.is_file():
-        # Check if local model file vs sdist archive
         name_lower = target_path.name.lower()
         if any(
             name_lower.endswith(ext)
@@ -428,6 +351,7 @@ def generate(
                 pretty=pretty,
                 describe_relationship=describe_relationship,
                 registry=registry,
+                provenance=provenance,
             )
 
     return generate_project_sbom(
@@ -437,13 +361,16 @@ def generate(
         pretty=pretty,
         describe_relationship=describe_relationship,
         registry=registry,
+        provenance=provenance,
     )
 
 
 __all__ = [
+    "ProvenanceConfig",
     "generate",
     "generate_env_sbom",
     "generate_model_sbom",
     "generate_project_sbom",
     "generate_wheel_sbom",
+    "merge_fragments",
 ]

--- a/src/pitloom/assemble/__init__.py
+++ b/src/pitloom/assemble/__init__.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 from pitloom.assemble.spdx3.document import build, build_deployed, build_model
 from pitloom.assemble.spdx3.fragments import merge_fragments
@@ -18,7 +17,7 @@ from pitloom.core.creation import CreationMetadata
 from pitloom.core.document import DocumentModel
 from pitloom.core.models import get_wheel_files
 from pitloom.core.project import ProjectMetadata
-from pitloom.extract._huggingface import read_huggingface
+from pitloom.extract._huggingface import is_huggingface_source, read_huggingface
 from pitloom.extract.ai_model import read_ai_model
 from pitloom.extract.binary import find_phantom_dependencies
 from pitloom.extract.env import read_environment
@@ -28,8 +27,8 @@ from pitloom.extract.wheel import read_wheel
 from pitloom.ids import IdRegistry, resolve_registry
 
 
-def generate_sbom(
-    project_dir: Path,
+def generate_project_sbom(
+    project_target: Path | str,
     *,
     output_path: Path | None = None,
     creation_metadata: CreationMetadata | None = None,
@@ -39,48 +38,25 @@ def generate_sbom(
     pitloom_config: PitloomConfig | None = None,
     registry: str | Path | IdRegistry | None = None,
 ) -> str:
-    """Generate an SPDX 3 SBOM for a Python project.
+    """Generate a Source SPDX 3 SBOM for a Python project or sdist archive.
 
     Args:
-        project_dir: Path to the project directory.  Supports PEP 621
-            ``[project]`` and Poetry ``[tool.poetry]`` in ``pyproject.toml``
-            (``[project]`` wins field-by-field when both are present), or
-            ``setup.cfg``/``setup.py`` when no ``pyproject.toml`` exists.
-        output_path: If given, the JSON-LD output is also written to this path.
-        creation_metadata: Creator and timestamp metadata for the SBOM document.
-            When ``None`` a default :class:`~pitloom.core.creation.CreationMetadata`
-            is used -- no named creator (the assembler emits the ``SoftwareAgent``
-            ``"Pitloom"`` in ``createdBy``), current UTC time.
-        pretty: If ``True``, indent the JSON output with 2 spaces.
-            If ``False``, produce compact output (no extra whitespace).
-            If ``None`` (default), read the setting from ``[tool.pitloom] pretty``
-            in ``pyproject.toml`` (which itself defaults to ``False``).
-        project_metadata: Pre-parsed project metadata, e.g. already loaded by
-            a caller such as the CLI. When ``None`` (default), parsed from
-            *project_dir* via :func:`~pitloom.extract.project.read_project`.
-            Must be supplied together with *pitloom_config* -- if only one
-            of the two is given, both are re-derived from *project_dir*
-            instead. Mutated in place: its ``.files`` attribute is set from
-            the wheel file scan.
-        pitloom_config: Pre-parsed ``[tool.pitloom]`` settings, paired with
-            *project_metadata* (see above).
-        registry: A :class:`~pitloom.ids.IdRegistry`, a path to a registry
-            JSON file, or ``None`` (default) to resolve one from
-            ``[tool.pitloom.ids] file`` / auto-discovery -- see
-            :func:`~pitloom.ids.resolve_registry`. Consulted so that wheel
-            files reuse ids shared with ``pitloom.loom`` fragments.
+        project_target: Path to a project directory or an sdist archive (.tar.gz, .zip).
+        output_path: If given, the JSON-LD output is written to this path.
+        creation_metadata: Creator and timestamp metadata.
+        pretty: Indent JSON output when True.
+        describe_relationship: Add human-readable text to SPDX relationships.
+        project_metadata: Pre-parsed project metadata.
+        pitloom_config: Pre-parsed config settings.
+        registry: IdRegistry or path to registry file.
 
     Returns:
         JSON-LD string of the generated SPDX 3 SBOM.
-
-    Raises:
-        FileNotFoundError: If none of ``pyproject.toml``, ``setup.cfg``, or
-            ``setup.py`` is found in ``project_dir`` (only checked when
-            *metadata*/*pitloom_config* are not supplied).
-        ValueError: If required project metadata (e.g., ``name``) is missing.
     """
+    target_path = Path(project_target)
     if project_metadata is None or pitloom_config is None:
-        project_metadata, pitloom_config, _ = read_project(project_dir)
+        project_metadata, pitloom_config, _ = read_project(target_path)
+
     effective_pretty: bool = pitloom_config.pretty if pretty is None else pretty
     effective_describe: bool = bool(
         pitloom_config.describe_relationship
@@ -88,19 +64,29 @@ def generate_sbom(
         else describe_relationship
     )
 
-    # Compute Merkle root via hatchling's own file discovery so the UUID
-    # matches the build-hook path exactly (same WheelBuilder, same file set).
-    merkle_root, project_files = get_wheel_files(project_dir)
-    project_metadata.files = project_files
+    if target_path.is_file():
+        # Sdist archive case
+        merkle_root = None
+        project_files = project_metadata.files
+        search_root = target_path.parent
+    else:
+        # Directory case
+        merkle_root, project_files = get_wheel_files(target_path)
+        project_metadata.files = project_files
+        search_root = target_path
 
-    ai_models = scan_project_for_ai_models(project_dir, project_files)
+    ai_models = (
+        scan_project_for_ai_models(target_path, project_files)
+        if target_path.is_dir()
+        else []
+    )
 
     resolved_registry = (
         registry
         if isinstance(registry, IdRegistry)
-        else IdRegistry.load(project_dir / registry)
+        else IdRegistry.load(search_root / registry)
         if registry is not None
-        else resolve_registry(project_dir, pitloom_config.ids_file)
+        else resolve_registry(search_root, pitloom_config.ids_file)
     )
 
     doc = DocumentModel(
@@ -119,7 +105,9 @@ def generate_sbom(
             pitloom_config.provenance_preserve_source_metadata
         ),
     )
-    merge_fragments(project_dir, pitloom_config.fragments, exporter)
+
+    if target_path.is_dir():
+        merge_fragments(target_path, pitloom_config.fragments, exporter)
 
     sbom_json = exporter.to_json(
         pretty=effective_pretty,
@@ -132,9 +120,10 @@ def generate_sbom(
     return sbom_json
 
 
-# pylint: disable=too-many-arguments,too-many-positional-arguments
-def generate_ai_model_sbom(
-    model_path: Path,
+# pylint: disable=too-many-arguments
+def generate_wheel_sbom(
+    wheel_path: Path | str,
+    *,
     output_path: Path | None = None,
     creation_metadata: CreationMetadata | None = None,
     pretty: bool = False,
@@ -145,54 +134,124 @@ def generate_ai_model_sbom(
     provenance_detail: str = "minimal",
     provenance_preserve_source_metadata: str = "auto",
 ) -> str:
-    """Generate a standalone SPDX 3 SBOM for a single AI model file.
-
-    The model is treated as an ``ai_AIPackage`` root element - no surrounding
-    Python project is required.
+    """Generate an Analyzed SPDX 3 SBOM for a built Python wheel.
 
     Args:
-        model_path: Path to the AI model file (GGUF, ONNX, Safetensors, etc.).
-        output_path: If given, the JSON-LD output is also written to this path.
-        creation_metadata: Creator and timestamp metadata.  Defaults to a
-            ``CreationMetadata`` with no named creator (the assembler emits
-            the ``SoftwareAgent`` ``"Pitloom"`` in ``createdBy``) and current
-            UTC time.
-        pretty: Indent JSON output with 2 spaces when ``True``.
+        wheel_path: Path to the .whl file.
+        output_path: If given, JSON-LD output is written to this path.
+        creation_metadata: Creator and timestamp metadata.
+        pretty: Indent JSON output when True.
         describe_relationship: Add human-readable text to SPDX relationships.
-        registry: A :class:`~pitloom.ids.IdRegistry`, a path to a registry
-            JSON file, or ``None`` (default) to auto-discover
-            ``loom-ids.json`` from the current working directory. The
-            model's file stem (e.g. ``"sentimentdemo"`` for
-            ``models/sentimentdemo.bin``) is looked up as an ``ai_AIPackage``
-            entity; a match reuses that registered ``spdxId`` so this SBOM's
-            model and a ``pitloom.loom`` fragment's model can be unified at
-            merge time.
-        provenance_format: How to record metadata provenance -- see
-            :mod:`pitloom.assemble.spdx3.provenance`.
-        provenance_schema: Schema id for the provenance Annotation statement.
-        provenance_detail: ``"minimal"`` (default) records only high-signal
-            field sources; ``"full"`` records every field's source.
+        registry: IdRegistry or path to registry file.
+        provenance_format: Metadata provenance format.
+        provenance_schema: Schema id for provenance Annotations.
+        provenance_detail: Provenance detail level ("minimal" or "full").
+        provenance_preserve_source_metadata: How to preserve source metadata.
 
     Returns:
         JSON-LD string of the generated SPDX 3 SBOM.
-
-    Raises:
-        FileNotFoundError: If *model_path* does not exist.
-        ValueError: If the model format is unsupported or cannot be parsed.
     """
-    model = read_ai_model(model_path)
+    wheel_path_obj = Path(wheel_path)
+    project_metadata, project_files = read_wheel(wheel_path_obj)
+    phantom_deps = find_phantom_dependencies(project_files)
+
+    cwd = Path.cwd()
     resolved_registry = (
         registry
         if isinstance(registry, IdRegistry)
-        else IdRegistry.load(Path(registry))
+        else IdRegistry.load(cwd / registry)
         if registry is not None
-        else IdRegistry.find()
+        else resolve_registry(cwd, None)
     )
-    entity_spdx_id = (
-        resolved_registry.lookup_entity(model_path.stem, "ai_AIPackage")
-        if resolved_registry is not None
-        else None
+
+    doc = DocumentModel(
+        project=project_metadata,
+        creation_metadata=creation_metadata or CreationMetadata(),
+        ai_models=[],
+        phantom_dependencies=phantom_deps,
     )
+    exporter = build(
+        doc,
+        merkle_root=None,
+        registry=resolved_registry,
+        provenance_format=provenance_format,
+        provenance_schema=provenance_schema,
+        provenance_detail=provenance_detail,
+        provenance_preserve_source_metadata=provenance_preserve_source_metadata,
+    )
+
+    sbom_json = exporter.to_json(
+        pretty=pretty,
+        describe_relationship=describe_relationship,
+    )
+
+    if output_path is not None:
+        output_path.write_text(sbom_json, encoding="utf-8")
+
+    return sbom_json
+
+
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+def generate_model_sbom(
+    source: Path | str,
+    *,
+    offline: bool = False,
+    output_path: Path | None = None,
+    creation_metadata: CreationMetadata | None = None,
+    pretty: bool = False,
+    describe_relationship: bool = False,
+    registry: str | Path | IdRegistry | None = None,
+    provenance_format: str = "both",
+    provenance_schema: str = DEFAULT_SCHEMA_ID,
+    provenance_detail: str = "minimal",
+    provenance_preserve_source_metadata: str = "auto",
+) -> str:
+    """Generate an Analyzed SPDX 3 AIBOM for a local model file or HF repository.
+
+    Args:
+        source: Path to local model file (GGUF, ONNX, Safetensors, etc.) OR
+            Hugging Face URL / bare model ID.
+        offline: If True, forbids network requests (raises ValueError for HF targets).
+        output_path: If given, JSON-LD output is written to this path.
+        creation_metadata: Creator and timestamp metadata.
+        pretty: Indent JSON output when True.
+        describe_relationship: Add human-readable text to SPDX relationships.
+        registry: IdRegistry or path to registry file.
+        provenance_format: Metadata provenance format.
+        provenance_schema: Schema id for provenance Annotations.
+        provenance_detail: Provenance detail level.
+        provenance_preserve_source_metadata: How to preserve source metadata.
+
+    Returns:
+        JSON-LD string of the generated SPDX 3 SBOM.
+    """
+    source_str = str(source)
+    is_hf = is_huggingface_source(source_str)
+
+    if is_hf:
+        if offline:
+            raise ValueError(
+                "Offline mode enabled: cannot fetch remote Hugging Face source "
+                f"'{source_str}'"
+            )
+        model = read_huggingface(source_str)
+        entity_spdx_id = None
+    else:
+        model_path = Path(source)
+        model = read_ai_model(model_path)
+        resolved_registry = (
+            registry
+            if isinstance(registry, IdRegistry)
+            else IdRegistry.load(Path(registry))
+            if registry is not None
+            else IdRegistry.find()
+        )
+        entity_spdx_id = (
+            resolved_registry.lookup_entity(model_path.stem, "ai_AIPackage")
+            if resolved_registry is not None
+            else None
+        )
+
     exporter = build_model(
         model,
         creation_metadata or CreationMetadata(),
@@ -214,152 +273,8 @@ def generate_ai_model_sbom(
     return sbom_json
 
 
-# pylint: disable=too-many-arguments,too-many-positional-arguments
-def generate_huggingface_sbom(
-    model_source: str,
-    output_path: Path | None = None,
-    creation_metadata: CreationMetadata | None = None,
-    pretty: bool = False,
-    describe_relationship: bool = False,
-    provenance_format: str = "both",
-    provenance_schema: str = DEFAULT_SCHEMA_ID,
-    provenance_detail: str = "minimal",
-    provenance_preserve_source_metadata: str = "auto",
-) -> str:
-    """Generate a standalone SPDX 3 SBOM for a Hugging Face model repository.
-
-    Fetches metadata from the Hugging Face Hub (``config.json``, model card,
-    ``tokenizer_config.json``, etc.) and assembles an ``ai_AIPackage`` SBOM.
-    No local model file is required.
-
-    Args:
-        model_source: Full HF URL
-            (e.g. ``https://huggingface.co/mistralai/Mistral-7B-v0.1``)
-            or bare model ID (e.g. ``Qwen/Qwen3-235B-A22B``).
-        output_path: If given, the JSON-LD output is also written to this path.
-        creation_metadata: Creator and timestamp metadata.  Defaults to a
-            ``CreationMetadata`` with no named creator (the assembler emits
-            the ``SoftwareAgent`` ``"Pitloom"`` in ``createdBy``) and current
-            UTC time.
-        pretty: Indent JSON output with 2 spaces when ``True``.
-        describe_relationship: Add human-readable text to SPDX relationships.
-        provenance_format: How to record metadata provenance -- see
-            :mod:`pitloom.assemble.spdx3.provenance`.
-        provenance_schema: Schema id for the provenance Annotation statement.
-        provenance_detail: ``"minimal"`` (default) records only high-signal
-            field sources; ``"full"`` records every field's source.
-
-    Returns:
-        JSON-LD string of the generated SPDX 3 SBOM.
-
-    Raises:
-        ImportError: If ``huggingface_hub`` is not installed.
-        ValueError: If *model_source* is not a valid Hugging Face URL or model ID.
-    """
-    model = read_huggingface(model_source)
-    exporter = build_model(
-        model,
-        creation_metadata or CreationMetadata(),
-        provenance_format=provenance_format,
-        provenance_schema=provenance_schema,
-        provenance_detail=provenance_detail,
-        provenance_preserve_source_metadata=provenance_preserve_source_metadata,
-    )
-
-    sbom_json = exporter.to_json(
-        pretty=pretty,
-        describe_relationship=describe_relationship,
-    )
-
-    if output_path is not None:
-        output_path.write_text(sbom_json, encoding="utf-8")
-
-    return sbom_json
-
-
 # pylint: disable=too-many-arguments
-def generate_analyzed_sbom(
-    wheel_path: Path,
-    *,
-    output_path: Path | None = None,
-    creation_metadata: CreationMetadata | None = None,
-    pretty: bool = False,
-    describe_relationship: bool = False,
-    registry: str | Path | IdRegistry | None = None,
-    provenance_format: str = "both",
-    provenance_schema: str = DEFAULT_SCHEMA_ID,
-    provenance_detail: str = "minimal",
-    provenance_preserve_source_metadata: str = "auto",
-) -> str:
-    """Generate an Analyzed SPDX 3 SBOM for a built Python wheel.
-
-    Args:
-        wheel_path: Path to the .whl file.
-        output_path: If given, the JSON-LD output is also written to this path.
-        creation_metadata: Creator and timestamp metadata for the SBOM document.
-        pretty: Indent JSON output with 2 spaces when True.
-        describe_relationship: Add human-readable text to SPDX relationships.
-        registry: A stable file/entity id registry (see IdRegistry).
-        provenance_format: How to record metadata provenance -- see
-            :mod:`pitloom.assemble.spdx3.provenance`.
-        provenance_schema: Schema id for the provenance Annotation statement.
-        provenance_detail: ``"minimal"`` (default) records only high-signal
-            field sources; ``"full"`` records every field's source.
-
-    Returns:
-        JSON-LD string of the generated SPDX 3 SBOM.
-    """
-    project_metadata, project_files = read_wheel(wheel_path)
-
-    # The wheel file itself is the artifact identity here; no separate
-    # source-tree Merkle root applies.
-    merkle_root = None
-
-    # AI model detection scans a source directory tree; wheel contents are
-    # not scanned for models, so this is always empty for an Analyzed SBOM.
-    ai_models: list[Any] = []
-
-    phantom_deps = find_phantom_dependencies(project_files)
-
-    # No project_dir is available to walk up from for loom-ids.json
-    # auto-discovery, so the current directory is used as the search root.
-    cwd = Path.cwd()
-    resolved_registry = (
-        registry
-        if isinstance(registry, IdRegistry)
-        else IdRegistry.load(cwd / registry)
-        if registry is not None
-        else resolve_registry(cwd, None)
-    )
-
-    doc = DocumentModel(
-        project=project_metadata,
-        creation_metadata=creation_metadata or CreationMetadata(),
-        ai_models=ai_models,
-        phantom_dependencies=phantom_deps,
-    )
-    exporter = build(
-        doc,
-        merkle_root=merkle_root,
-        registry=resolved_registry,
-        provenance_format=provenance_format,
-        provenance_schema=provenance_schema,
-        provenance_detail=provenance_detail,
-        provenance_preserve_source_metadata=provenance_preserve_source_metadata,
-    )
-
-    sbom_json = exporter.to_json(
-        pretty=pretty,
-        describe_relationship=describe_relationship,
-    )
-
-    if output_path is not None:
-        output_path.write_text(sbom_json, encoding="utf-8")
-
-    return sbom_json
-
-
-def generate_deployed_sbom(
+def generate_env_sbom(
     *,
     output_path: Path | None = None,
     creation_metadata: CreationMetadata | None = None,
@@ -370,27 +285,23 @@ def generate_deployed_sbom(
     provenance_schema: str = DEFAULT_SCHEMA_ID,
     provenance_detail: str = "minimal",
 ) -> str:
-    """Generate a Deployed SPDX 3 SBOM for the current Python environment.
+    """Generate a Deployed SPDX 3 SBOM for the current installed environment.
 
     Args:
-        output_path: If given, the JSON-LD output is also written to this path.
-        creation_metadata: Creator and timestamp metadata for the SBOM document.
-        pretty: Indent JSON output with 2 spaces when True.
+        output_path: If given, JSON-LD output is written to this path.
+        creation_metadata: Creator and timestamp metadata.
+        pretty: Indent JSON output when True.
         describe_relationship: Add human-readable text to SPDX relationships.
-        registry: A stable file/entity id registry (see IdRegistry).
-        provenance_format: How to record metadata provenance -- see
-            :mod:`pitloom.assemble.spdx3.provenance`.
-        provenance_schema: Schema id for the provenance Annotation statement.
-        provenance_detail: ``"minimal"`` (default) records only high-signal
-            field sources; ``"full"`` records every field's source.
+        registry: IdRegistry or path to registry file.
+        provenance_format: Metadata provenance format.
+        provenance_schema: Schema id for provenance Annotations.
+        provenance_detail: Provenance detail level.
 
     Returns:
         JSON-LD string of the generated SPDX 3 SBOM.
     """
     project_metadata, env_tree = read_environment()
 
-    # No project_dir applies to a deployed-environment scan, so the current
-    # directory is used as the loom-ids.json search root.
     cwd = Path.cwd()
     resolved_registry = (
         registry
@@ -425,10 +336,114 @@ def generate_deployed_sbom(
     return sbom_json
 
 
+# pylint: disable=too-many-arguments
+def generate(
+    target: Path | str = ".",
+    *,
+    offline: bool = False,
+    output_path: Path | None = None,
+    creation_metadata: CreationMetadata | None = None,
+    pretty: bool = False,
+    describe_relationship: bool = False,
+    registry: str | Path | IdRegistry | None = None,
+) -> str:
+    """Smart unified entrypoint for generating SPDX 3 SBOMs across all target types.
+
+    Auto-detects target type:
+    - `"env"` / `"environment"` -> Deployed SBOM for current environment.
+    - `.whl` file -> Analyzed Wheel SBOM.
+    - Local model file / HF URL -> Analyzed AI Model SBOM.
+    - Directory or sdist archive -> Source SBOM.
+
+    Args:
+        target: Target path, HF URL/ID, or "env". Defaults to current directory.
+        offline: If True, forbids network requests for remote targets.
+        output_path: Optional file path to write output.
+        creation_metadata: Creator and timestamp metadata.
+        pretty: Indent JSON output when True.
+        describe_relationship: Add human-readable text to SPDX relationships.
+        registry: IdRegistry or path to registry file.
+
+    Returns:
+        JSON-LD string of the generated SPDX 3 SBOM.
+    """
+    target_str = str(target).strip()
+
+    if target_str.lower() in ("env", "environment", "--env"):
+        return generate_env_sbom(
+            output_path=output_path,
+            creation_metadata=creation_metadata,
+            pretty=pretty,
+            describe_relationship=describe_relationship,
+            registry=registry,
+        )
+
+    if target_str.lower().endswith(".whl"):
+        return generate_wheel_sbom(
+            target_str,
+            output_path=output_path,
+            creation_metadata=creation_metadata,
+            pretty=pretty,
+            describe_relationship=describe_relationship,
+            registry=registry,
+        )
+
+    if is_huggingface_source(target_str):
+        return generate_model_sbom(
+            target_str,
+            offline=offline,
+            output_path=output_path,
+            creation_metadata=creation_metadata,
+            pretty=pretty,
+            describe_relationship=describe_relationship,
+            registry=registry,
+        )
+
+    target_path = Path(target)
+    if target_path.is_file():
+        # Check if local model file vs sdist archive
+        name_lower = target_path.name.lower()
+        if any(
+            name_lower.endswith(ext)
+            for ext in (
+                ".gguf",
+                ".safetensors",
+                ".onnx",
+                ".pt",
+                ".pth",
+                ".h5",
+                ".hdf5",
+                ".keras",
+                ".npy",
+                ".npz",
+                ".bin",
+                ".ftz",
+            )
+        ):
+            return generate_model_sbom(
+                target_path,
+                offline=offline,
+                output_path=output_path,
+                creation_metadata=creation_metadata,
+                pretty=pretty,
+                describe_relationship=describe_relationship,
+                registry=registry,
+            )
+
+    return generate_project_sbom(
+        target_path,
+        output_path=output_path,
+        creation_metadata=creation_metadata,
+        pretty=pretty,
+        describe_relationship=describe_relationship,
+        registry=registry,
+    )
+
+
 __all__ = [
-    "generate_ai_model_sbom",
-    "generate_analyzed_sbom",
-    "generate_deployed_sbom",
-    "generate_huggingface_sbom",
-    "generate_sbom",
+    "generate",
+    "generate_env_sbom",
+    "generate_model_sbom",
+    "generate_project_sbom",
+    "generate_wheel_sbom",
 ]

--- a/src/pitloom/assemble/spdx3/ai.py
+++ b/src/pitloom/assemble/spdx3/ai.py
@@ -23,6 +23,7 @@ from pitloom.assemble.spdx3.provenance import (
 )
 from pitloom.core.ai_metadata import AiModelFormat, AiModelMetadata
 from pitloom.core.models import generate_spdx_id
+from pitloom.core.provenance import ProvenanceConfig
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 from pitloom.ids import IdRegistry
 
@@ -418,59 +419,14 @@ def add_ai_models(
     doc_uuid: str,
     exporter: Spdx3JsonExporter,
     registry: IdRegistry | None = None,
-    provenance_format: str = "both",
+    *,
+    provenance_config: ProvenanceConfig | None = None,
     encoder: ProvenanceEncoder | None = None,
-    provenance_detail: str = "minimal",
-    preserve_source_metadata: str = "auto",
 ) -> None:
     """Build ``ai_AIPackage`` and ``contains`` relationship elements for each
-    AI model and add them to the exporter.
-
-    For each entry in ``ai_models``:
-
-    - An ``ai_AIPackage`` element is built from the extracted metadata.
-    - A ``contains`` relationship links the main Python package to the AI model.
-    - ``type_of_model`` and ``architecture`` are both stored in
-      ``ai_typeOfModel``.
-    - ``quantization`` and hyperparameters are stored as ``ai_hyperparameter``
-      DictionaryEntry list (quantization first).
-    - ``domain`` + ``usage.domains`` -> ``ai_domain`` (merged, de-duplicated).
-    - ``usage.limitations`` -> ``ai_limitation`` (joined string).
-    - ``usage.safety_risk_assessment`` -> ``ai_safetyRiskAssessment`` enum.
-    - ``usage.intended_use`` / ``usage.unintended_use`` -> merged into
-      ``ai_informationAboutApplication`` JSON alongside I/O specs.
-    - ``usage.known_biases`` -> SPDX ``comment``; ``provenance`` -> a Core
-      ``Annotation`` and/or legacy ``comment``, per *provenance_format*.
-
-    The caller is responsible for appending
-    ``ProfileIdentifierType.ai`` to the document's ``profileConformance``
-    when at least one AI model is present.
-
-    Args:
-        ai_models: List of extracted :class:`~pitloom.core.ai_metadata.AiModelMetadata`.
-        main_package_spdx_id: SPDX ID of the parent Python package.
-        creation_info: Shared ``CreationInfo`` for all new elements.
-        doc_name: Document name (project name) for SPDX ID generation.
-        doc_uuid: Document-scoped UUID used in SPDX ID generation.
-        exporter: Receives the new package and relationship elements.
-        registry: Optional stable file/entity id registry (see
-            :mod:`pitloom.ids`). When given, each model is looked up via
-            :func:`_lookup_ai_model_entity` (by name, physical path, then
-            file stem); a match reuses that registered ``spdxId`` instead of
-            minting a fresh one -- unifying a scan-discovered model (e.g. the
-            wheel's own packaged model file) with the ``ai_AIPackage`` a
-            ``pitloom.loom`` fragment already registered for the same model.
-        provenance_format: How to record metadata provenance -- see
-            :func:`~pitloom.assemble.spdx3.provenance.emit_provenance`.
-        encoder: Provenance statement encoder; defaults to the registered
-            default schema.
-        provenance_detail: ``"minimal"`` (default) keeps only high-signal
-            field sources; ``"full"`` records every field.
-        preserve_source_metadata: Whether to embed each model's verbatim
-            original metadata blob (P1) -- ``"auto"`` (default) only when the
-            model file is not shipped in the distribution, else ``"always"``/
-            ``"never"``. See :func:`_should_preserve_metadata`.
-    """
+    AI model."""
+    config = provenance_config or ProvenanceConfig()
+    preserve_source_metadata = config.preserve_source_metadata
     lineage_ctx = _LineageContext(
         creation_info=creation_info,
         doc_name=doc_name,
@@ -491,9 +447,8 @@ def add_ai_models(
             doc_name=doc_name,
             doc_uuid=doc_uuid,
             exporter=exporter,
-            provenance_format=provenance_format,
+            provenance_config=config,
             encoder=encoder,
-            provenance_detail=provenance_detail,
         )
         _emit_source_metadata(
             ai_model,
@@ -514,9 +469,8 @@ def add_ai_models(
                 doc_name=doc_name,
                 doc_uuid=doc_uuid,
                 exporter=exporter,
-                provenance_format=provenance_format,
+                provenance_config=config,
                 encoder=encoder,
-                provenance_detail=provenance_detail,
             )
 
         if ai_model.license:
@@ -531,9 +485,8 @@ def add_ai_models(
                 doc_name=doc_name,
                 doc_uuid=doc_uuid,
                 exporter=exporter,
-                provenance_format=provenance_format,
+                provenance_config=config,
                 encoder=encoder,
-                provenance_detail=provenance_detail,
             )
             if rel_declared:
                 exporter.add_relationship(rel_declared)

--- a/src/pitloom/assemble/spdx3/ai.py
+++ b/src/pitloom/assemble/spdx3/ai.py
@@ -118,7 +118,7 @@ def _lookup_ai_model_entity(
        lookup key when invoked with that same path.
     3. The file stem of ``format_info.file_name`` (e.g. ``"model"`` for
        ``"model.bin"``) -- mirrors the lookup
-       :func:`pitloom.assemble.generate_ai_model_sbom` performs for
+       :func:`~pitloom.assemble.generate_model_sbom` performs for
        ``loom model``/``--registry``.
 
     Returns ``None`` (mint a fresh id, unchanged behaviour) when no registry

--- a/src/pitloom/assemble/spdx3/dataset.py
+++ b/src/pitloom/assemble/spdx3/dataset.py
@@ -12,6 +12,7 @@ from spdx_python_model.bindings import v3_0_1 as spdx3
 from pitloom.assemble.spdx3.provenance import ProvenanceEncoder, emit_provenance
 from pitloom.core.dataset_metadata import DatasetMetadata, DatasetReference
 from pitloom.core.models import generate_spdx_id
+from pitloom.core.provenance import ProvenanceConfig
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 
 # Mapping from DatasetReference.role strings to SPDX 3.0.1 RelationshipType.
@@ -201,46 +202,15 @@ def add_datasets_for_model(
     doc_name: str,
     doc_uuid: str,
     exporter: Spdx3JsonExporter,
-    provenance_format: str = "both",
+    *,
+    provenance_config: ProvenanceConfig | None = None,
     encoder: ProvenanceEncoder | None = None,
-    provenance_detail: str = "minimal",
 ) -> None:
     """Build ``dataset_DatasetPackage`` and relationship elements for each
-    dataset reference and add them to the exporter.
-
-    For each entry in ``datasets``:
-
-    - A ``dataset_DatasetPackage`` element is built from the extracted metadata.
-    - A relationship element links the AI package (``from_``) to the dataset
-      (``to``), using the role to select the relationship type.
-    - Roles ``"trainedOn"`` and ``"testedOn"`` map to the corresponding SPDX 3.0.1
-      relationship types directly.
-    - Other roles (``"finetunedOn"``, ``"validatedOn"``, ``"pretrainedOn"``)
-      use ``RelationshipType.other`` with an explanatory comment.
-
-    The caller is responsible for appending ``ProfileIdentifierType.dataset``
-    to the document's ``profileConformance`` when at least one dataset is present.
-
-    Args:
-        ai_package_spdx_id: SPDX ID of the ``ai_AIPackage`` element that this
-            dataset is associated with.
-        datasets: List of :class:`~pitloom.core.dataset_metadata.DatasetReference`
-            objects, each carrying a role and extracted metadata.
-        creation_info: Shared ``CreationInfo`` for all new elements.
-        doc_name: Document name (project name) for SPDX ID generation.
-        doc_uuid: Document-scoped UUID used in SPDX ID generation.
-        exporter: Receives the new dataset package and relationship elements.
-        provenance_format: How to record metadata provenance -- see
-            :func:`~pitloom.assemble.spdx3.provenance.emit_provenance`.
-        encoder: Provenance statement encoder; defaults to the registered
-            default schema.
-        provenance_detail: ``"minimal"`` (default) keeps only high-signal
-            field sources; ``"full"`` records every field.
-    """
+    dataset reference."""
     for dataset_ref in datasets:
         meta = dataset_ref.metadata
         dataset_pkg = _build_dataset_package(meta, creation_info, doc_name, doc_uuid)
-        # dataset_DatasetPackage is not a software_Package so add via object_set.
         exporter.object_set.add(dataset_pkg)
         emit_provenance(
             subject=dataset_pkg,
@@ -249,9 +219,8 @@ def add_datasets_for_model(
             doc_name=doc_name,
             doc_uuid=doc_uuid,
             exporter=exporter,
-            provenance_format=provenance_format,
+            provenance_config=provenance_config,
             encoder=encoder,
-            provenance_detail=provenance_detail,
         )
 
         if meta.creator:

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -21,6 +21,7 @@ from pitloom.assemble.spdx3.provenance import (
 )
 from pitloom.core.models import build_pypi_purl, generate_spdx_id
 from pitloom.core.project import PhantomDependency
+from pitloom.core.provenance import ProvenanceConfig
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 
 # Operators used in PEP 508 dependency specifiers, ordered longest-first to
@@ -85,35 +86,11 @@ def _enrich_from_installed(
     doc_name: str,
     doc_uuid: str,
     exporter: Spdx3JsonExporter,
-    provenance_format: str = "both",
+    *,
+    provenance_config: ProvenanceConfig | None = None,
     encoder: ProvenanceEncoder | None = None,
-    provenance_detail: str = "minimal",
 ) -> None:
-    """Populate optional fields on a dependency package from installed metadata.
-
-    Uses ``importlib.metadata`` to read the package's core metadata from the
-    build environment and fills in:
-
-    - ``description`` (from ``Summary``)
-    - ``software_homePage`` (from ``Home-page`` or a ``Project-URL`` with a
-      homepage label)
-    - ``software_downloadLocation`` (from ``Download-URL`` or a ``Project-URL``
-      with a download label)
-    - ``software_packageUrl`` (PyPI PURL constructed from name and version)
-    - ``hasDeclaredLicense`` relationship (from ``License-Expression`` or
-      ``License`` core metadata field)
-
-    Fields are only set when a non-empty, non-``UNKNOWN`` value is available.
-    Does nothing if the package is not found in the build environment.
-
-    Args:
-        dep_name: Bare package name (e.g. ``"requests"``).
-        dep_package: The ``software_Package`` element to enrich.
-        creation_info: Shared ``CreationInfo`` for any new SPDX elements.
-        doc_name: Document name (project name) for SPDX ID generation.
-        doc_uuid: Document UUID for SPDX ID generation.
-        exporter: Receives any new license and relationship elements.
-    """
+    """Populate optional fields on a dependency package from installed metadata."""
     try:
         pkg_meta: PackageMetadata = get_pkg_metadata(dep_name)
     except PackageNotFoundError:
@@ -148,8 +125,6 @@ def _enrich_from_installed(
         dep_package.software_downloadLocation = download_url
 
     # packageUrl -- PyPI PURL (pkg:pypi/<name>@<version>)
-    # The package was resolved from the build environment, so it is pip-installable.
-    # See ECMA-427 https://tc54.org/purl/
     version = dep_package.software_packageVersion
     if version and version != "unknown":
         dep_package.software_packageUrl = build_pypi_purl(dep_name, version)
@@ -165,9 +140,8 @@ def _enrich_from_installed(
             doc_name=doc_name,
             doc_uuid=doc_uuid,
             exporter=exporter,
-            provenance_format=provenance_format,
+            provenance_config=provenance_config,
             encoder=encoder,
-            provenance_detail=provenance_detail,
         )
         if rel_declared:
             exporter.add_relationship(rel_declared)
@@ -197,34 +171,12 @@ def build_license_elements(
     doc_name: str,
     doc_uuid: str,
     exporter: Spdx3JsonExporter,
-    provenance_format: str = "both",
+    *,
+    provenance_config: ProvenanceConfig | None = None,
     encoder: ProvenanceEncoder | None = None,
-    provenance_detail: str = "minimal",
 ) -> tuple[spdx3.Relationship | None, spdx3.Relationship | None]:
-    """Get or create a SimpleLicensingText element and build its
-    hasDeclaredLicense / hasConcludedLicense relationships for a given package.
-
-    If a ``SimpleLicensingText`` with the same ``simplelicensing_licenseText``
-    was already added to *exporter*, it is reused.  Otherwise a new element is
-    created and registered.  Either way, two fresh ``Relationship`` elements
-    are returned -- the caller is responsible for adding them to the exporter.
-
-    Args:
-        license_id: SPDX license identifier string (e.g. ``"Apache-2.0"``).
-        package_spdx_id: SPDX ID of the package the license applies to
-                         (the "from" in each relationship).
-        license_provenance: Human-readable provenance note for the comment field
-            of a newly created SimpleLicensingText element.
-        creation_info: Shared CreationInfo for all new elements.
-        doc_name: Document name (project name) used in SPDX ID generation.
-        doc_uuid: Document UUID used in SPDX ID generation.
-        exporter: Used to look up and register the SimpleLicensingText element.
-
-    Returns:
-        A 2-tuple of ``(hasDeclaredLicense Relationship,
-        hasConcludedLicense Relationship)``.
-    """
-    # Reuse an existing SimpleLicensingText if one with the same text exists.
+    """Get or create a SimpleLicensingText element and build its declared/concluded
+    license relationships."""
     existing_spdx_id = exporter.find_license(license_id)
     if existing_spdx_id:
         license_spdx_id = existing_spdx_id
@@ -249,9 +201,8 @@ def build_license_elements(
             doc_name=doc_name,
             doc_uuid=doc_uuid,
             exporter=exporter,
-            provenance_format=provenance_format,
+            provenance_config=provenance_config,
             encoder=encoder,
-            provenance_detail=provenance_detail,
         )
         license_spdx_id = require_spdx_id(license_text)
 
@@ -262,7 +213,6 @@ def build_license_elements(
     rel_has_concluded_license: spdx3.Relationship | None = None
 
     if is_concluded:
-        # The license identified by the SPDX data creator.
         rel_has_concluded_license = spdx3.Relationship(
             spdxId=generate_spdx_id(
                 "Relationship",
@@ -275,7 +225,6 @@ def build_license_elements(
             to=[license_spdx_id],
         )
     else:
-        # The license asserted by the author in the Software Artifact.
         rel_has_declared_license = spdx3.Relationship(
             spdxId=generate_spdx_id(
                 "Relationship",
@@ -300,40 +249,12 @@ def add_dependencies(
     doc_name: str,
     doc_uuid: str,
     exporter: Spdx3JsonExporter,
-    provenance_format: str = "both",
+    *,
+    provenance_config: ProvenanceConfig | None = None,
     encoder: ProvenanceEncoder | None = None,
-    provenance_detail: str = "minimal",
 ) -> None:
     """Build SPDX ``software_Package`` and ``Relationship`` elements for each
-    declared dependency and add them to the exporter.
-
-    For each entry in ``dependencies``:
-    - The package name is parsed from the PEP 508 specifier.
-    - The installed version is resolved via ``importlib.metadata`` when
-      available, providing build-time accuracy beyond the declared constraint.
-    - Additional fields (description, homePage, downloadLocation, packageUrl,
-      hasDeclaredLicense) are populated from the installed package metadata
-      when available.
-    - A ``dependsOn`` relationship links the main package to the dependency.
-    - Provenance is recorded as a Core ``Annotation`` and/or legacy
-      ``comment``, per *provenance_format*.
-
-    Args:
-        dependencies: List of PEP 508 dependency specifier strings.
-        dep_provenance: Provenance string for the dependencies field
-            (e.g. ``"Source: pyproject.toml | Field: project.dependencies"``).
-        main_package_spdx_id: SPDX ID of the parent package for relationships.
-        creation_info: Shared ``CreationInfo`` for all new elements.
-        doc_name: Document name (project name) for SPDX ID generation.
-        doc_uuid: Document-scoped UUID used in SPDX ID generation.
-        exporter: Receives the new package and relationship elements.
-        provenance_format: How to record metadata provenance -- see
-            :func:`~pitloom.assemble.spdx3.provenance.emit_provenance`.
-        encoder: Provenance statement encoder; defaults to the registered
-            default schema.
-        provenance_detail: ``"minimal"`` (default) keeps only high-signal
-            field sources; ``"full"`` records every field.
-    """
+    declared dependency."""
     for dep in dependencies:
         dep_name = _parse_dep_name(dep)
         dep_version, version_note = _resolve_version(dep_name, dep)
@@ -360,9 +281,8 @@ def add_dependencies(
             doc_name,
             doc_uuid,
             exporter,
-            provenance_format=provenance_format,
+            provenance_config=provenance_config,
             encoder=encoder,
-            provenance_detail=provenance_detail,
         )
 
         exporter.add_package(dep_package)
@@ -373,9 +293,8 @@ def add_dependencies(
             doc_name=doc_name,
             doc_uuid=doc_uuid,
             exporter=exporter,
-            provenance_format=provenance_format,
+            provenance_config=provenance_config,
             encoder=encoder,
-            provenance_detail=provenance_detail,
         )
 
         dep_rel = spdx3.Relationship(
@@ -387,10 +306,6 @@ def add_dependencies(
             relationshipType=spdx3.RelationshipType.dependsOn,
             creationInfo=creation_info,
         )
-        # No provenance Annotation on the dependsOn relationship itself: the
-        # relationship *is* the native record of the dependency, and the
-        # extraction-source already lives on the dependency package above.
-        # Annotating the edge too would just shadow the native construct.
         exporter.add_relationship(dep_rel)
 
 
@@ -403,28 +318,11 @@ def add_phantom_dependencies(
     doc_name: str,
     doc_uuid: str,
     exporter: Spdx3JsonExporter,
-    provenance_format: str = "both",
+    *,
+    provenance_config: ProvenanceConfig | None = None,
     encoder: ProvenanceEncoder | None = None,
-    provenance_detail: str = "minimal",
 ) -> None:
-    """Build SPDX elements for bundled phantom binary dependencies.
-
-    Args:
-        phantom_deps: List of PhantomDependency objects discovered in the distribution.
-        main_package_spdx_id: SPDX ID of the parent package for relationships.
-        file_spdx_ids: Mapping of file paths to their SPDX IDs, to link
-            packages to files.
-        creation_info: Shared CreationInfo for all new elements.
-        doc_name: Document name (project name) for SPDX ID generation.
-        doc_uuid: Document-scoped UUID used in SPDX ID generation.
-        exporter: Receives the new package and relationship elements.
-        provenance_format: How to record metadata provenance -- see
-            :func:`~pitloom.assemble.spdx3.provenance.emit_provenance`.
-        encoder: Provenance statement encoder; defaults to the registered
-            default schema.
-        provenance_detail: ``"minimal"`` (default) keeps only high-signal
-            field sources; ``"full"`` records every field.
-    """
+    """Build SPDX elements for bundled phantom binary dependencies."""
     for dep in phantom_deps:
         dep_package = spdx3.software_Package(
             spdxId=generate_spdx_id("Package", doc_name=doc_name, doc_uuid=doc_uuid),
@@ -438,7 +336,6 @@ def add_phantom_dependencies(
 
         dep_package.software_primaryPurpose = spdx3.software_SoftwarePurpose.library
 
-        # Download URL and license are not derivable from a bundled binary alone.
         exporter.add_package(dep_package)
         emit_provenance(
             subject=dep_package,
@@ -449,9 +346,8 @@ def add_phantom_dependencies(
             doc_name=doc_name,
             doc_uuid=doc_uuid,
             exporter=exporter,
-            provenance_format=provenance_format,
+            provenance_config=provenance_config,
             encoder=encoder,
-            provenance_detail=provenance_detail,
         )
 
         # The main package depends on this phantom package.

--- a/src/pitloom/assemble/spdx3/document.py
+++ b/src/pitloom/assemble/spdx3/document.py
@@ -29,7 +29,6 @@ from pitloom.assemble.spdx3.deps import (
     build_license_elements,
 )
 from pitloom.assemble.spdx3.provenance import (
-    DEFAULT_SCHEMA_ID,
     ProvenanceEncoder,
     emit_provenance,
     resolve_encoder,
@@ -43,6 +42,7 @@ from pitloom.core.models import (
     compute_doc_uuid,
     generate_spdx_id,
 )
+from pitloom.core.provenance import ProvenanceConfig
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 from pitloom.ids import IdRegistry
 
@@ -210,49 +210,14 @@ def build(
     doc: DocumentModel,
     merkle_root: str | None = None,
     *,
+    sbom_type: Any = spdx3.software_SbomType.source,
     registry: IdRegistry | None = None,
-    provenance_format: str = "both",
-    provenance_schema: str = DEFAULT_SCHEMA_ID,
-    provenance_detail: str = "minimal",
-    provenance_preserve_source_metadata: str = "auto",
+    provenance: ProvenanceConfig | None = None,
 ) -> Spdx3JsonExporter:
-    """Assemble SPDX 3 elements from a :class:`~pitloom.core.document.DocumentModel`.
-
-    Args:
-        doc: Format-neutral document model with project metadata, creation
-            metadata, and any AI model metadata.
-        merkle_root: Optional hex-encoded SHA-256 Merkle root of the wheel
-            source files (see :func:`~pitloom.core.models.compute_wheel_merkle_root`).
-            When provided, any change to the packaged source causes a new document UUID.
-        registry: Optional stable file id registry (see
-            :mod:`pitloom.ids`). When given, wheel files reuse the
-            registered ``spdxId`` for their physical path/content hash
-            instead of a freshly minted one -- see :func:`_add_package_files`.
-            Also consulted for any scan-discovered AI model (see
-            :func:`~pitloom.assemble.spdx3.ai.add_ai_models`), so a model
-            file packaged into the wheel reuses the id a ``pitloom.loom``
-            fragment already registered for it instead of minting a second,
-            duplicate ``ai_AIPackage``.
-        provenance_format: How to record metadata provenance -- ``"annotation"``
-            (SPDX Core/Annotation elements only), ``"comment"`` (legacy
-            ``Element.comment`` strings only), or ``"both"`` (default). See
-            :mod:`pitloom.assemble.spdx3.provenance`.
-        provenance_schema: Schema id for the provenance Annotation statement,
-            resolved via :func:`~pitloom.assemble.spdx3.provenance.resolve_encoder`.
-            Defaults to Pitloom's own ``"pitloom/1"`` schema.
-        provenance_detail: ``"minimal"`` (default) records only high-signal
-            field sources; ``"full"`` records every field's source.
-        provenance_preserve_source_metadata: Whether to embed each AI model's
-            verbatim original metadata (P1) -- ``"auto"`` (default),
-            ``"always"``, or ``"never"``. See
-            :func:`~pitloom.assemble.spdx3.ai._should_preserve_metadata`.
-
-    Returns:
-        A populated :class:`~pitloom.export.spdx3_json.Spdx3JsonExporter`
-        containing all SPDX 3 elements for the project and its dependencies.
-    """
+    """Assemble SPDX 3 elements from a :class:`~pitloom.core.document.DocumentModel`."""
     metadata = doc.project
-    encoder: ProvenanceEncoder = resolve_encoder(provenance_schema)
+    prov_cfg = provenance or ProvenanceConfig()
+    encoder: ProvenanceEncoder = resolve_encoder(prov_cfg.schema)
 
     exporter = Spdx3JsonExporter()
     doc_uuid = compute_doc_uuid(
@@ -281,7 +246,7 @@ def build(
         creationInfo=spdx_ci,
         rootElement=[main_package.spdxId],
     )
-    sbom.software_sbomType = [spdx3.software_SbomType.build]
+    sbom.software_sbomType = [sbom_type]
 
     spdx_doc = spdx3.SpdxDocument(
         spdxId=generate_spdx_id(
@@ -305,9 +270,8 @@ def build(
         doc_name=metadata.name,
         doc_uuid=doc_uuid,
         exporter=exporter,
-        provenance_format=provenance_format,
+        provenance_config=prov_cfg,
         encoder=encoder,
-        provenance_detail=provenance_detail,
     )
 
     # --- License ---
@@ -322,9 +286,8 @@ def build(
             doc_name=metadata.name,
             doc_uuid=doc_uuid,
             exporter=exporter,
-            provenance_format=provenance_format,
+            provenance_config=prov_cfg,
             encoder=encoder,
-            provenance_detail=provenance_detail,
         )
         if rel_declared:
             exporter.add_relationship(rel_declared)
@@ -341,9 +304,8 @@ def build(
         doc_name=metadata.name,
         doc_uuid=doc_uuid,
         exporter=exporter,
-        provenance_format=provenance_format,
+        provenance_config=prov_cfg,
         encoder=encoder,
-        provenance_detail=provenance_detail,
     )
 
     # --- Files ---
@@ -361,9 +323,8 @@ def build(
             doc_name=metadata.name,
             doc_uuid=doc_uuid,
             exporter=exporter,
-            provenance_format=provenance_format,
+            provenance_config=prov_cfg,
             encoder=encoder,
-            provenance_detail=provenance_detail,
         )
 
     # --- AI models (and their associated datasets) ---
@@ -388,57 +349,25 @@ def build(
             doc_uuid=doc_uuid,
             exporter=exporter,
             registry=registry,
-            provenance_format=provenance_format,
+            provenance_config=prov_cfg,
             encoder=encoder,
-            provenance_detail=provenance_detail,
-            preserve_source_metadata=provenance_preserve_source_metadata,
         )
 
     return exporter
 
 
-# pylint: disable=too-many-locals
+# # pylint: disable=too-many-locals
 def build_model(
     model: AiModelMetadata,
     creation_metadata: CreationMetadata,
     *,
     entity_spdx_id: str | None = None,
-    provenance_format: str = "both",
-    provenance_schema: str = DEFAULT_SCHEMA_ID,
-    provenance_detail: str = "minimal",
-    provenance_preserve_source_metadata: str = "auto",
+    provenance: ProvenanceConfig | None = None,
 ) -> Spdx3JsonExporter:
-    """Assemble a standalone SPDX 3 SBOM for a single AI model file.
-
-    Produces a minimal document containing only the ``ai_AIPackage`` element
-    derived from *model*.  There is no parent Python package -- the AI package
-    is itself the root element of the ``software_Sbom``.
-
-    Args:
-        model: Extracted AI model metadata.
-        creation_metadata: Creator and timestamp metadata for the SBOM document.
-        entity_spdx_id: When given, overrides the ``ai_AIPackage``'s minted
-            ``spdxId`` with this one -- used by ``pitloom model ... --registry``
-            so the resulting element shares its id with any
-            ``pitloom.loom`` fragment that registered the same entity name
-            (see :meth:`pitloom.ids.IdRegistry.lookup_entity`), letting the
-            two be unified by :func:`~pitloom.assemble.spdx3.fragments.merge_fragments`.
-        provenance_format: How to record metadata provenance -- see
-            :func:`~pitloom.assemble.spdx3.provenance.emit_provenance`.
-        provenance_schema: Schema id for the provenance Annotation statement;
-            defaults to Pitloom's own ``"pitloom/1"`` schema.
-        provenance_detail: ``"minimal"`` (default) records only high-signal
-            field sources; ``"full"`` records every field's source.
-        provenance_preserve_source_metadata: Whether to embed each AI model's
-            verbatim original metadata (P1) -- ``"auto"`` (default),
-            ``"always"``, or ``"never"``. See
-            :func:`~pitloom.assemble.spdx3.ai._should_preserve_metadata`.
-
-    Returns:
-        A populated :class:`~pitloom.export.spdx3_json.Spdx3JsonExporter`.
-    """
+    """Assemble a standalone SPDX 3 SBOM for a single AI model file."""
     doc_name: str = model.name or model.format_info.file_name or "model"
-    encoder: ProvenanceEncoder = resolve_encoder(provenance_schema)
+    prov_cfg = provenance or ProvenanceConfig()
+    encoder: ProvenanceEncoder = resolve_encoder(prov_cfg.schema)
 
     exporter = Spdx3JsonExporter()
     doc_uuid = compute_doc_uuid(
@@ -475,43 +404,19 @@ def build_model(
         doc_name=doc_name,
         doc_uuid=doc_uuid,
         exporter=exporter,
-        provenance_format=provenance_format,
+        provenance_config=prov_cfg,
         encoder=encoder,
-        provenance_detail=provenance_detail,
     )
-    # Standalone model SBOM: the model is the root artifact, not bundled in a
-    # wheel, so the file set is empty and "auto" preserves its raw metadata.
     _emit_source_metadata(
         model,
         ai_pkg,
         {},
-        provenance_preserve_source_metadata,
+        prov_cfg.preserve_source_metadata,
         spdx_ci,
         doc_name,
         doc_uuid,
         exporter,
     )
-
-    if model.license:
-        rel_declared, rel_concluded = build_license_elements(
-            license_id=model.license,
-            package_spdx_id=require_spdx_id(ai_pkg),
-            license_provenance=model.provenance.get(
-                "license",
-                "Source: model file / Hugging Face Hub",
-            ),
-            creation_info=spdx_ci,
-            doc_name=doc_name,
-            doc_uuid=doc_uuid,
-            exporter=exporter,
-            provenance_format=provenance_format,
-            encoder=encoder,
-            provenance_detail=provenance_detail,
-        )
-        if rel_declared:
-            exporter.add_relationship(rel_declared)
-        if rel_concluded:
-            exporter.add_relationship(rel_concluded)
 
     if model.datasets:
         add_datasets_for_model(
@@ -521,17 +426,35 @@ def build_model(
             doc_name=doc_name,
             doc_uuid=doc_uuid,
             exporter=exporter,
-            provenance_format=provenance_format,
+            provenance_config=prov_cfg,
             encoder=encoder,
-            provenance_detail=provenance_detail,
         )
+
+    if model.license:
+        rel_declared, rel_concluded = build_license_elements(
+            license_id=model.license,
+            package_spdx_id=require_spdx_id(ai_pkg),
+            license_provenance=model.provenance.get(
+                "license", "Source: AI model metadata"
+            ),
+            creation_info=spdx_ci,
+            doc_name=doc_name,
+            doc_uuid=doc_uuid,
+            exporter=exporter,
+            provenance_config=prov_cfg,
+            encoder=encoder,
+        )
+        if rel_declared:
+            exporter.add_relationship(rel_declared)
+        if rel_concluded:
+            exporter.add_relationship(rel_concluded)
 
     sbom = spdx3.software_Sbom(
         spdxId=generate_spdx_id("Sbom", doc_name=doc_name, doc_uuid=doc_uuid),
         creationInfo=spdx_ci,
         rootElement=[ai_pkg.spdxId],
     )
-    sbom.software_sbomType = [spdx3.software_SbomType.build]
+    sbom.software_sbomType = [spdx3.software_SbomType.analyzed]
 
     spdx_doc = spdx3.SpdxDocument(
         spdxId=generate_spdx_id("SpdxDocument", doc_name=doc_name, doc_uuid=doc_uuid),
@@ -560,40 +483,12 @@ def build_deployed(
     env_tree: list[dict[str, Any]],
     *,
     registry: IdRegistry | None = None,
-    provenance_format: str = "both",
-    provenance_schema: str = DEFAULT_SCHEMA_ID,
-    provenance_detail: str = "minimal",
+    provenance: ProvenanceConfig | None = None,
 ) -> Spdx3JsonExporter:
-    """Assemble SPDX 3 elements for a deployed environment.
-
-    Args:
-        doc: Format-neutral document model with environment metadata.
-        env_tree: Flat JSON list of packages and dependencies from pipdeptree.
-        registry: Optional stable file id registry. Each installed
-            package's id is looked up by name
-            (:meth:`~pitloom.ids.IdRegistry.lookup_entity`, type
-            ``"software_Package"``); a match reuses the registered
-            ``spdxId`` instead of minting a fresh one, so this element can
-            be unified with the same package referenced elsewhere (e.g. a
-            Source or Analyzed SBOM) once merged. A miss falls back to the
-            existing deterministic minting. A package gets a registry
-            entry either via an explicit ``pitloom ids generate --entity
-            <name>:software_Package``, or in bulk via ``pitloom ids
-            import <existing-sbom>`` (:meth:`~pitloom.ids.IdRegistry.import_sbom`
-            harvests every named element generically, not just files and
-            AI models).
-        provenance_format: How to record metadata provenance -- see
-            :func:`~pitloom.assemble.spdx3.provenance.emit_provenance`.
-        provenance_schema: Schema id for the provenance Annotation statement;
-            defaults to Pitloom's own ``"pitloom/1"`` schema.
-        provenance_detail: ``"minimal"`` (default) records only high-signal
-            field sources; ``"full"`` records every field's source.
-
-    Returns:
-        A populated Spdx3JsonExporter.
-    """
+    """Assemble SPDX 3 elements for a deployed environment."""
     metadata = doc.project
-    encoder: ProvenanceEncoder = resolve_encoder(provenance_schema)
+    prov_cfg = provenance or ProvenanceConfig()
+    encoder: ProvenanceEncoder = resolve_encoder(prov_cfg.schema)
     exporter = Spdx3JsonExporter()
     doc_uuid = compute_doc_uuid(
         name=metadata.name,
@@ -621,31 +516,30 @@ def build_deployed(
         doc_name=metadata.name,
         doc_uuid=doc_uuid,
         exporter=exporter,
-        provenance_format=provenance_format,
+        provenance_config=prov_cfg,
         encoder=encoder,
-        provenance_detail=provenance_detail,
     )
 
-    # --- Packages and Relationships ---
+    # --- First pass: Create software_Package elements ---
     package_spdx_ids: dict[str, str] = {}
-
-    # First pass: Create all packages
     for node in env_tree:
         pkg_info = node.get("package", {})
-        dep_name = pkg_info.get("package_name")
-        if not dep_name:
-            continue
-
+        dep_name = pkg_info.get("package_name") or pkg_info.get("key", "unknown")
         dep_version = pkg_info.get("installed_version", "unknown")
 
-        registered_id = (
-            registry.lookup_entity(dep_name, "software_Package")
+        lookup_key = pkg_info.get("key", dep_name.lower())
+        spdx_id = (
+            registry.lookup_entity(lookup_key, "software_Package")
             if registry is not None
             else None
         )
+        if spdx_id is None:
+            spdx_id = generate_spdx_id(
+                "Package", doc_name=metadata.name, doc_uuid=doc_uuid
+            )
+
         dep_package = spdx3.software_Package(
-            spdxId=registered_id
-            or generate_spdx_id("Package", doc_name=metadata.name, doc_uuid=doc_uuid),
+            spdxId=spdx_id,
             name=dep_name,
             creationInfo=spdx_ci,
         )
@@ -659,9 +553,8 @@ def build_deployed(
             metadata.name,
             doc_uuid,
             exporter,
-            provenance_format=provenance_format,
+            provenance_config=prov_cfg,
             encoder=encoder,
-            provenance_detail=provenance_detail,
         )
 
         exporter.add_package(dep_package)
@@ -672,9 +565,8 @@ def build_deployed(
             doc_name=metadata.name,
             doc_uuid=doc_uuid,
             exporter=exporter,
-            provenance_format=provenance_format,
+            provenance_config=prov_cfg,
             encoder=encoder,
-            provenance_detail=provenance_detail,
         )
         package_spdx_ids[pkg_info.get("key", dep_name.lower())] = require_spdx_id(
             dep_package

--- a/src/pitloom/assemble/spdx3/provenance.py
+++ b/src/pitloom/assemble/spdx3/provenance.py
@@ -25,6 +25,7 @@ from typing import Any, Protocol
 from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.core.models import generate_spdx_id
+from pitloom.core.provenance import ProvenanceConfig
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 
 #: Segment-key normalization for the ``"Key: value | Key: value"`` strings
@@ -389,9 +390,9 @@ def emit_provenance(
     doc_name: str,
     doc_uuid: str,
     exporter: Spdx3JsonExporter,
-    provenance_format: str = "both",
+    *,
+    provenance_config: ProvenanceConfig | None = None,
     encoder: ProvenanceEncoder | None = None,
-    provenance_detail: str = "minimal",
 ) -> None:
     """Write provenance for *subject* as an Annotation, a ``.comment``, or both.
 
@@ -403,22 +404,18 @@ def emit_provenance(
         doc_name: Document name (project name) for SPDX ID generation.
         doc_uuid: Document-scoped UUID used in SPDX ID generation.
         exporter: Receives the new Annotation element, when built.
-        provenance_format: ``"annotation"``, ``"comment"``, or ``"both"``
-            (default).
+        provenance_config: ProvenanceConfig instance (defaults to default
+            ProvenanceConfig()).
         encoder: Encoder used for the annotation path; defaults to the
             registered default schema.
-        provenance_detail: ``"minimal"`` (default, matching the system/config
-            default) first filters to high-signal fields only
-            (:func:`filter_high_signal`) so trivial "came from pyproject.toml"
-            noise is dropped; ``"full"`` records every field's source. Applies
-            to both the comment and annotation paths.
 
     Raises:
         ValueError: If *provenance_format* or *provenance_detail* is not a valid
-            value. Rejected rather than silently falling through -- an unknown
-            *provenance_format* would fire neither branch (provenance lost), and
-            an unknown *provenance_detail* would silently behave as ``"full"``.
+            value. Rejected rather than silently falling through.
     """
+    config = provenance_config or ProvenanceConfig()
+    provenance_format = config.format
+    provenance_detail = config.detail
     if provenance_format not in VALID_PROVENANCE_FORMATS:
         valid = ", ".join(sorted(VALID_PROVENANCE_FORMATS))
         raise ValueError(

--- a/src/pitloom/core/__init__.py
+++ b/src/pitloom/core/__init__.py
@@ -4,3 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Core SPDX models and data structures."""
+
+from pitloom.core.provenance import ProvenanceConfig
+
+__all__ = ["ProvenanceConfig"]

--- a/src/pitloom/core/config.py
+++ b/src/pitloom/core/config.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from pitloom.core.creation import Creator, Tool
+from pitloom.core.provenance import ProvenanceConfig
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -140,6 +141,16 @@ class PitloomConfig:
     provenance_schema: str = _DEFAULT_PROVENANCE_SCHEMA
     provenance_detail: str = "minimal"
     provenance_preserve_source_metadata: str = "auto"
+
+    @property
+    def provenance(self) -> ProvenanceConfig:
+        """Return ProvenanceConfig constructed from current config settings."""
+        return ProvenanceConfig(
+            format=self.provenance_format,
+            schema=self.provenance_schema,
+            detail=self.provenance_detail,
+            preserve_source_metadata=self.provenance_preserve_source_metadata,
+        )
 
 
 def _check_moved_creation_keys(

--- a/src/pitloom/core/provenance.py
+++ b/src/pitloom/core/provenance.py
@@ -1,0 +1,30 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration dataclass for metadata provenance Annotations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+DEFAULT_PROVENANCE_SCHEMA = "pitloom/1"
+
+
+@dataclass(frozen=True)
+class ProvenanceConfig:
+    """Configuration settings for SPDX 3 metadata provenance annotations.
+
+    Attributes:
+        format: How to record metadata provenance ("annotation", "comment", "both").
+        schema: Schema id for provenance Annotations.
+        detail: Provenance detail level ("minimal", "full").
+        preserve_source_metadata: How to preserve source metadata
+            ("auto", "always", "never").
+    """
+
+    format: str = "both"
+    schema: str = DEFAULT_PROVENANCE_SCHEMA
+    detail: str = "minimal"
+    preserve_source_metadata: str = "auto"

--- a/src/pitloom/extract/project.py
+++ b/src/pitloom/extract/project.py
@@ -5,10 +5,10 @@
 
 """Single entry point for resolving a project's metadata and Pitloom config.
 
-Tries ``pyproject.toml`` first, then ``setup.cfg``/``setup.py``, so both the
-CLI (:mod:`pitloom.__main__`) and the library entry point
-(:func:`pitloom.assemble.generate_sbom`) resolve project metadata and
-``[tool.pitloom]`` config the same way, from a single parse.
+Tries ``pyproject.toml`` first, then ``setup.cfg``/``setup.py``, or reads an
+sdist archive (.tar.gz, .zip), so both the CLI (:mod:`pitloom.__main__`) and
+the library entry point (:func:`pitloom.assemble.generate_project_sbom`) resolve
+project metadata the same way.
 """
 
 from __future__ import annotations
@@ -18,22 +18,32 @@ from pathlib import Path
 from pitloom.core.config import PitloomConfig
 from pitloom.core.project import ProjectMetadata
 from pitloom.extract.pyproject import read_pyproject
+from pitloom.extract.sdist import read_sdist
 from pitloom.extract.setuptools import read_setuptools
+
+_SDIST_EXTENSIONS = (".tar.gz", ".tgz", ".tar.bz2", ".tar.xz", ".zip")
+
+
+def _is_sdist_archive(path: Path) -> bool:
+    """Return True if path points to an sdist file archive."""
+    if not path.is_file():
+        return False
+    name_lower = path.name.lower()
+    return any(name_lower.endswith(ext) for ext in _SDIST_EXTENSIONS)
 
 
 def read_project(
-    project_dir: Path,
+    project_path: Path,
 ) -> tuple[ProjectMetadata, PitloomConfig, Path | None]:
-    """Resolve project metadata and Pitloom config from *project_dir*.
+    """Resolve project metadata and Pitloom config from *project_path*.
 
-    Tries ``pyproject.toml`` first (if it exists at all, regardless of
-    whether it has a ``[project]`` section), then falls back to
-    ``setup.cfg``/``setup.py``. A parse or validation error from either
-    source propagates -- it is a genuine config mistake, not a signal to
-    silently try the next source.
+    If *project_path* is a source distribution archive (.tar.gz, .zip),
+    extracts metadata from its internal PKG-INFO or pyproject.toml.
+    Otherwise, treats *project_path* as a directory and tries
+    ``pyproject.toml`` first, then ``setup.cfg``/``setup.py``.
 
     Args:
-        project_dir: Project root directory.
+        project_path: Project root directory or sdist archive path.
 
     Returns:
         A 3-tuple of:
@@ -42,29 +52,35 @@ def read_project(
           metadata.
         * :class:`~pitloom.core.config.PitloomConfig` -- resolved
           ``[tool.pitloom]`` settings.
-        * The config file path used (``pyproject.toml``, ``setup.cfg``, or
-          ``setup.py``).
+        * The config file path used (or the archive path itself).
 
     Raises:
-        FileNotFoundError: If none of ``pyproject.toml``, ``setup.cfg``, or
-            ``setup.py`` exist in *project_dir*.
-        ValueError: If ``[tool.pitloom]`` (or ``[tool:pitloom]``) config is
-            malformed.
+        FileNotFoundError: If *project_path* does not exist or no valid project
+            config is found.
+        ValueError: If config is malformed.
     """
-    pyproject_path = project_dir / "pyproject.toml"
+    if not project_path.exists():
+        raise FileNotFoundError(f"Project path not found: {project_path}")
+
+    if _is_sdist_archive(project_path):
+        metadata, files = read_sdist(project_path)
+        metadata.files = files
+        return metadata, PitloomConfig(), project_path
+
+    pyproject_path = project_path / "pyproject.toml"
     if pyproject_path.exists():
         metadata, pitloom_config = read_pyproject(pyproject_path)
         return metadata, pitloom_config, pyproject_path
 
-    setup_cfg = project_dir / "setup.cfg"
-    setup_py = project_dir / "setup.py"
+    setup_cfg = project_path / "setup.cfg"
+    setup_py = project_path / "setup.py"
     if setup_cfg.exists() or setup_py.exists():
-        metadata, pitloom_config = read_setuptools(project_dir)
+        metadata, pitloom_config = read_setuptools(project_path)
         config_path = setup_cfg if setup_cfg.exists() else setup_py
         return metadata, pitloom_config, config_path
 
     raise FileNotFoundError(
-        f"No pyproject.toml, setup.cfg, or setup.py found in {project_dir}"
+        f"No pyproject.toml, setup.cfg, or setup.py found in {project_path}"
     )
 
 

--- a/src/pitloom/extract/sdist.py
+++ b/src/pitloom/extract/sdist.py
@@ -1,0 +1,204 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Extractor for Python source distributions (sdists: .tar.gz, .zip)."""
+
+from __future__ import annotations
+
+import email
+import hashlib
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+from pitloom.core.project import ProjectFile, ProjectMetadata
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+
+def _parse_pkg_info(metadata_content: str, source_label: str) -> ProjectMetadata:
+    """Parse a PKG-INFO file content into ProjectMetadata."""
+    msg = email.message_from_string(metadata_content)
+    metadata = ProjectMetadata(name=msg.get("Name", "unknown"))
+
+    fields: dict[str, str] = {
+        "Version": "version",
+        "Summary": "description",
+        "Author": "author",
+        "Author-email": "author_email",
+        "License": "license",
+    }
+    for header, attr in fields.items():
+        value = msg.get(header)
+        if value and value != "UNKNOWN":
+            setattr(metadata, attr, value)
+            metadata.provenance[attr] = source_label
+
+    keywords = msg.get("Keywords")
+    if keywords and keywords != "UNKNOWN":
+        metadata.keywords = [kw.strip() for kw in keywords.split(",") if kw.strip()]
+        metadata.provenance["keywords"] = source_label
+
+    project_urls = msg.get_all("Project-URL") or []
+    if project_urls:
+        urls: dict[str, str] = {}
+        for entry in project_urls:
+            if "," in entry:
+                label, url = entry.split(",", 1)
+                urls[label.strip()] = url.strip()
+        if urls:
+            metadata.urls = urls
+            metadata.provenance["urls"] = source_label
+
+    author = msg.get("Author")
+    if author and author != "UNKNOWN":
+        metadata.authors = [{"name": author}]
+        metadata.provenance["authors"] = source_label
+
+    requires_dist = msg.get_all("Requires-Dist") or []
+    if requires_dist:
+        metadata.dependencies = list(requires_dist)
+        metadata.provenance["dependencies"] = source_label
+
+    return metadata
+
+
+def _read_tar_sdist(sdist_path: Path) -> tuple[ProjectMetadata, list[ProjectFile]]:
+    """Extract metadata and files from a tar-based sdist (.tar.gz, .tgz, etc.)."""
+    metadata = ProjectMetadata(name="unknown")
+    project_files: list[ProjectFile] = []
+    source_label = f"Source: sdist PKG-INFO | File: {sdist_path.name}"
+
+    with tarfile.open(sdist_path, "r:*") as tf:
+        pkg_info_content: str | None = None
+        pyproject_content: bytes | None = None
+
+        for member in tf.getmembers():
+            if not member.isfile():
+                continue
+
+            # Read file content for PKG-INFO / pyproject.toml
+            basename = Path(member.name).name
+            if basename == "PKG-INFO" and pkg_info_content is None:
+                extracted = tf.extractfile(member)
+                if extracted is not None:
+                    pkg_info_content = extracted.read().decode(
+                        "utf-8", errors="replace"
+                    )
+            elif basename == "pyproject.toml" and pyproject_content is None:
+                extracted = tf.extractfile(member)
+                if extracted is not None:
+                    pyproject_content = extracted.read()
+
+            # Hash file content
+            extracted_file = tf.extractfile(member)
+            hasher = hashlib.sha256()
+            if extracted_file is not None:
+                while chunk := extracted_file.read(8192):
+                    hasher.update(chunk)
+
+            project_files.append(
+                ProjectFile(
+                    physical_path=member.name,
+                    distribution_path=member.name,
+                    digest_sha256=hasher.hexdigest(),
+                )
+            )
+
+        if pkg_info_content is not None:
+            metadata = _parse_pkg_info(pkg_info_content, source_label)
+        elif pyproject_content is not None:
+            # Fallback to parsing pyproject.toml if PKG-INFO is missing
+            try:
+                data = tomllib.loads(
+                    pyproject_content.decode("utf-8", errors="replace")
+                )
+                proj = data.get("project", {})
+                metadata = ProjectMetadata(
+                    name=proj.get("name", "unknown"),
+                    version=proj.get("version"),
+                    description=proj.get("description"),
+                    dependencies=proj.get("dependencies", []),
+                )
+            except Exception:  # pylint: disable=broad-exception-caught
+                metadata = ProjectMetadata(name="unknown")
+
+    return metadata, project_files
+
+
+def _read_zip_sdist(sdist_path: Path) -> tuple[ProjectMetadata, list[ProjectFile]]:
+    """Extract metadata and files from a zip-based sdist (.zip)."""
+    metadata = ProjectMetadata(name="unknown")
+    project_files: list[ProjectFile] = []
+    source_label = f"Source: sdist PKG-INFO | File: {sdist_path.name}"
+
+    with zipfile.ZipFile(sdist_path, "r") as zf:
+        pkg_info_content: str | None = None
+        pyproject_content: bytes | None = None
+
+        for info in zf.infolist():
+            if info.is_dir():
+                continue
+
+            basename = Path(info.filename).name
+            if basename == "PKG-INFO" and pkg_info_content is None:
+                pkg_info_content = zf.read(info).decode("utf-8", errors="replace")
+            elif basename == "pyproject.toml" and pyproject_content is None:
+                pyproject_content = zf.read(info)
+
+            hasher = hashlib.sha256()
+            with zf.open(info) as f:
+                while chunk := f.read(8192):
+                    hasher.update(chunk)
+
+            project_files.append(
+                ProjectFile(
+                    physical_path=info.filename,
+                    distribution_path=info.filename,
+                    digest_sha256=hasher.hexdigest(),
+                )
+            )
+
+        if pkg_info_content is not None:
+            metadata = _parse_pkg_info(pkg_info_content, source_label)
+        elif pyproject_content is not None:
+            try:
+                data = tomllib.loads(
+                    pyproject_content.decode("utf-8", errors="replace")
+                )
+                proj = data.get("project", {})
+                metadata = ProjectMetadata(
+                    name=proj.get("name", "unknown"),
+                    version=proj.get("version"),
+                    description=proj.get("description"),
+                    dependencies=proj.get("dependencies", []),
+                )
+            except Exception:  # pylint: disable=broad-exception-caught
+                metadata = ProjectMetadata(name="unknown")
+
+    return metadata, project_files
+
+
+def read_sdist(sdist_path: Path | str) -> tuple[ProjectMetadata, list[ProjectFile]]:
+    """Extract project metadata and file records from a source distribution archive.
+
+    Args:
+        sdist_path: Path to a .tar.gz, .tgz, .tar.bz2, .tar.xz, or .zip sdist file.
+
+    Returns:
+        A tuple of (ProjectMetadata, list of ProjectFile).
+    """
+    path = Path(sdist_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Source distribution archive not found: {path}")
+
+    filename_lower = path.name.lower()
+    if filename_lower.endswith(".zip"):
+        return _read_zip_sdist(path)
+    return _read_tar_sdist(path)

--- a/src/pitloom/extract/sdist.py
+++ b/src/pitloom/extract/sdist.py
@@ -3,7 +3,9 @@
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
-"""Extractor for Python source distributions (sdists: .tar.gz, .zip)."""
+"""Tests for sdist archive metadata extraction."""
+
+# pylint: disable=redefined-outer-name
 
 from __future__ import annotations
 
@@ -22,28 +24,31 @@ else:
     import tomli as tomllib
 
 
-def _parse_pkg_info(metadata_content: str, source_label: str) -> ProjectMetadata:
-    """Parse a PKG-INFO file content into ProjectMetadata."""
-    msg = email.message_from_string(metadata_content)
-    metadata = ProjectMetadata(name=msg.get("Name", "unknown"))
+def _parse_pkg_info(pkg_info_text: str, source_label: str) -> ProjectMetadata:
+    """Parse Metadata-Version 2.x PKG-INFO content into ProjectMetadata."""
+    msg = email.message_from_string(pkg_info_text)
+    name = msg.get("Name", "unknown")
+    version = msg.get("Version")
+    summary = msg.get("Summary")
+    license_name = msg.get("License")
+    requires_python = msg.get("Requires-Python")
 
-    fields: dict[str, str] = {
-        "Version": "version",
-        "Summary": "description",
-        "Author": "author",
-        "Author-email": "author_email",
-        "License": "license",
-    }
-    for header, attr in fields.items():
-        value = msg.get(header)
-        if value and value != "UNKNOWN":
-            setattr(metadata, attr, value)
-            metadata.provenance[attr] = source_label
-
-    keywords = msg.get("Keywords")
-    if keywords and keywords != "UNKNOWN":
-        metadata.keywords = [kw.strip() for kw in keywords.split(",") if kw.strip()]
-        metadata.provenance["keywords"] = source_label
+    metadata = ProjectMetadata(
+        name=name,
+        version=version,
+        description=summary,
+        license_name=license_name,
+        requires_python=requires_python,
+    )
+    metadata.provenance["name"] = source_label
+    if version:
+        metadata.provenance["version"] = source_label
+    if summary:
+        metadata.provenance["description"] = source_label
+    if license_name:
+        metadata.provenance["license"] = source_label
+    if requires_python:
+        metadata.provenance["requires_python"] = source_label
 
     project_urls = msg.get_all("Project-URL") or []
     if project_urls:
@@ -63,58 +68,55 @@ def _parse_pkg_info(metadata_content: str, source_label: str) -> ProjectMetadata
 
     requires_dist = msg.get_all("Requires-Dist") or []
     if requires_dist:
-        metadata.dependencies = list(requires_dist)
+        metadata.dependencies = [r.strip() for r in requires_dist]
         metadata.provenance["dependencies"] = source_label
 
     return metadata
 
 
 def _read_tar_sdist(sdist_path: Path) -> tuple[ProjectMetadata, list[ProjectFile]]:
-    """Extract metadata and files from a tar-based sdist (.tar.gz, .tgz, etc.)."""
+    """Extract metadata and files from a tar-based sdist (.tar.gz, .tgz)."""
     metadata = ProjectMetadata(name="unknown")
     project_files: list[ProjectFile] = []
+    pkg_info_content: str | None = None
+    pyproject_content: bytes | None = None
     source_label = f"Source: sdist PKG-INFO | File: {sdist_path.name}"
 
     with tarfile.open(sdist_path, "r:*") as tf:
-        pkg_info_content: str | None = None
-        pyproject_content: bytes | None = None
-
         for member in tf.getmembers():
             if not member.isfile():
                 continue
 
-            # Read file content for PKG-INFO / pyproject.toml
+            extracted = tf.extractfile(member)
+            if extracted is None:
+                continue
+
+            with extracted:
+                content = extracted.read()
+
+            parts = Path(member.name).parts
             basename = Path(member.name).name
-            if basename == "PKG-INFO" and pkg_info_content is None:
-                extracted = tf.extractfile(member)
-                if extracted is not None:
-                    pkg_info_content = extracted.read().decode(
-                        "utf-8", errors="replace"
-                    )
-            elif basename == "pyproject.toml" and pyproject_content is None:
-                extracted = tf.extractfile(member)
-                if extracted is not None:
-                    pyproject_content = extracted.read()
+            if basename == "PKG-INFO" and pkg_info_content is None and len(parts) == 2:
+                pkg_info_content = content.decode("utf-8", errors="replace")
+            elif (
+                basename == "pyproject.toml"
+                and pyproject_content is None
+                and len(parts) == 2
+            ):
+                pyproject_content = content
 
-            # Hash file content
-            extracted_file = tf.extractfile(member)
-            hasher = hashlib.sha256()
-            if extracted_file is not None:
-                while chunk := extracted_file.read(8192):
-                    hasher.update(chunk)
-
+            digest = hashlib.sha256(content).hexdigest()
             project_files.append(
                 ProjectFile(
                     physical_path=member.name,
                     distribution_path=member.name,
-                    digest_sha256=hasher.hexdigest(),
+                    digest_sha256=digest,
                 )
             )
 
         if pkg_info_content is not None:
             metadata = _parse_pkg_info(pkg_info_content, source_label)
         elif pyproject_content is not None:
-            # Fallback to parsing pyproject.toml if PKG-INFO is missing
             try:
                 data = tomllib.loads(
                     pyproject_content.decode("utf-8", errors="replace")
@@ -137,31 +139,34 @@ def _read_zip_sdist(sdist_path: Path) -> tuple[ProjectMetadata, list[ProjectFile
     metadata = ProjectMetadata(name="unknown")
     project_files: list[ProjectFile] = []
     source_label = f"Source: sdist PKG-INFO | File: {sdist_path.name}"
+    pkg_info_content: str | None = None
+    pyproject_content: bytes | None = None
 
     with zipfile.ZipFile(sdist_path, "r") as zf:
-        pkg_info_content: str | None = None
-        pyproject_content: bytes | None = None
-
         for info in zf.infolist():
             if info.is_dir():
                 continue
 
-            basename = Path(info.filename).name
-            if basename == "PKG-INFO" and pkg_info_content is None:
-                pkg_info_content = zf.read(info).decode("utf-8", errors="replace")
-            elif basename == "pyproject.toml" and pyproject_content is None:
-                pyproject_content = zf.read(info)
-
-            hasher = hashlib.sha256()
             with zf.open(info) as f:
-                while chunk := f.read(8192):
-                    hasher.update(chunk)
+                content = f.read()
 
+            parts = Path(info.filename).parts
+            basename = Path(info.filename).name
+            if basename == "PKG-INFO" and pkg_info_content is None and len(parts) == 2:
+                pkg_info_content = content.decode("utf-8", errors="replace")
+            elif (
+                basename == "pyproject.toml"
+                and pyproject_content is None
+                and len(parts) == 2
+            ):
+                pyproject_content = content
+
+            digest = hashlib.sha256(content).hexdigest()
             project_files.append(
                 ProjectFile(
                     physical_path=info.filename,
                     distribution_path=info.filename,
-                    digest_sha256=hasher.hexdigest(),
+                    digest_sha256=digest,
                 )
             )
 
@@ -185,20 +190,19 @@ def _read_zip_sdist(sdist_path: Path) -> tuple[ProjectMetadata, list[ProjectFile
     return metadata, project_files
 
 
-def read_sdist(sdist_path: Path | str) -> tuple[ProjectMetadata, list[ProjectFile]]:
-    """Extract project metadata and file records from a source distribution archive.
+def read_sdist(sdist_path: Path) -> tuple[ProjectMetadata, list[ProjectFile]]:
+    """Read metadata and files from an sdist archive (.tar.gz, .tgz, .zip).
 
     Args:
-        sdist_path: Path to a .tar.gz, .tgz, .tar.bz2, .tar.xz, or .zip sdist file.
+        sdist_path: Path to the sdist archive.
 
     Returns:
-        A tuple of (ProjectMetadata, list of ProjectFile).
+        Tuple of (ProjectMetadata, list of ProjectFile).
     """
-    path = Path(sdist_path)
-    if not path.exists():
-        raise FileNotFoundError(f"Source distribution archive not found: {path}")
+    if not sdist_path.exists():
+        raise FileNotFoundError(f"Sdist archive not found: {sdist_path}")
 
-    filename_lower = path.name.lower()
+    filename_lower = sdist_path.name.lower()
     if filename_lower.endswith(".zip"):
-        return _read_zip_sdist(path)
-    return _read_tar_sdist(path)
+        return _read_zip_sdist(sdist_path)
+    return _read_tar_sdist(sdist_path)

--- a/src/pitloom/ids.py
+++ b/src/pitloom/ids.py
@@ -505,7 +505,7 @@ def resolve_registry(project_dir: Path, ids_file: str | None) -> IdRegistry | No
     """Resolve the registry a project build should consult.
 
     Shared by the Hatchling build hook and the CLI project-assembly path
-    (see :func:`pitloom.assemble.generate_sbom`) so both use the exact same
+    (see :func:`~pitloom.assemble.generate_project_sbom`) so both use the exact same
     resolution rule as ``pitloom.loom``: an explicit ``[tool.pitloom.ids]
     file`` (``ids_file``) is loaded relative to *project_dir*; otherwise
     ``loom-ids.json`` is auto-discovered by walking up from

--- a/src/pitloom/loom.py
+++ b/src/pitloom/loom.py
@@ -20,6 +20,7 @@ from pitloom.assemble.spdx3.creation_info import build_creation_info
 from pitloom.assemble.spdx3.provenance import emit_provenance
 from pitloom.core.creation import CreationMetadata
 from pitloom.core.models import generate_spdx_id
+from pitloom.core.provenance import ProvenanceConfig
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 from pitloom.extract._extract_utils import sanitize_provenance_text
 from pitloom.ids import IdRegistry
@@ -28,7 +29,7 @@ from pitloom.ids import IdRegistry
 #: through a pyproject.toml-based [tool.pitloom.provenance] config -- so
 #: provenance is always recorded both ways (Annotation + legacy comment)
 #: rather than threading a format setting through the whole SDK surface.
-_LOOM_PROVENANCE_FORMAT = "both"
+_LOOM_PROVENANCE_CONFIG = ProvenanceConfig(format="both")
 
 log = logging.getLogger(__name__)
 
@@ -292,7 +293,7 @@ class _ActiveRun:  # pylint: disable=too-many-instance-attributes
             doc_name=name,
             doc_uuid=self.doc_uuid,
             exporter=self.exporter,
-            provenance_format=_LOOM_PROVENANCE_FORMAT,
+            provenance_config=_LOOM_PROVENANCE_CONFIG,
         )
 
     def use_model(
@@ -337,7 +338,7 @@ class _ActiveRun:  # pylint: disable=too-many-instance-attributes
             doc_name=self.model.name or "model",
             doc_uuid=self.doc_uuid,
             exporter=self.exporter,
-            provenance_format=_LOOM_PROVENANCE_FORMAT,
+            provenance_config=_LOOM_PROVENANCE_CONFIG,
         )
 
     def _build_dataset_package(
@@ -362,7 +363,7 @@ class _ActiveRun:  # pylint: disable=too-many-instance-attributes
             doc_name=name,
             doc_uuid=self.doc_uuid,
             exporter=self.exporter,
-            provenance_format=_LOOM_PROVENANCE_FORMAT,
+            provenance_config=_LOOM_PROVENANCE_CONFIG,
         )
         if hash_element is not None:
             dataset_pkg.verifiedUsing = [hash_element]

--- a/src/pitloom/plugins/hatch.py
+++ b/src/pitloom/plugins/hatch.py
@@ -17,6 +17,7 @@ from typing import Any
 from hatchling.builders.config import BuilderConfig
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from hatchling.plugin import hookimpl
+from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.assemble.spdx3.creation_info import to_spdx3_datetime
 from pitloom.assemble.spdx3.document import build as assemble_spdx3
@@ -207,13 +208,9 @@ class PitloomBuildHook(BuildHookInterface[BuilderConfig]):
         exporter = assemble_spdx3(
             document,
             merkle_root=merkle_root,
+            sbom_type=spdx3.software_SbomType.build,
             registry=registry,
-            provenance_format=pitloom_config.provenance_format,
-            provenance_schema=pitloom_config.provenance_schema,
-            provenance_detail=pitloom_config.provenance_detail,
-            provenance_preserve_source_metadata=(
-                pitloom_config.provenance_preserve_source_metadata
-            ),
+            provenance=pitloom_config.provenance,
         )
         merge_fragments(project_dir, pitloom_config.fragments, exporter)
 

--- a/tests/test_annotation_provenance.py
+++ b/tests/test_annotation_provenance.py
@@ -31,6 +31,7 @@ from pitloom.assemble.spdx3.provenance import (
     resolve_encoder,
 )
 from pitloom.core.models import _clear_doc_counters, compute_doc_uuid, generate_spdx_id
+from pitloom.core.provenance import ProvenanceConfig
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 
 _DOC_NAME = "testproject"
@@ -266,7 +267,7 @@ def test_emit_provenance_unknown_format_raises() -> None:
             doc_name=_DOC_NAME,
             doc_uuid=_DOC_UUID,
             exporter=exporter,
-            provenance_format="bogus-value",
+            provenance_config=ProvenanceConfig(format="bogus-value"),
         )
     # Nothing partially applied.
     assert pkg.comment is None
@@ -289,7 +290,7 @@ def test_emit_provenance_unknown_detail_raises() -> None:
             doc_name=_DOC_NAME,
             doc_uuid=_DOC_UUID,
             exporter=exporter,
-            provenance_detail="verbose",
+            provenance_config=ProvenanceConfig(detail="verbose"),
         )
     assert pkg.comment is None
     assert not any(isinstance(o, spdx3.Annotation) for o in exporter.object_set.objects)
@@ -308,8 +309,7 @@ def test_emit_provenance_both_sets_comment_and_annotation() -> None:
         doc_name=_DOC_NAME,
         doc_uuid=_DOC_UUID,
         exporter=exporter,
-        provenance_format="both",
-        provenance_detail="full",
+        provenance_config=ProvenanceConfig(format="both", detail="full"),
     )
 
     assert pkg.comment is not None
@@ -334,8 +334,7 @@ def test_emit_provenance_annotation_only_leaves_comment_unset() -> None:
         doc_name=_DOC_NAME,
         doc_uuid=_DOC_UUID,
         exporter=exporter,
-        provenance_format="annotation",
-        provenance_detail="full",
+        provenance_config=ProvenanceConfig(format="annotation", detail="full"),
     )
 
     assert pkg.comment is None
@@ -358,8 +357,7 @@ def test_emit_provenance_comment_only_creates_no_annotation() -> None:
         doc_name=_DOC_NAME,
         doc_uuid=_DOC_UUID,
         exporter=exporter,
-        provenance_format="comment",
-        provenance_detail="full",
+        provenance_config=ProvenanceConfig(format="comment", detail="full"),
     )
 
     assert pkg.comment is not None
@@ -382,7 +380,7 @@ def test_emit_provenance_empty_provenance_is_a_noop() -> None:
         doc_name=_DOC_NAME,
         doc_uuid=_DOC_UUID,
         exporter=exporter,
-        provenance_format="both",
+        provenance_config=ProvenanceConfig(format="both"),
     )
 
     assert pkg.comment is None
@@ -408,13 +406,12 @@ def test_emit_provenance_appends_to_existing_comment() -> None:
         doc_name=_DOC_NAME,
         doc_uuid=_DOC_UUID,
         exporter=exporter,
-        provenance_format="comment",
-        provenance_detail="full",
+        provenance_config=ProvenanceConfig(format="comment", detail="full"),
     )
 
     assert pkg.comment
     assert pkg.comment.startswith("Known biases: overrepresents English text\n")
-    assert "Metadata provenance" in pkg.comment
+    assert "Metadata provenance: name: " in pkg.comment
 
 
 # ---------------------------------------------------------------------------
@@ -531,8 +528,7 @@ def test_emit_provenance_minimal_filters_trivial_fields() -> None:
         doc_name=_DOC_NAME,
         doc_uuid=_DOC_UUID,
         exporter=exporter,
-        provenance_format="annotation",
-        provenance_detail="minimal",
+        provenance_config=ProvenanceConfig(format="annotation", detail="minimal"),
     )
     annotations = [
         o for o in exporter.object_set.objects if isinstance(o, spdx3.Annotation)
@@ -556,8 +552,7 @@ def test_emit_provenance_minimal_all_trivial_emits_nothing() -> None:
         doc_name=_DOC_NAME,
         doc_uuid=_DOC_UUID,
         exporter=exporter,
-        provenance_format="both",
-        provenance_detail="minimal",
+        provenance_config=ProvenanceConfig(format="both", detail="minimal"),
     )
     assert pkg.comment is None
     assert not any(isinstance(o, spdx3.Annotation) for o in exporter.object_set.objects)
@@ -579,8 +574,7 @@ def test_emit_provenance_full_keeps_all_fields() -> None:
         doc_name=_DOC_NAME,
         doc_uuid=_DOC_UUID,
         exporter=exporter,
-        provenance_format="annotation",
-        provenance_detail="full",
+        provenance_config=ProvenanceConfig(format="annotation", detail="full"),
     )
     annotations = [
         o for o in exporter.object_set.objects if isinstance(o, spdx3.Annotation)

--- a/tests/test_extract_sdist.py
+++ b/tests/test_extract_sdist.py
@@ -1,0 +1,98 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for sdist archive metadata extraction."""
+
+# pylint: disable=redefined-outer-name
+
+from __future__ import annotations
+
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from pitloom.extract.project import read_project
+from pitloom.extract.sdist import read_sdist
+
+
+@pytest.fixture
+def sample_pkg_info() -> str:
+    return (
+        "Metadata-Version: 2.1\n"
+        "Name: demo-sdist-pkg\n"
+        "Version: 1.2.3\n"
+        "Summary: A demo package for sdist testing\n"
+        "Author: Alice Developer\n"
+        "Author-email: alice@example.com\n"
+        "License: Apache-2.0\n"
+        "Requires-Dist: requests>=2.28.0\n"
+    )
+
+
+def test_read_tar_sdist(tmp_path: Path, sample_pkg_info: str) -> None:
+    sdist_path = tmp_path / "demo-sdist-pkg-1.2.3.tar.gz"
+
+    with tarfile.open(sdist_path, "w:gz") as tf:
+        # PKG-INFO
+        pkg_bytes = sample_pkg_info.encode("utf-8")
+        ti = tarfile.TarInfo(name="demo-sdist-pkg-1.2.3/PKG-INFO")
+        ti.size = len(pkg_bytes)
+        tf.addfile(ti, io.BytesIO(pkg_bytes))
+
+        # pyproject.toml
+        pyproj_bytes = b'[project]\nname = "demo-sdist-pkg"\nversion = "1.2.3"\n'
+        ti2 = tarfile.TarInfo(name="demo-sdist-pkg-1.2.3/pyproject.toml")
+        ti2.size = len(pyproj_bytes)
+        tf.addfile(ti2, io.BytesIO(pyproj_bytes))
+
+        # source file
+        src_bytes = b'print("hello from sdist")\n'
+        ti3 = tarfile.TarInfo(name="demo-sdist-pkg-1.2.3/src/main.py")
+        ti3.size = len(src_bytes)
+        tf.addfile(ti3, io.BytesIO(src_bytes))
+
+    metadata, files = read_sdist(sdist_path)
+    assert metadata.name == "demo-sdist-pkg"
+    assert metadata.version == "1.2.3"
+    assert metadata.description == "A demo package for sdist testing"
+    assert metadata.authors == [{"name": "Alice Developer"}]
+    assert metadata.dependencies == ["requests>=2.28.0"]
+    assert len(files) == 3
+
+
+def test_read_zip_sdist(tmp_path: Path, sample_pkg_info: str) -> None:
+    sdist_path = tmp_path / "demo-sdist-pkg-1.2.3.zip"
+
+    with zipfile.ZipFile(sdist_path, "w") as zf:
+        zf.writestr("demo-sdist-pkg-1.2.3/PKG-INFO", sample_pkg_info)
+        zf.writestr("demo-sdist-pkg-1.2.3/src/main.py", 'print("hello zip")\n')
+
+    metadata, files = read_sdist(sdist_path)
+    assert metadata.name == "demo-sdist-pkg"
+    assert metadata.version == "1.2.3"
+    assert len(files) == 2
+
+
+def test_read_project_with_sdist(tmp_path: Path, sample_pkg_info: str) -> None:
+    sdist_path = tmp_path / "demo-sdist-pkg-1.2.3.tar.gz"
+
+    with tarfile.open(sdist_path, "w:gz") as tf:
+        pkg_bytes = sample_pkg_info.encode("utf-8")
+        ti = tarfile.TarInfo(name="demo-sdist-pkg-1.2.3/PKG-INFO")
+        ti.size = len(pkg_bytes)
+        tf.addfile(ti, io.BytesIO(pkg_bytes))
+
+    metadata, _, path_used = read_project(sdist_path)
+    assert metadata.name == "demo-sdist-pkg"
+    assert metadata.version == "1.2.3"
+    assert path_used == sdist_path
+
+
+def test_read_sdist_not_found(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        read_sdist(tmp_path / "non_existent.tar.gz")

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -39,7 +39,7 @@ import pytest
 from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom import loom
-from pitloom.assemble import generate_sbom
+from pitloom.assemble import generate_project_sbom
 from pitloom.assemble.spdx3.fragments import merge_fragments
 from pitloom.core.creation import CreationMetadata, Creator
 from pitloom.export.spdx3_json import Spdx3JsonExporter
@@ -401,7 +401,7 @@ class TestMultipleFragmentsMerge:
 
 
 # ---------------------------------------------------------------------------
-# End-to-end via generate_sbom -- fragment elements survive full pipeline
+# End-to-end via generate_project_sbom -- fragment elements survive full pipeline
 # ---------------------------------------------------------------------------
 
 
@@ -426,8 +426,8 @@ files = [
 """
 
 
-def test_generate_sbom_includes_ai_model_fragment_elements() -> None:
-    """Full generate_sbom pipeline must include elements from listed fragments."""
+def test_generate_project_sbom_includes_ai_model_fragment_elements() -> None:
+    """Full pipeline must include elements from listed fragments."""
     with tempfile.TemporaryDirectory() as tmpdir:
         tmppath = Path(tmpdir)
 
@@ -438,7 +438,7 @@ def test_generate_sbom_includes_ai_model_fragment_elements() -> None:
         for name in (_AI_MODEL_FRAGMENT, _TRAINING_RUN_FRAGMENT):
             shutil.copy(_FRAGMENTS_DIR / name, tmppath / name)
 
-        sbom_json = generate_sbom(
+        sbom_json = generate_project_sbom(
             tmppath,
             creation_metadata=CreationMetadata(creators=[Creator(name="Test")]),
         )
@@ -473,8 +473,8 @@ def test_generate_sbom_includes_ai_model_fragment_elements() -> None:
         assert m.get("val_accuracy") == "0.9876"
 
 
-def test_generate_sbom_includes_dataset_fragment_elements() -> None:
-    """dataset_DatasetPackage from fragment must appear in generate_sbom output."""
+def test_generate_project_sbom_includes_dataset_fragment_elements() -> None:
+    """dataset_DatasetPackage from fragment must appear in output."""
     pyproject = """\
 [build-system]
 requires = ["hatchling"]
@@ -495,7 +495,7 @@ files = ["dataset-fragment.spdx3.json"]
         (tmppath / "pyproject.toml").write_text(pyproject)
         shutil.copy(_FRAGMENTS_DIR / _DATASET_FRAGMENT, tmppath / _DATASET_FRAGMENT)
 
-        sbom_json = generate_sbom(
+        sbom_json = generate_project_sbom(
             tmppath,
             creation_metadata=CreationMetadata(creators=[Creator(name="Test")]),
         )
@@ -606,7 +606,7 @@ def _run_unify_pipeline(tmppath: Path) -> None:
 
 
 class TestRegistryUnification:
-    """The full workflow: `ids generate` -> loom runs -> generate_sbom."""
+    """The full workflow: `ids generate` -> loom runs -> generate_project_sbom."""
 
     @pytest.fixture()
     def merged(
@@ -616,7 +616,7 @@ class TestRegistryUnification:
         monkeypatch.chdir(tmp_path)
         _run_unify_pipeline(tmp_path)
 
-        sbom_json = generate_sbom(tmp_path, creation_metadata=_fixed_creation())
+        sbom_json = generate_project_sbom(tmp_path, creation_metadata=_fixed_creation())
         graph = json.loads(sbom_json).get("@graph", [])
         index = {e["spdxId"]: e for e in graph if "spdxId" in e}
         registry = IdRegistry.load(tmp_path / "loom-ids.json")
@@ -735,8 +735,8 @@ class TestRegistryUnification:
         monkeypatch.chdir(tmp_path)
         _run_unify_pipeline(tmp_path)
         creation = _fixed_creation()
-        first = generate_sbom(tmp_path, creation_metadata=creation)
-        second = generate_sbom(tmp_path, creation_metadata=creation)
+        first = generate_project_sbom(tmp_path, creation_metadata=creation)
+        second = generate_project_sbom(tmp_path, creation_metadata=creation)
         assert first == second
 
 
@@ -882,7 +882,7 @@ def test_fragment_envelope_is_dropped(tmp_path: Path) -> None:
         json.dumps(envelope_fragment)
     )
 
-    sbom_json = generate_sbom(
+    sbom_json = generate_project_sbom(
         tmp_path, creation_metadata=CreationMetadata(creators=[Creator(name="Test")])
     )
     graph = json.loads(sbom_json).get("@graph", [])

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -949,7 +949,7 @@ def test_assembler_ai_model_reuses_registry_entity_by_physical_path() -> None:
 
 def test_assembler_ai_model_reuses_registry_entity_by_file_stem() -> None:
     """Falls back to the model file's stem (mirroring the lookup
-    generate_ai_model_sbom performs for loom model/--registry) when no
+    generate_model_sbom performs for loom model/--registry) when no
     physical_path or name match is registered."""
     project = ProjectMetadata(name="ai-project", version="0.1.0")
     ai_model = AiModelMetadata(
@@ -1553,7 +1553,7 @@ def test_fixture_license_export(fixture_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# assemble-layer wiring: generate_analyzed_sbom() / generate_deployed_sbom()
+# assemble-layer wiring: generate_wheel_sbom() / generate_env_sbom()
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -19,9 +19,10 @@ from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.__about__ import __version__
 from pitloom.assemble import (
-    generate_analyzed_sbom,
-    generate_deployed_sbom,
-    generate_sbom,
+    generate,
+    generate_env_sbom,
+    generate_project_sbom,
+    generate_wheel_sbom,
 )
 from pitloom.assemble.spdx3.document import build, build_deployed, build_model
 from pitloom.core.ai_metadata import AiModelFormat, AiModelFormatInfo, AiModelMetadata
@@ -36,7 +37,7 @@ from pitloom.extract.ai_model import read_ai_model
 from pitloom.ids import IdRegistry
 
 
-def test_generate_sbom_basic() -> None:
+def test_generate_project_sbom_basic() -> None:
     """Test basic SBOM generation from a simple project."""
     pyproject_content = """
 [build-system]
@@ -59,7 +60,7 @@ Source = "https://github.com/test/test-package"
         pyproject_path = tmppath / "pyproject.toml"
         pyproject_path.write_text(pyproject_content)
 
-        sbom_json = generate_sbom(
+        sbom_json = generate_project_sbom(
             tmppath,
             creation_metadata=CreationMetadata(
                 creators=[Creator(name="Test Creator", email="test@example.com")],
@@ -95,7 +96,7 @@ Source = "https://github.com/test/test-package"
         assert len(dep_packages) >= 2
 
 
-def test_generate_sbom_basic_main_package_purl() -> None:
+def test_generate_project_sbom_basic_main_package_purl() -> None:
     """The main package must carry a pkg:pypi PURL when a real version is known."""
     pyproject_content = """
 [build-system]
@@ -112,7 +113,7 @@ description = "A test package"
         tmppath = Path(tmpdir)
         (tmppath / "pyproject.toml").write_text(pyproject_content)
 
-        sbom_json = generate_sbom(tmppath)
+        sbom_json = generate_project_sbom(tmppath)
         graph = json.loads(sbom_json)["@graph"]
 
         packages = [e for e in graph if e.get("type") == "software_Package"]
@@ -182,7 +183,7 @@ def test_build_package_files_have_sha256_verified_using() -> None:
         assert hash_obj["hashValue"] == pf.digest_sha256
 
 
-def test_generate_sbom_to_output_path() -> None:
+def test_generate_project_sbom_to_output_path() -> None:
     """Test SBOM generation written to an output file."""
     pyproject_content = """
 [build-system]
@@ -201,7 +202,7 @@ description = "A simple application"
         pyproject_path.write_text(pyproject_content)
 
         output_path = tmppath / "sbom.spdx3.json"
-        generate_sbom(tmppath, output_path=output_path)
+        generate_project_sbom(tmppath, output_path=output_path)
 
         assert output_path.exists()
 
@@ -211,7 +212,7 @@ description = "A simple application"
         assert "@graph" in sbom_data
 
 
-def test_generate_sbom_creation_comment_and_no_tool() -> None:
+def test_generate_project_sbom_creation_comment_and_no_tool() -> None:
     """Creation comment must map to CreationInfo.comment and tool is optional."""
     pyproject_content = """
 [build-system]
@@ -228,7 +229,7 @@ version = "0.1.0"
         pyproject_path = tmppath / "pyproject.toml"
         pyproject_path.write_text(pyproject_content)
 
-        sbom_json = generate_sbom(
+        sbom_json = generate_project_sbom(
             tmppath,
             creation_metadata=CreationMetadata(
                 creators=[Creator(name="Test Creator")],
@@ -248,7 +249,7 @@ version = "0.1.0"
         assert not tool_elements
 
 
-def test_generate_sbom_tool_summary_default_and_no_comment() -> None:
+def test_generate_project_sbom_tool_summary_default_and_no_comment() -> None:
     """Default creation_tool gets a Pitloom-versioned summary; no comment by default."""
     pyproject_content = """
 [build-system]
@@ -265,7 +266,7 @@ version = "0.1.0"
         pyproject_path = tmppath / "pyproject.toml"
         pyproject_path.write_text(pyproject_content)
 
-        sbom_json = generate_sbom(tmppath)
+        sbom_json = generate_project_sbom(tmppath)
         sbom_data = json.loads(sbom_json)
         graph = sbom_data["@graph"]
 
@@ -279,7 +280,7 @@ version = "0.1.0"
         assert tool_elements[0]["summary"] == f"Pitloom {__version__}"
 
 
-def test_generate_sbom_tool_summary_omitted_for_custom_tool_name() -> None:
+def test_generate_project_sbom_tool_summary_omitted_for_custom_tool_name() -> None:
     """A user-supplied tool name gets no Pitloom-version summary."""
     pyproject_content = """
 [build-system]
@@ -296,7 +297,7 @@ version = "0.1.0"
         pyproject_path = tmppath / "pyproject.toml"
         pyproject_path.write_text(pyproject_content)
 
-        sbom_json = generate_sbom(
+        sbom_json = generate_project_sbom(
             tmppath,
             creation_metadata=CreationMetadata(tools=[Tool("MyWrapper")]),
         )
@@ -317,7 +318,7 @@ def _creation_agents(graph: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [by_id[ref] for ref in creation_infos[0]["createdBy"]]
 
 
-def test_generate_sbom_default_creator_is_software_agent() -> None:
+def test_generate_project_sbom_default_creator_is_software_agent() -> None:
     """With no named creator, createdBy is the SoftwareAgent "Pitloom", not a
     Person, and the package asserts no suppliedBy."""
     pyproject_content = """
@@ -329,7 +330,7 @@ version = "0.1.0"
         tmppath = Path(tmpdir)
         (tmppath / "pyproject.toml").write_text(pyproject_content)
 
-        graph = json.loads(generate_sbom(tmppath))["@graph"]
+        graph = json.loads(generate_project_sbom(tmppath))["@graph"]
 
         agents = _creation_agents(graph)
         assert [a["type"] for a in agents] == ["SoftwareAgent"]
@@ -340,7 +341,7 @@ version = "0.1.0"
         assert packages and all("suppliedBy" not in p for p in packages)
 
 
-def test_generate_sbom_named_creator_is_person_with_supplied_by() -> None:
+def test_generate_project_sbom_named_creator_is_person_with_supplied_by() -> None:
     """A named creator becomes a Person in createdBy and the main package's
     suppliedBy."""
     pyproject_content = """
@@ -353,7 +354,7 @@ version = "0.1.0"
         (tmppath / "pyproject.toml").write_text(pyproject_content)
 
         graph = json.loads(
-            generate_sbom(
+            generate_project_sbom(
                 tmppath,
                 creation_metadata=CreationMetadata(
                     creators=[Creator(name="Alice", email="alice@example.com")]
@@ -373,7 +374,7 @@ version = "0.1.0"
         assert main_pkg["suppliedBy"] == agents[0]["spdxId"]
 
 
-def test_generate_sbom_organization_creator() -> None:
+def test_generate_project_sbom_organization_creator() -> None:
     """type='organization' makes the named creator an Organization."""
     pyproject_content = """
 [project]
@@ -385,7 +386,7 @@ version = "0.1.0"
         (tmppath / "pyproject.toml").write_text(pyproject_content)
 
         graph = json.loads(
-            generate_sbom(
+            generate_project_sbom(
                 tmppath,
                 creation_metadata=CreationMetadata(
                     creators=[Creator(name="Acme Corp", type="organization")]
@@ -407,7 +408,7 @@ version = "0.1.0"
         ("agent", "Agent"),
     ],
 )
-def test_generate_sbom_all_valid_creator_types(
+def test_generate_project_sbom_all_valid_creator_types(
     creator_type: str, expected_element_type: str
 ) -> None:
     """Every SPDX 3 Agent subclass is a valid createdBy type: Person,
@@ -422,7 +423,7 @@ version = "0.1.0"
         (tmppath / "pyproject.toml").write_text(pyproject_content)
 
         graph = json.loads(
-            generate_sbom(
+            generate_project_sbom(
                 tmppath,
                 creation_metadata=CreationMetadata(
                     creators=[Creator(name="Bot", type=creator_type)]
@@ -435,7 +436,7 @@ version = "0.1.0"
         assert agents[0]["name"] == "Bot"
 
 
-def test_generate_sbom_invalid_creator_type_raises() -> None:
+def test_generate_project_sbom_invalid_creator_type_raises() -> None:
     """An unrecognised creator type raises ValueError naming the valid set,
     rather than silently falling back to Person."""
     pyproject_content = """
@@ -448,7 +449,7 @@ version = "0.1.0"
         (tmppath / "pyproject.toml").write_text(pyproject_content)
 
         with pytest.raises(ValueError, match="Invalid creator type"):
-            generate_sbom(
+            generate_project_sbom(
                 tmppath,
                 creation_metadata=CreationMetadata(
                     creators=[Creator(name="Bot", type="robot")]
@@ -456,7 +457,7 @@ version = "0.1.0"
             )
 
 
-def test_generate_sbom_creation_datetime_normalized_on_export() -> None:
+def test_generate_project_sbom_creation_datetime_normalized_on_export() -> None:
     """Full ISO creation_datetime must be normalised only at SPDX export time."""
     pyproject_content = """
 [build-system]
@@ -473,7 +474,7 @@ version = "0.1.0"
         pyproject_path = tmppath / "pyproject.toml"
         pyproject_path.write_text(pyproject_content)
 
-        sbom_json = generate_sbom(
+        sbom_json = generate_project_sbom(
             tmppath,
             creation_metadata=CreationMetadata(
                 creators=[Creator(name="Test Creator")],
@@ -488,7 +489,7 @@ version = "0.1.0"
         assert creation_infos[0]["created"] == "2026-01-01T10:04:56Z"
 
 
-def test_generate_sbom_multiple_creators_and_supplied_by_first() -> None:
+def test_generate_project_sbom_multiple_creators_and_supplied_by_first() -> None:
     """Multiple creators each become their own Agent in createdBy, of the
     correct subclass; suppliedBy on the main package is the *first* named
     creator."""
@@ -502,7 +503,7 @@ version = "0.1.0"
         (tmppath / "pyproject.toml").write_text(pyproject_content)
 
         graph = json.loads(
-            generate_sbom(
+            generate_project_sbom(
                 tmppath,
                 creation_metadata=CreationMetadata(
                     creators=[
@@ -526,7 +527,7 @@ version = "0.1.0"
         assert main_pkg["suppliedBy"] == agents[0]["spdxId"]
 
 
-def test_generate_sbom_multiple_creators_same_type_distinct_agents() -> None:
+def test_generate_project_sbom_multiple_creators_same_type_distinct_agents() -> None:
     """Two creators of the *same* type each become their own Agent, with
     distinct spdxIds, and both are present in createdBy -- same-type
     creators must not collapse into a single Agent."""
@@ -540,7 +541,7 @@ version = "0.1.0"
         (tmppath / "pyproject.toml").write_text(pyproject_content)
 
         graph = json.loads(
-            generate_sbom(
+            generate_project_sbom(
                 tmppath,
                 creation_metadata=CreationMetadata(
                     creators=[
@@ -564,7 +565,7 @@ version = "0.1.0"
         }
 
 
-def test_generate_sbom_multiple_tools() -> None:
+def test_generate_project_sbom_multiple_tools() -> None:
     """Multiple tools each become their own Tool in createdUsing."""
     pyproject_content = """
 [project]
@@ -575,7 +576,7 @@ version = "0.1.0"
         tmppath = Path(tmpdir)
         (tmppath / "pyproject.toml").write_text(pyproject_content)
 
-        sbom_json = generate_sbom(
+        sbom_json = generate_project_sbom(
             tmppath,
             creation_metadata=CreationMetadata(
                 tools=[Tool("Pitloom"), Tool("MyWrapper")]
@@ -593,7 +594,7 @@ version = "0.1.0"
         assert "summary" not in tools[1]
 
 
-def test_generate_sbom_sentimentdemo_structure() -> None:
+def test_generate_project_sbom_sentimentdemo_structure() -> None:
     """Test SBOM generation with sentimentdemo-like structure."""
     pyproject_content = """
 [build-system]
@@ -632,7 +633,7 @@ Source = "https://github.com/bact/sentimentdemo"
         about_path = src_dir / "__about__.py"
         about_path.write_text(about_content)
 
-        sbom_json = generate_sbom(tmppath)
+        sbom_json = generate_project_sbom(tmppath)
         sbom_data = json.loads(sbom_json)
 
         # Verify structure
@@ -654,7 +655,7 @@ Source = "https://github.com/bact/sentimentdemo"
         assert len(relationships) >= 3  # At least 3 dependencies
 
 
-def test_generate_sbom_with_fragments() -> None:
+def test_generate_project_sbom_with_fragments() -> None:
     """Test SBOM generation with external generic SBOM fragments."""
     pyproject_content = """
 [build-system]
@@ -718,7 +719,7 @@ files = ["fragment1.json", "fragment2.json"]
         exporter2.add_package(dataset_pkg)
         (tmppath / "fragment2.json").write_text(exporter2.to_json())
 
-        sbom_json = generate_sbom(tmppath)
+        sbom_json = generate_project_sbom(tmppath)
         sbom_data = json.loads(sbom_json)
 
         # Validate that elements from fragments are included in the graph
@@ -737,11 +738,11 @@ files = ["fragment1.json", "fragment2.json"]
         assert dataset_packages[0]["name"] == "cool-dataset"
 
 
-def test_generate_sbom_setup_cfg_only_project() -> None:
-    """generate_sbom() must support projects with no pyproject.toml at all,
+def test_generate_project_sbom_setup_cfg_only_project() -> None:
+    """generate_project_sbom() must support projects with no pyproject.toml at all,
     falling back to setup.cfg via the shared read_project() helper.
 
-    Regression test: generate_sbom() previously hardcoded a pyproject.toml
+    Regression test: generate_project_sbom() previously hardcoded a pyproject.toml
     read with no setup.cfg/setup.py fallback, so a setup.cfg-only project
     raised FileNotFoundError.
     """
@@ -751,7 +752,7 @@ def test_generate_sbom_setup_cfg_only_project() -> None:
             "[metadata]\nname = setup-cfg-only-package\nversion = 1.2.3\n"
         )
 
-        sbom_json = generate_sbom(tmppath)
+        sbom_json = generate_project_sbom(tmppath)
         graph = json.loads(sbom_json)["@graph"]
 
         packages = [e for e in graph if e.get("type") == "software_Package"]
@@ -761,17 +762,17 @@ def test_generate_sbom_setup_cfg_only_project() -> None:
         assert main_package["software_packageVersion"] == "1.2.3"
 
 
-def test_generate_sbom_uses_preparsed_metadata_without_reparsing() -> None:
-    """When metadata/pitloom_config are given, generate_sbom() must not
+def test_generate_project_sbom_uses_preparsed_metadata_without_reparsing() -> None:
+    """When metadata/pitloom_config are given, generate_project_sbom() must not
     re-parse project_dir via read_project()."""
     with tempfile.TemporaryDirectory() as tmpdir:
         tmppath = Path(tmpdir)
         # No pyproject.toml, setup.cfg, or setup.py -- read_project() would
-        # raise FileNotFoundError if generate_sbom() called it.
+        # raise FileNotFoundError if generate_project_sbom() called it.
         metadata = ProjectMetadata(name="preparsed-package", version="9.9.9")
         pitloom_config = PitloomConfig()
 
-        sbom_json = generate_sbom(
+        sbom_json = generate_project_sbom(
             tmppath, project_metadata=metadata, pitloom_config=pitloom_config
         )
         graph = json.loads(sbom_json)["@graph"]
@@ -781,7 +782,7 @@ def test_generate_sbom_uses_preparsed_metadata_without_reparsing() -> None:
         assert main_package["software_packageVersion"] == "9.9.9"
 
 
-def test_generate_sbom_partial_preparsed_args_reparses_both() -> None:
+def test_generate_project_sbom_partial_preparsed_args_reparses_both() -> None:
     """project_metadata and pitloom_config must be given together.
 
     Passing only one is treated as if neither were given: both are read
@@ -793,7 +794,7 @@ def test_generate_sbom_partial_preparsed_args_reparses_both() -> None:
         )
         fake_metadata = ProjectMetadata(name="should-be-discarded")
 
-        sbom_json = generate_sbom(
+        sbom_json = generate_project_sbom(
             tmppath, project_metadata=fake_metadata, pitloom_config=None
         )
         graph = json.loads(sbom_json)["@graph"]
@@ -1566,15 +1567,15 @@ def _make_wheel(tmp_path: Path, name: str, version: str) -> Path:
     return wheel_path
 
 
-def test_generate_analyzed_sbom_from_wheel(
+def test_generate_wheel_sbom_from_wheel(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """generate_analyzed_sbom() wires read_wheel()'s extracted metadata into
+    """generate_wheel_sbom() wires read_wheel()'s extracted metadata into
     a valid SPDX 3 JSON-LD document with the expected package name/version."""
     monkeypatch.chdir(tmp_path)
     wheel_path = _make_wheel(tmp_path, "analyzed-pkg", "2.3.4")
 
-    sbom_json = generate_analyzed_sbom(wheel_path)
+    sbom_json = generate_wheel_sbom(wheel_path)
     data = json.loads(sbom_json)
 
     assert "@graph" in data
@@ -1584,10 +1585,10 @@ def test_generate_analyzed_sbom_from_wheel(
     assert main_package["software_packageVersion"] == "2.3.4"
 
 
-def test_generate_deployed_sbom_mocked_pipdeptree(
+def test_generate_env_sbom_mocked_pipdeptree(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """generate_deployed_sbom() wires read_environment()'s pipdeptree tree
+    """generate_env_sbom() wires read_environment()'s pipdeptree tree
     into a valid SPDX 3 JSON-LD document containing the installed package."""
     monkeypatch.chdir(tmp_path)
     tree = [
@@ -1607,7 +1608,7 @@ def test_generate_deployed_sbom_mocked_pipdeptree(
     )
 
     with patch("subprocess.run", return_value=fake_result):
-        sbom_json = generate_deployed_sbom()
+        sbom_json = generate_env_sbom()
 
     data = json.loads(sbom_json)
 
@@ -1616,6 +1617,24 @@ def test_generate_deployed_sbom_mocked_pipdeptree(
     packages = [e for e in graph if e.get("type") == "software_Package"]
     requests_pkg = next(p for p in packages if p["name"] == "requests")
     assert requests_pkg["software_packageVersion"] == "2.31.0"
+
+
+def test_generate_smart_entrypoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """generate() smart entrypoint auto-detects targets correctly."""
+    monkeypatch.chdir(tmp_path)
+    pyproject = '[project]\nname = "smart-pkg"\nversion = "0.1.0"\n'
+    (tmp_path / "pyproject.toml").write_text(pyproject)
+
+    # 1. Directory target
+    proj_json = generate(tmp_path)
+    assert "smart-pkg" in proj_json
+
+    # 2. Wheel target
+    wheel_path = _make_wheel(tmp_path, "smart-wheel", "1.0.0")
+    wheel_json = generate(wheel_path)
+    assert "smart-wheel" in wheel_json
 
 
 def test_build_model_base_model_lineage() -> None:

--- a/tests/test_jcs.py
+++ b/tests/test_jcs.py
@@ -26,7 +26,7 @@ from typing import Any
 
 import rfc8785
 
-from pitloom.assemble import generate_sbom
+from pitloom.assemble import generate_project_sbom
 from pitloom.core.creation import CreationMetadata
 
 # Fixed creation timestamp so every test call with the same pyproject produces
@@ -44,11 +44,11 @@ dependencies = ["requests>=2.28.0"]
 
 
 def _sbom_compact(tmppath: Path) -> str:
-    return generate_sbom(tmppath, creation_metadata=_FIXED_CI)
+    return generate_project_sbom(tmppath, creation_metadata=_FIXED_CI)
 
 
 def _sbom_pretty(tmppath: Path) -> str:
-    return generate_sbom(tmppath, creation_metadata=_FIXED_CI, pretty=True)
+    return generate_project_sbom(tmppath, creation_metadata=_FIXED_CI, pretty=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -1156,7 +1156,7 @@ def test_hf_url_with_tree_path_resolves_correctly(
 
 
 # ---------------------------------------------------------------------------
-# `loom analyze <wheel>` / `loom deployed` / `loom ids` dispatch
+# `loom wheel` / `loom env` / `loom ids` dispatch
 # ---------------------------------------------------------------------------
 
 
@@ -1172,7 +1172,7 @@ def _make_wheel(tmp_path: Path, name: str, version: str) -> Path:
 def test_analyze_wheel_dispatches_to_wheel_path(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """`loom analyze foo.whl` must dispatch to generate_analyzed_sbom(),
+    """`loom wheel foo.whl` must dispatch to generate_wheel_sbom(),
     not the AI-model or Hugging Face paths."""
     monkeypatch.chdir(tmp_path)
     wheel_path = _make_wheel(tmp_path, "pkg", "1.0.0")
@@ -1201,7 +1201,7 @@ def test_analyze_wheel_dispatches_to_wheel_path(
 def test_deployed_dispatches_to_generate_env_sbom(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """`loom deployed` must dispatch to generate_env_sbom()."""
+    """`loom env` must dispatch to generate_env_sbom()."""
     monkeypatch.chdir(tmp_path)
     captured: dict[str, object] = {}
 
@@ -1245,7 +1245,7 @@ def test_ids_import_cli_end_to_end(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """`loom ids import` smoke test through main(): harvests ids from a real
-    SBOM produced by `loom source`."""
+    SBOM produced by `loom project`."""
     pyproject_content = """\
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -49,7 +49,7 @@ pretty = true
     output_path = project_dir / "out.spdx3.json"
     captured: dict[str, object] = {}
 
-    def _fake_generate_sbom(
+    def _fake_generate_project_sbom(
         project_dir: Path,
         output_path: Path | None = None,
         creation_metadata: object | None = None,
@@ -68,11 +68,11 @@ pretty = true
         captured["describe_relationship"] = describe_relationship
         return "{}"
 
-    monkeypatch.setattr(__main__, "generate_sbom", _fake_generate_sbom)
+    monkeypatch.setattr(__main__, "generate_project_sbom", _fake_generate_project_sbom)
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "source", str(project_dir), "-o", str(output_path)],
+        ["loom", "project", str(project_dir), "-o", str(output_path)],
     )
 
     exit_code = __main__.main()
@@ -104,7 +104,7 @@ creation-datetime = "2026-04-01T00:00:00Z"
 
     captured: dict[str, object] = {}
 
-    def _fake_generate_sbom(
+    def _fake_generate_project_sbom(
         project_dir: Path,
         output_path: Path | None = None,
         creation_metadata: object | None = None,
@@ -126,8 +126,8 @@ creation-datetime = "2026-04-01T00:00:00Z"
         captured["creation_metadata"] = creation_metadata
         return "{}"
 
-    monkeypatch.setattr(__main__, "generate_sbom", _fake_generate_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "source", str(project_dir)])
+    monkeypatch.setattr(__main__, "generate_project_sbom", _fake_generate_project_sbom)
+    monkeypatch.setattr(sys, "argv", ["loom", "project", str(project_dir)])
 
     exit_code = __main__.main()
 
@@ -176,7 +176,7 @@ creation-datetime = "2030-01-02T03:04:05Z"
 
     captured: dict[str, object] = {}
 
-    def _fake_generate_sbom(
+    def _fake_generate_project_sbom(
         project_dir: Path,
         output_path: Path | None = None,
         creation_metadata: object | None = None,
@@ -199,8 +199,8 @@ creation-datetime = "2030-01-02T03:04:05Z"
         return "{}"
 
     monkeypatch.chdir(current_dir)
-    monkeypatch.setattr(__main__, "generate_sbom", _fake_generate_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "source", str(target_dir)])
+    monkeypatch.setattr(__main__, "generate_project_sbom", _fake_generate_project_sbom)
+    monkeypatch.setattr(sys, "argv", ["loom", "project", str(target_dir)])
 
     exit_code = __main__.main()
 
@@ -242,7 +242,7 @@ version = "0.1.0"
         encoding="utf-8",
     )
 
-    def _fake_generate_sbom(
+    def _fake_generate_project_sbom(
         project_dir: Path,
         output_path: Path | None = None,
         creation_metadata: object | None = None,
@@ -265,8 +265,8 @@ version = "0.1.0"
         return "{}"
 
     monkeypatch.chdir(current_dir)
-    monkeypatch.setattr(__main__, "generate_sbom", _fake_generate_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "source", str(target_dir), "-v"])
+    monkeypatch.setattr(__main__, "generate_project_sbom", _fake_generate_project_sbom)
+    monkeypatch.setattr(sys, "argv", ["loom", "project", str(target_dir), "-v"])
 
     exit_code = __main__.main()
     captured = capsys.readouterr()
@@ -307,13 +307,13 @@ creator-name = 123
         encoding="utf-8",
     )
 
-    def _fake_generate_sbom(*args: object, **kwargs: object) -> str:
+    def _fake_generate_project_sbom(*args: object, **kwargs: object) -> str:
         raise AssertionError(
-            "generate_sbom must not run when [tool.pitloom] config is malformed"
+            "generate_project_sbom must not run when [tool.pitloom] config is malformed"
         )
 
-    monkeypatch.setattr(__main__, "generate_sbom", _fake_generate_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "source", str(project_dir)])
+    monkeypatch.setattr(__main__, "generate_project_sbom", _fake_generate_project_sbom)
+    monkeypatch.setattr(sys, "argv", ["loom", "project", str(project_dir)])
 
     exit_code = __main__.main()
     captured = capsys.readouterr()
@@ -341,15 +341,16 @@ def test_model_mode_no_project_dir_required(
         pretty: bool = False,
         describe_relationship: bool = False,
         registry: object | None = None,
+        **kwargs: object,
     ) -> str:
-        _ = registry
+        _ = (registry, kwargs)
         _ = (creation_metadata, pretty, describe_relationship)
         captured["model_path"] = model_path
         captured["output_path"] = output_path
         return "{}"
 
-    monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "analyze", str(SAFETENSORS_FIXTURE)])
+    monkeypatch.setattr(__main__, "generate_model_sbom", _fake_generate_model_sbom)
+    monkeypatch.setattr(sys, "argv", ["loom", "model", str(SAFETENSORS_FIXTURE)])
 
     assert __main__.main() == 0
     assert captured["model_path"] == SAFETENSORS_FIXTURE.resolve()
@@ -369,15 +370,16 @@ def test_model_mode_explicit_output_path(
         pretty: bool = False,
         describe_relationship: bool = False,
         registry: object | None = None,
+        **kwargs: object,
     ) -> str:
-        _ = registry
+        _ = (registry, kwargs)
         _ = (model_path, creation_metadata, pretty, describe_relationship)
         captured["output_path"] = output_path
         return "{}"
 
-    monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
+    monkeypatch.setattr(__main__, "generate_model_sbom", _fake_generate_model_sbom)
     monkeypatch.setattr(
-        sys, "argv", ["loom", "analyze", str(ONNX_FIXTURE), "-o", str(explicit_out)]
+        sys, "argv", ["loom", "model", str(ONNX_FIXTURE), "-o", str(explicit_out)]
     )
 
     assert __main__.main() == 0
@@ -396,14 +398,15 @@ def test_model_mode_default_output_path_uses_stem(
         pretty: bool = False,
         describe_relationship: bool = False,
         registry: object | None = None,
+        **kwargs: object,
     ) -> str:
-        _ = registry
+        _ = (registry, kwargs)
         _ = (model_path, creation_metadata, pretty, describe_relationship)
         captured["output_path"] = output_path
         return "{}"
 
-    monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "analyze", str(SAFETENSORS_FIXTURE)])
+    monkeypatch.setattr(__main__, "generate_model_sbom", _fake_generate_model_sbom)
+    monkeypatch.setattr(sys, "argv", ["loom", "model", str(SAFETENSORS_FIXTURE)])
 
     assert __main__.main() == 0
     out = captured["output_path"]
@@ -424,14 +427,15 @@ def test_model_mode_passes_pretty_flag(
         pretty: bool = False,
         describe_relationship: bool = False,
         registry: object | None = None,
+        **kwargs: object,
     ) -> str:
-        _ = registry
+        _ = (registry, kwargs)
         _ = (model_path, output_path, creation_metadata, describe_relationship)
         captured["pretty"] = pretty
         return "{}"
 
-    monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "analyze", str(ONNX_FIXTURE), "--pretty"])
+    monkeypatch.setattr(__main__, "generate_model_sbom", _fake_generate_model_sbom)
+    monkeypatch.setattr(sys, "argv", ["loom", "model", str(ONNX_FIXTURE), "--pretty"])
 
     assert __main__.main() == 0
     assert captured["pretty"] is True
@@ -449,17 +453,18 @@ def test_model_mode_passes_creation_info(
         pretty: bool = False,
         describe_relationship: bool = False,
         registry: object | None = None,
+        **kwargs: object,
     ) -> str:
-        _ = registry
+        _ = (registry, kwargs)
         _ = (model_path, output_path, pretty, describe_relationship)
         captured["creation_metadata"] = creation_metadata
         return "{}"
 
-    monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
+    monkeypatch.setattr(__main__, "generate_model_sbom", _fake_generate_model_sbom)
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "analyze", str(SAFETENSORS_FIXTURE), "--creator-name", "TestBot"],
+        ["loom", "model", str(SAFETENSORS_FIXTURE), "--creator-name", "TestBot"],
     )
 
     assert __main__.main() == 0
@@ -473,7 +478,7 @@ def test_model_mode_nonexistent_file_returns_error(
     tmp_path: Path,
 ) -> None:
     monkeypatch.setattr(
-        sys, "argv", ["loom", "analyze", str(tmp_path / "no-such-model.safetensors")]
+        sys, "argv", ["loom", "model", str(tmp_path / "no-such-model.safetensors")]
     )
     assert __main__.main() == 1
 
@@ -490,7 +495,7 @@ def test_project_mode_default_creation_comment(
     )
     out = tmp_path / "cli-app.spdx3.json"
     monkeypatch.setattr(
-        sys, "argv", ["loom", "source", str(project_dir), "-o", str(out)]
+        sys, "argv", ["loom", "project", str(project_dir), "-o", str(out)]
     )
 
     assert __main__.main() == 0
@@ -517,7 +522,7 @@ def test_project_mode_creator_type_organization(
         "argv",
         [
             "loom",
-            "source",
+            "project",
             str(project_dir),
             "-o",
             str(out),
@@ -561,7 +566,7 @@ def test_project_mode_creator_type_software_agent_and_agent(
         "argv",
         [
             "loom",
-            "source",
+            "project",
             str(project_dir),
             "-o",
             str(out),
@@ -597,7 +602,7 @@ def test_project_mode_multiple_interleaved_creators(
         "argv",
         [
             "loom",
-            "source",
+            "project",
             str(project_dir),
             "-o",
             str(out),
@@ -643,7 +648,7 @@ def test_project_mode_three_creators_type_and_email_bind_to_most_recent(
         "argv",
         [
             "loom",
-            "source",
+            "project",
             str(project_dir),
             "-o",
             str(out),
@@ -691,7 +696,7 @@ def test_creator_type_invalid_choice_rejected_by_argparse(
         "argv",
         [
             "loom",
-            "source",
+            "project",
             ".",
             "--creator-name",
             "Bot",
@@ -710,7 +715,7 @@ def test_creator_type_before_creator_name_errors(
 ) -> None:
     """--creator-type before any --creator-name is a clear argparse error."""
     monkeypatch.setattr(
-        sys, "argv", ["loom", "source", ".", "--creator-type", "organization"]
+        sys, "argv", ["loom", "project", ".", "--creator-type", "organization"]
     )
     with pytest.raises(SystemExit):
         __main__.main()
@@ -723,7 +728,7 @@ def test_creator_email_before_creator_name_errors(
 ) -> None:
     """--creator-email before any --creator-name is a clear argparse error."""
     monkeypatch.setattr(
-        sys, "argv", ["loom", "source", ".", "--creator-email", "a@example.com"]
+        sys, "argv", ["loom", "project", ".", "--creator-email", "a@example.com"]
     )
     with pytest.raises(SystemExit):
         __main__.main()
@@ -747,7 +752,7 @@ def test_project_mode_repeated_creation_tool(
         "argv",
         [
             "loom",
-            "source",
+            "project",
             str(project_dir),
             "-o",
             str(out),
@@ -787,13 +792,14 @@ def test_model_mode_verbose_shows_model_path(
         pretty: bool = False,
         describe_relationship: bool = False,
         registry: object | None = None,
+        **kwargs: object,
     ) -> str:
-        _ = registry
+        _ = (registry, kwargs)
         _ = (model_path, output_path, creation_metadata, pretty, describe_relationship)
         return "{}"
 
-    monkeypatch.setattr(__main__, "generate_ai_model_sbom", _fake_generate_model_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "analyze", str(ONNX_FIXTURE), "-v"])
+    monkeypatch.setattr(__main__, "generate_model_sbom", _fake_generate_model_sbom)
+    monkeypatch.setattr(sys, "argv", ["loom", "model", str(ONNX_FIXTURE), "-v"])
 
     assert __main__.main() == 0
     out = capsys.readouterr().out
@@ -814,7 +820,7 @@ def test_model_mode_safetensors_produces_ai_package(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "analyze", str(SAFETENSORS_FIXTURE), "-o", str(out)],
+        ["loom", "model", str(SAFETENSORS_FIXTURE), "-o", str(out)],
     )
 
     assert __main__.main() == 0
@@ -834,7 +840,7 @@ def test_model_mode_onnx_produces_ai_package(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "analyze", str(ONNX_FIXTURE), "-o", str(out)],
+        ["loom", "model", str(ONNX_FIXTURE), "-o", str(out)],
     )
 
     assert __main__.main() == 0
@@ -854,7 +860,7 @@ def test_model_mode_safetensors_no_software_package(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "analyze", str(SAFETENSORS_FIXTURE), "-o", str(out)],
+        ["loom", "model", str(SAFETENSORS_FIXTURE), "-o", str(out)],
     )
 
     assert __main__.main() == 0
@@ -873,7 +879,7 @@ def test_model_mode_onnx_sbom_root_is_ai_package(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "analyze", str(ONNX_FIXTURE), "-o", str(out)],
+        ["loom", "model", str(ONNX_FIXTURE), "-o", str(out)],
     )
 
     assert __main__.main() == 0
@@ -903,16 +909,17 @@ def test_hf_url_routes_to_huggingface_sbom(
         creation_metadata: object = None,
         pretty: bool = False,
         describe_relationship: bool = False,
+        **kwargs: object,
     ) -> str:
-        _ = (output_path, creation_metadata, pretty, describe_relationship)
+        _ = (output_path, creation_metadata, pretty, describe_relationship, kwargs)
         captured["model_source"] = model_source
         return "{}"
 
-    monkeypatch.setattr(__main__, "generate_huggingface_sbom", _fake_generate_hf_sbom)
+    monkeypatch.setattr(__main__, "generate_model_sbom", _fake_generate_hf_sbom)
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "analyze", "https://huggingface.co/mistralai/Mistral-7B-v0.1"],
+        ["loom", "model", "https://huggingface.co/mistralai/Mistral-7B-v0.1"],
     )
 
     assert __main__.main() == 0
@@ -930,13 +937,14 @@ def test_hf_model_id_routes_to_huggingface_sbom(
         creation_metadata: object = None,
         pretty: bool = False,
         describe_relationship: bool = False,
+        **kwargs: object,
     ) -> str:
-        _ = (output_path, creation_metadata, pretty, describe_relationship)
+        _ = (output_path, creation_metadata, pretty, describe_relationship, kwargs)
         captured["model_source"] = model_source
         return "{}"
 
-    monkeypatch.setattr(__main__, "generate_huggingface_sbom", _fake_generate_hf_sbom)
-    monkeypatch.setattr(sys, "argv", ["loom", "analyze", "Qwen/Qwen3-235B-A22B"])
+    monkeypatch.setattr(__main__, "generate_model_sbom", _fake_generate_hf_sbom)
+    monkeypatch.setattr(sys, "argv", ["loom", "model", "Qwen/Qwen3-235B-A22B"])
 
     assert __main__.main() == 0
     assert captured["model_source"] == "Qwen/Qwen3-235B-A22B"
@@ -953,16 +961,17 @@ def test_hf_mode_default_output_uses_model_name(
         creation_metadata: object = None,
         pretty: bool = False,
         describe_relationship: bool = False,
+        **kwargs: object,
     ) -> str:
-        _ = (model_source, creation_metadata, pretty, describe_relationship)
+        _ = (model_source, creation_metadata, pretty, describe_relationship, kwargs)
         captured["output_path"] = output_path
         return "{}"
 
-    monkeypatch.setattr(__main__, "generate_huggingface_sbom", _fake_generate_hf_sbom)
+    monkeypatch.setattr(__main__, "generate_model_sbom", _fake_generate_hf_sbom)
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "analyze", "https://huggingface.co/mistralai/Mistral-7B-v0.1"],
+        ["loom", "model", "https://huggingface.co/mistralai/Mistral-7B-v0.1"],
     )
 
     assert __main__.main() == 0
@@ -985,18 +994,19 @@ def test_hf_mode_explicit_output_path(
         creation_metadata: object = None,
         pretty: bool = False,
         describe_relationship: bool = False,
+        **kwargs: object,
     ) -> str:
-        _ = (model_source, creation_metadata, pretty, describe_relationship)
+        _ = (model_source, creation_metadata, pretty, describe_relationship, kwargs)
         captured["output_path"] = output_path
         return "{}"
 
-    monkeypatch.setattr(__main__, "generate_huggingface_sbom", _fake_generate_hf_sbom)
+    monkeypatch.setattr(__main__, "generate_model_sbom", _fake_generate_hf_sbom)
     monkeypatch.setattr(
         sys,
         "argv",
         [
             "loom",
-            "analyze",
+            "model",
             "mistralai/Mistral-7B-v0.1",
             "-o",
             str(explicit_out),
@@ -1018,18 +1028,19 @@ def test_hf_mode_passes_creation_info(
         creation_metadata: object = None,
         pretty: bool = False,
         describe_relationship: bool = False,
+        **kwargs: object,
     ) -> str:
-        _ = (model_source, output_path, pretty, describe_relationship)
+        _ = (model_source, output_path, pretty, describe_relationship, kwargs)
         captured["creation_metadata"] = creation_metadata
         return "{}"
 
-    monkeypatch.setattr(__main__, "generate_huggingface_sbom", _fake_generate_hf_sbom)
+    monkeypatch.setattr(__main__, "generate_model_sbom", _fake_generate_hf_sbom)
     monkeypatch.setattr(
         sys,
         "argv",
         [
             "loom",
-            "analyze",
+            "model",
             "Qwen/Qwen3-235B-A22B",
             "--creator-name",
             "Researcher",
@@ -1053,16 +1064,23 @@ def test_hf_mode_passes_pretty_flag(
         creation_metadata: object = None,
         pretty: bool = False,
         describe_relationship: bool = False,
+        **kwargs: object,
     ) -> str:
-        _ = (model_source, output_path, creation_metadata, describe_relationship)
+        _ = (
+            model_source,
+            output_path,
+            creation_metadata,
+            describe_relationship,
+            kwargs,
+        )
         captured["pretty"] = pretty
         return "{}"
 
-    monkeypatch.setattr(__main__, "generate_huggingface_sbom", _fake_generate_hf_sbom)
+    monkeypatch.setattr(__main__, "generate_model_sbom", _fake_generate_hf_sbom)
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "analyze", "mistralai/Mistral-7B-v0.1", "--pretty"],
+        ["loom", "model", "mistralai/Mistral-7B-v0.1", "--pretty"],
     )
 
     assert __main__.main() == 0
@@ -1079,6 +1097,7 @@ def test_hf_mode_verbose_shows_model_id(
         creation_metadata: object = None,
         pretty: bool = False,
         describe_relationship: bool = False,
+        **kwargs: object,
     ) -> str:
         _ = (
             model_source,
@@ -1086,14 +1105,15 @@ def test_hf_mode_verbose_shows_model_id(
             creation_metadata,
             pretty,
             describe_relationship,
+            kwargs,
         )
         return "{}"
 
-    monkeypatch.setattr(__main__, "generate_huggingface_sbom", _fake_generate_hf_sbom)
+    monkeypatch.setattr(__main__, "generate_model_sbom", _fake_generate_hf_sbom)
     monkeypatch.setattr(
         sys,
         "argv",
-        ["loom", "analyze", "https://huggingface.co/Qwen/Qwen3-235B-A22B", "-v"],
+        ["loom", "model", "https://huggingface.co/Qwen/Qwen3-235B-A22B", "-v"],
     )
 
     assert __main__.main() == 0
@@ -1113,18 +1133,19 @@ def test_hf_url_with_tree_path_resolves_correctly(
         creation_metadata: object = None,
         pretty: bool = False,
         describe_relationship: bool = False,
+        **kwargs: object,
     ) -> str:
-        _ = (output_path, creation_metadata, pretty, describe_relationship)
+        _ = (output_path, creation_metadata, pretty, describe_relationship, kwargs)
         captured["model_source"] = model_source
         return "{}"
 
-    monkeypatch.setattr(__main__, "generate_huggingface_sbom", _fake_generate_hf_sbom)
+    monkeypatch.setattr(__main__, "generate_model_sbom", _fake_generate_hf_sbom)
     monkeypatch.setattr(
         sys,
         "argv",
         [
             "loom",
-            "analyze",
+            "model",
             "https://huggingface.co/mistralai/Mistral-7B-v0.1/tree/main",
         ],
     )
@@ -1170,23 +1191,21 @@ def test_analyze_wheel_dispatches_to_wheel_path(
         captured["output_path"] = output_path
         return "{}"
 
-    monkeypatch.setattr(
-        __main__, "generate_analyzed_sbom", _fake_generate_analyzed_sbom
-    )
-    monkeypatch.setattr(sys, "argv", ["loom", "analyze", str(wheel_path)])
+    monkeypatch.setattr(__main__, "generate_wheel_sbom", _fake_generate_analyzed_sbom)
+    monkeypatch.setattr(sys, "argv", ["loom", "wheel", str(wheel_path)])
 
     assert __main__.main() == 0
     assert captured["wheel_path"] == wheel_path.resolve()
 
 
-def test_deployed_dispatches_to_generate_deployed_sbom(
+def test_deployed_dispatches_to_generate_env_sbom(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """`loom deployed` must dispatch to generate_deployed_sbom()."""
+    """`loom deployed` must dispatch to generate_env_sbom()."""
     monkeypatch.chdir(tmp_path)
     captured: dict[str, object] = {}
 
-    def _fake_generate_deployed_sbom(
+    def _fake_generate_env_sbom(
         output_path: object = None,
         creation_metadata: object = None,
         pretty: bool = False,
@@ -1197,10 +1216,8 @@ def test_deployed_dispatches_to_generate_deployed_sbom(
         captured["output_path"] = output_path
         return "{}"
 
-    monkeypatch.setattr(
-        __main__, "generate_deployed_sbom", _fake_generate_deployed_sbom
-    )
-    monkeypatch.setattr(sys, "argv", ["loom", "deployed"])
+    monkeypatch.setattr(__main__, "generate_env_sbom", _fake_generate_env_sbom)
+    monkeypatch.setattr(sys, "argv", ["loom", "env"])
 
     assert __main__.main() == 0
     assert captured["output_path"] == tmp_path / "deployed-environment.spdx3.json"
@@ -1242,7 +1259,7 @@ version = "1.0.0"
     monkeypatch.chdir(tmp_path)
 
     sbom_path = tmp_path / "importable-pkg-1.0.0.spdx3.json"
-    monkeypatch.setattr(sys, "argv", ["loom", "source", str(tmp_path)])
+    monkeypatch.setattr(sys, "argv", ["loom", "project", str(tmp_path)])
     assert __main__.main() == 0
     assert sbom_path.exists()
 

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -9,7 +9,7 @@ import json
 import tempfile
 from pathlib import Path
 
-from pitloom.assemble import generate_sbom
+from pitloom.assemble import generate_project_sbom
 from pitloom.core.creation import CreationMetadata, Creator
 from pitloom.extract.pyproject import read_pyproject
 
@@ -106,7 +106,7 @@ authors = [{name = "Jane Doe"}]
         pyproject_path = tmppath / "pyproject.toml"
         pyproject_path.write_text(pyproject_content)
 
-        sbom_json = generate_sbom(
+        sbom_json = generate_project_sbom(
             tmppath,
             creation_metadata=CreationMetadata(creators=[Creator(name="Test")]),
         )
@@ -142,7 +142,7 @@ dependencies = ["numpy==1.24.0", "pandas>=1.5.0"]
         pyproject_path = tmppath / "pyproject.toml"
         pyproject_path.write_text(pyproject_content)
 
-        sbom_json = generate_sbom(tmppath)
+        sbom_json = generate_project_sbom(tmppath)
         sbom_data = json.loads(sbom_json)
 
         dep_packages = [
@@ -175,7 +175,7 @@ dependencies = ["requests>=2.28.0"]
         pyproject_path = tmppath / "pyproject.toml"
         pyproject_path.write_text(pyproject_content)
 
-        sbom_json = generate_sbom(tmppath)
+        sbom_json = generate_project_sbom(tmppath)
         graph = json.loads(sbom_json)["@graph"]
 
         relationships = [e for e in graph if e["type"] == "Relationship"]
@@ -232,7 +232,7 @@ authors = [{name = "Jane Doe"}]
         pyproject_path = tmppath / "pyproject.toml"
         pyproject_path.write_text(pyproject_content)
 
-        sbom_json = generate_sbom(tmppath)
+        sbom_json = generate_project_sbom(tmppath)
         sbom_data = json.loads(sbom_json)
         graph = sbom_data["@graph"]
 

--- a/tests/test_spdx3_compliance.py
+++ b/tests/test_spdx3_compliance.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from spdx_python_model.bindings import v3_0_1 as spdx3
 
-from pitloom.assemble import generate_sbom
+from pitloom.assemble import generate_project_sbom
 from pitloom.core.creation import CreationMetadata
 from pitloom.export.spdx3_json import (
     _deduplicate_creation_infos,
@@ -48,7 +48,7 @@ dependencies = ["requests>=2.28.0"]
         pyproject_path.write_text(pyproject_content)
 
         output_path = tmppath / "sbom.spdx3.json"
-        generate_sbom(tmppath, output_path=output_path)
+        generate_project_sbom(tmppath, output_path=output_path)
 
         # Load and validate structure
         sbom_data = json.loads(output_path.read_text())
@@ -132,7 +132,7 @@ description = "Test for required elements"
         pyproject_path.write_text(pyproject_content)
 
         output_path = tmppath / "sbom.spdx3.json"
-        generate_sbom(tmppath, output_path=output_path)
+        generate_project_sbom(tmppath, output_path=output_path)
 
         sbom_data = json.loads(output_path.read_text())
         graph = sbom_data["@graph"]
@@ -169,7 +169,7 @@ version = "1.0.0"
         pyproject_path.write_text(pyproject_content)
 
         output_path = tmppath / "sbom.spdx3.json"
-        generate_sbom(tmppath, output_path=output_path)
+        generate_project_sbom(tmppath, output_path=output_path)
 
         sbom_data = json.loads(output_path.read_text())
         graph = sbom_data["@graph"]
@@ -206,7 +206,7 @@ dependencies = ["numpy==1.24.0"]
         pyproject_path.write_text(pyproject_content)
 
         output_path = tmppath / "sbom.spdx3.json"
-        generate_sbom(tmppath, output_path=output_path)
+        generate_project_sbom(tmppath, output_path=output_path)
 
         sbom_data = json.loads(output_path.read_text())
         graph = sbom_data["@graph"]
@@ -262,7 +262,7 @@ packages = ["src/hash_test_package"]
         (pkg_dir / "__init__.py").write_text("", encoding="utf-8")
 
         output_path = tmppath / "sbom.spdx3.json"
-        generate_sbom(tmppath, output_path=output_path)
+        generate_project_sbom(tmppath, output_path=output_path)
 
         graph = json.loads(output_path.read_text())["@graph"]
         file_elements = [e for e in graph if e.get("type") == "software_File"]
@@ -304,7 +304,7 @@ version = "3.1.4"
         )
 
         output_path = tmppath / "sbom.spdx3.json"
-        generate_sbom(tmppath, output_path=output_path)
+        generate_project_sbom(tmppath, output_path=output_path)
 
         graph = json.loads(output_path.read_text())["@graph"]
         packages = [e for e in graph if e.get("type") == "software_Package"]
@@ -352,7 +352,7 @@ version = "1.0.0"
         tmppath = Path(tmpdir)
         (tmppath / "pyproject.toml").write_text(pyproject_content)
 
-        sbom_json = generate_sbom(tmppath)
+        sbom_json = generate_project_sbom(tmppath)
         graph: list[dict[str, Any]] = json.loads(sbom_json)["@graph"]
 
         id_to_type = _build_spdx_id_type_map(graph)
@@ -390,7 +390,7 @@ version = "1.0.0"
         tmppath = Path(tmpdir)
         (tmppath / "pyproject.toml").write_text(pyproject_content)
 
-        sbom_json = generate_sbom(tmppath)
+        sbom_json = generate_project_sbom(tmppath)
         graph: list[dict[str, Any]] = json.loads(sbom_json)["@graph"]
 
         id_to_type = _build_spdx_id_type_map(graph)
@@ -420,7 +420,7 @@ version = "1.0.0"
         tmppath = Path(tmpdir)
         (tmppath / "pyproject.toml").write_text(pyproject_content)
 
-        sbom_json = generate_sbom(tmppath)
+        sbom_json = generate_project_sbom(tmppath)
         graph: list[dict[str, Any]] = json.loads(sbom_json)["@graph"]
 
         element_types = {e["type"] for e in graph}
@@ -462,8 +462,8 @@ dependencies = ["requests>=2.28.0"]
         tmppath = Path(tmpdir)
         (tmppath / "pyproject.toml").write_text(pyproject_content)
 
-        sbom_json_1 = generate_sbom(tmppath, creation_metadata=fixed_ci)
-        sbom_json_2 = generate_sbom(tmppath, creation_metadata=fixed_ci)
+        sbom_json_1 = generate_project_sbom(tmppath, creation_metadata=fixed_ci)
+        sbom_json_2 = generate_project_sbom(tmppath, creation_metadata=fixed_ci)
 
         # Determinism: two calls with identical inputs must produce identical output
         assert sbom_json_1 == sbom_json_2, (
@@ -642,7 +642,7 @@ dependencies = ["requests>=2.28.0"]
         pyproject_path = tmppath / "pyproject.toml"
         pyproject_path.write_text(pyproject_content)
 
-        sbom_json = generate_sbom(tmppath)
+        sbom_json = generate_project_sbom(tmppath)
         graph = json.loads(sbom_json)["@graph"]
 
         all_ids = {e["spdxId"] for e in graph if isinstance(e.get("spdxId"), str)}
@@ -682,7 +682,7 @@ authors = [{name = "Jane Doe"}]
         pitloom_config = dataclasses.replace(
             pitloom_config, provenance_format="annotation"
         )
-        sbom_json = generate_sbom(
+        sbom_json = generate_project_sbom(
             tmppath,
             project_metadata=project_metadata,
             pitloom_config=pitloom_config,

--- a/working-docs/design/cli-ux.md
+++ b/working-docs/design/cli-ux.md
@@ -72,7 +72,7 @@ loom generate mypkg-1.0.0.tar.gz         # Sdist archive     -> Source SBOM
 loom generate dist/pkg-1.0-py3-none.whl  # Wheel file        -> Analyzed SBOM
 loom generate models/model.gguf          # Model file        -> AI Model SBOM
 loom generate mistralai/Mistral-7B      # HF Model ID       -> Remote AI Model SBOM
-loom generate --env                      # Active venv       -> Deployed SBOM
+loom generate env                      # Active venv       -> Deployed SBOM
 ```
 
 #### 2. Project Source & Sdist: `loom project [PATH]`

--- a/working-docs/design/cli-ux.md
+++ b/working-docs/design/cli-ux.md
@@ -15,7 +15,9 @@ This document details the architectural evolution of Pitloom's CLI subcommands, 
 ## 1. Background & Evolution
 
 ### Initial State (v0.12.0+)
+
 The CLI initially exposed subcommands named directly after CISA SBOM lifecycle stages:
+
 - `loom source [project_dir]` (Source SBOM)
 - `loom analyze <target>` (Analyzed SBOM — handles `.whl`, local model binaries, and Hugging Face URLs)
 - `loom deployed` (Deployed SBOM — active environment)
@@ -65,7 +67,9 @@ The key resolution is to separate the **User Interface (UX)** from the **Emitted
 ### Subcommand Specification
 
 #### 1. Smart Entrypoint: `loom generate [TARGET]`
+
 Auto-detects the target type and dispatches to the corresponding target command:
+
 ```bash
 loom generate .                          # Project directory -> Source SBOM
 loom generate mypkg-1.0.0.tar.gz         # Sdist archive     -> Source SBOM
@@ -76,42 +80,57 @@ loom generate env                      # Active venv       -> Deployed SBOM
 ```
 
 #### 2. Project Source & Sdist: `loom project [PATH]`
+
 Scans unbuilt source directories OR archived source distributions (`.tar.gz` / `.zip` sdists):
+
 ```bash
 loom project .                           # Unpacked project root
 loom project /path/to/project
 loom project dist/mypkg-1.0.0.tar.gz     # Native sdist support (no manual extraction required)
 ```
+
 - **CISA SBOM Type**: `Source` (`software_sbomType = [source]`)
 
 #### 3. Built Wheel: `loom wheel <WHEEL_FILE>`
+
 Inspects built Python `.whl` archives:
+
 ```bash
 loom wheel dist/mypkg-1.0.0-py3-none-any.whl -o sbom.spdx3.json
 ```
+
 - **CISA SBOM Type**: `Analyzed` (`software_sbomType = [analyzed]`)
 
 #### 4. AI Model Asset: `loom model <FILE_OR_URL> [--offline]`
+
 Inspects local model weight files (`.gguf`, `.safetensors`, `.onnx`, `.pt`, etc.) or Hugging Face Hub repositories:
+
 ```bash
 loom model models/sentiment.gguf
 loom model mistralai/Mistral-7B-v0.1
 loom model models/sentiment.gguf --offline    # Guarantees zero network calls in sandboxed runners
 ```
+
 - **CISA SBOM Type**: `Analyzed` (`software_sbomType = [analyzed]`, `ai_AIPackage`)
 
 #### 5. Deployed Environment: `loom env`
+
 Inspects active Python environment (`site-packages` via `pipdeptree`):
+
 ```bash
 loom env -o env.spdx3.json
 ```
+
 - **CISA SBOM Type**: `Deployed` (`software_sbomType = [deployed]`)
 
 #### 6. Fragment Merging: `loom merge <FRAGMENTS_DIR>`
+
 Stitches dynamic `@loom.run` runtime execution fragments into a static parent SBOM:
+
 ```bash
 loom merge .spdx3-fragments/ -o combined.spdx3.json
 ```
+
 - **CISA SBOM Type**: `Runtime` (`software_sbomType = [runtime]`)
 
 ---

--- a/working-docs/design/format-neutral-representation.md
+++ b/working-docs/design/format-neutral-representation.md
@@ -67,7 +67,7 @@ Serializers pick the fields they understand and ignore the rest.
 | **Extractors** | Read data sources; populate metadata objects | `ProjectMetadata`, `AiModelMetadata` |
 | **Core model** | Format-neutral assembled document | `DocumentModel`, `PitloomConfig`, `CreationMetadata` |
 | **Assemblers** | Translate `DocumentModel` -> format-specific objects | `Spdx3JsonExporter`, future exporters |
-| **Orchestrator** | Build `DocumentModel`, call assembler, merge fragments | `generate_sbom()` |
+| **Orchestrator** | Build `DocumentModel`, call assembler, merge fragments | `generate_project_sbom()` / `generate()` |
 
 ## Data classes in ``pitloom.core``
 

--- a/working-docs/design/hatchling-build-hook.md
+++ b/working-docs/design/hatchling-build-hook.md
@@ -118,7 +118,7 @@ The user adds `pitloom` to their build dependencies and enables the hook:
 
 ```toml
 [build-system]
-requires = ["hatchling>=1.28.0", "pitloom>=0.11.0"]
+requires = ["hatchling>=1.28.0", "pitloom>=0.12.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.hooks.pitloom]

--- a/working-docs/design/hatchling-build-hook.md
+++ b/working-docs/design/hatchling-build-hook.md
@@ -81,7 +81,7 @@ The build hook maps this object into Pitloom's format-neutral
 project_dir)` -- **not** via `pitloom.extract.pyproject.read_pyproject()`,
 which re-parses `pyproject.toml` from scratch and cannot see dynamic values
 resolved by Hatchling plugins. `read_pyproject()` remains the metadata source
-for the standalone CLI (`pitloom`/`loom source`), which has no build
+for the standalone CLI (`pitloom`/`loom project`), which has no build
 backend to consult; both paths converge on the same
 `pitloom.assemble.spdx3.document.build()` assembly layer, so the emitted SBOM
 shape is identical either way. `read_pitloom_config()`

--- a/working-docs/design/metadata-sources.md
+++ b/working-docs/design/metadata-sources.md
@@ -212,7 +212,7 @@ Recommended long-term priority order for project metadata resolution is:
 Tiers 3-5 are implemented as a single existence-based priority (not a
 field-level merge across tiers) in
 `pitloom.extract.project.read_project()`, used by both the CLI and
-`generate_sbom()`'s default parsing path. Tiers 1-2 remain future work --
+`generate_project_sbom()`'s default parsing path. Tiers 1-2 remain future work --
 see `working-docs/implementation/setuptools-support.md` for the current
 conflict-resolution behaviour and its known limitations.
 

--- a/working-docs/design/roadmap.md
+++ b/working-docs/design/roadmap.md
@@ -29,7 +29,7 @@ SPDX-License-Identifier: CC0-1.0
     `merge_metadata()`, `detect_build_backend()`
     in `src/pitloom/extract/setuptools.py`
   - Conflict resolution: `pyproject.toml` > `setup.cfg` > `setup.py`
-  - CLI and `generate_sbom()` work without `pyproject.toml`
+  - CLI and `generate_project_sbom()` work without `pyproject.toml`
   - `[tool:pitloom]` config section in `setup.cfg`
 - [x] Poetry support -- initial implementation
   - `read_poetry()`, `extract_poetry_metadata()`

--- a/working-docs/design/sbom-enrichment.md
+++ b/working-docs/design/sbom-enrichment.md
@@ -163,7 +163,7 @@ instructions and a worked fragment example.
    (e.g., `enrich/readme.py`, `enrich/openssf.py`, `enrich/huggingface.py`).
 2. Each enricher accepts an `AiModelMetadata` and updates it in-place, following
    the same in-place mutation pattern used by the model extractors.
-3. The `generate_sbom()` orchestrator reads the `[tool.pitloom.enrich]` config
+3. The `generate_project_sbom()` orchestrator reads the `[tool.pitloom.enrich]` config
    and dispatches to the enabled enrichers after extraction but before assembly.
 4. Provenance is recorded for each enriched field (source, field path)
    using the existing `AiModelMetadata.provenance` dict.

--- a/working-docs/implementation/agent-skill.md
+++ b/working-docs/implementation/agent-skill.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-07-05
-Last-Modified: 2026-07-05
+Last-Modified: 2026-08-08
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -124,10 +124,10 @@ worked fragment example.
 
 ```bash
 # sbom, project mode:
-loom source . -o /tmp/sbom.spdx3.json
+loom project . -o /tmp/sbom.spdx3.json
 
 # sbom, model mode (adjust the path to a real model file):
-loom analyze tests/fixtures/aimodels/onnx/squeezenet1.1-7.onnx -o /tmp/model.spdx3.json
+loom model tests/fixtures/aimodels/onnx/squeezenet1.1-7.onnx -o /tmp/model.spdx3.json
 
 # Both should exit 0 and produce a file containing an "@graph" array.
 ```

--- a/working-docs/implementation/annotation-provenance.md
+++ b/working-docs/implementation/annotation-provenance.md
@@ -568,7 +568,7 @@ opaque to SPARQL except as text (accepted tradeoff, decision §3.2).
   ([`tests/test_spdx3_compliance.py::test_spdx3_provenance_annotations_are_compliant`](../../tests/test_spdx3_compliance.py)).
 - [x] Output is byte-stable across two generations (determinism preserved) —
   verified cross-process with a fixed `creation_datetime`, both for
-  `generate_sbom()` and the `pitloom.loom` SDK path.
+  `generate_project_sbom()` and the `pitloom.loom` SDK path.
 - [x] Existing `test_provenance.py` extraction assertions still pass.
 - [x] A second (stub) encoder can be registered without editing call sites —
   demonstrated by

--- a/working-docs/implementation/claude-code-plugin.md
+++ b/working-docs/implementation/claude-code-plugin.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-07-05
-Last-Modified: 2026-07-05
+Last-Modified: 2026-08-08
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -39,7 +39,7 @@ explicit invocation (`/pitloom:sbom`, `/pitloom:enrich`).
 `- marketplace.json      Self-hosted marketplace entry (source: "./").
 skills/
 |- sbom/                 Generate skill (see agent-skill.md) -- bundled
-|                         as-is; no changes were needed to add the plugin.
+|                         as-is; drives 'loom generate' / 'loom project' / 'loom wheel' / 'loom model'.
 `- enrich/               Enrich skill -- same.
 ```
 

--- a/working-docs/implementation/demo.md
+++ b/working-docs/implementation/demo.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-02-06
-Last-Modified: 2026-07-08
+Last-Modified: 2026-08-08
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -87,7 +87,7 @@ The reference SBOM at
 ### 1. Working CLI tool
 
 ```bash
-loom source /path/to/project -o sbom.spdx3.json
+loom project /path/to/project -o sbom.spdx3.json
 ```
 
 ### 2. Dynamic version extraction
@@ -164,13 +164,13 @@ pip install -e ".[dev]"
 
 ```bash
 # Basic usage
-loom source /path/to/project
+loom project /path/to/project
 
 # With custom output
-loom source /path/to/project -o custom-sbom.spdx3.json
+loom project /path/to/project -o custom-sbom.spdx3.json
 
 # With creator info
-loom source /path/to/project --creator-name "Your Name" --creator-email "your@example.com"
+loom project /path/to/project --creator-name "Your Name" --creator-email "your@example.com"
 ```
 
 ### Run tests

--- a/working-docs/implementation/github-action.md
+++ b/working-docs/implementation/github-action.md
@@ -34,7 +34,7 @@ jobs:
           output: "sbom.spdx3.json"
 ```
 
-This installs Pitloom, runs `loom source . -o sbom.spdx3.json`, and uploads the
+This installs Pitloom, runs `loom project . -o sbom.spdx3.json`, and uploads the
 result as a workflow artefact named `sbom` (all defaults; see below to
 change any of it).
 
@@ -43,7 +43,7 @@ change any of it).
 | Input | Default | Purpose |
 | :--- | :--- | :--- |
 | `project-path` | `.` | Directory to scan. Ignored when `model` is set. |
-| `model` | `""` | Local model file path or Hugging Face URL/ID -- runs analyze mode (`loom analyze ...`) instead of project mode. |
+| `model` | `""` | Local model file path or Hugging Face URL/ID -- runs model mode (`loom model ...`) instead of project mode. |
 | `output` | `sbom.spdx3.json` | SBOM output path. |
 | `extras` | `""` | Comma-separated pip extras, e.g. `aimodel,huggingface`. |
 | `pretty` | `false` | Pretty-print the SBOM JSON. |

--- a/working-docs/implementation/setuptools-support.md
+++ b/working-docs/implementation/setuptools-support.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-03-24
-Last-Modified: 2026-07-09
+Last-Modified: 2026-08-08
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -21,7 +21,7 @@ initial setuptools support added in the `setuptools-support` branch.
 | File | Role |
 | :--- | :--- |
 | `src/pitloom/extract/setuptools.py` | New extraction module |
-| `src/pitloom/extract/project.py` | Shared resolver (`read_project()`) used by both the CLI and `generate_sbom()` |
+| `src/pitloom/extract/project.py` | Shared resolver (`read_project()`) used by both the CLI and `generate_project_sbom()` |
 | `src/pitloom/__main__.py` | CLI updated to accept projects without `pyproject.toml` |
 | `tests/test_setuptools.py` | 53 new unit and integration tests |
 | `tests/fixtures/projects/sampleproject-setuptools/` | Transitional-layout fixture project |
@@ -131,7 +131,7 @@ overriding secondary on key conflicts.
 Multiple metadata sources may coexist in a single project (common during
 migration to pyproject.toml).  Resolution happens in `read_project()` in
 `src/pitloom/extract/project.py`, the single entry point used by both the
-CLI and `generate_sbom()`'s default parsing path:
+CLI and `generate_project_sbom()`'s default parsing path:
 
 1. If `pyproject.toml` exists at all (existence check only -- regardless of
    whether it has a `[project]` section), it is the sole metadata source,

--- a/working-docs/implementation/summary.md
+++ b/working-docs/implementation/summary.md
@@ -56,12 +56,13 @@ SPDX 3.0 compliant SBOMs in JSON-LD format.
    - Graceful component ingestion via `spdx3.JSONLDDeserializer`
 
 4. **SBOM generator** (`src/pitloom/assemble/`)
-   - `generate_sbom()` orchestrates the full pipeline for source code
-     (Source SBOM)
-   - `generate_analyzed_sbom()` orchestrates the pipeline for built wheels
-     (Analyzed SBOM), utilizing `wheel.py` and `binary.py` to identify phantom
-      dependencies
-   - `generate_deployed_sbom()` orchestrates the pipeline for active
+   - `generate_project_sbom()` / `generate()` orchestrates the full pipeline
+     for source code (Source SBOM)
+   - `generate_wheel_sbom()` and `generate_model_sbom()` orchestrate the
+     pipeline for built wheels and AI models
+     (Analyzed SBOM), utilizing `wheel.py`, `ai.py`, and `binary.py`
+     to identify phantom dependencies
+   - `generate_env_sbom()` orchestrates the pipeline for active
      environments (Deployed SBOM), mapping the tree using `env.py`
    - Builds `DocumentModel` from extracted metadata
    - Passes `DocumentModel` to assembly functions
@@ -82,19 +83,24 @@ SPDX 3.0 compliant SBOMs in JSON-LD format.
      `[[tool.pitloom.creator]]` / `[[tool.pitloom.creation-tool]]` /
      `[tool.pitloom.creation]` -- the same settings the CLI uses
 
- 6. **Command-line interface & API redesign** (`src/pitloom/__main__.py`, `src/pitloom/assemble/`)
+6. **Command-line interface & API redesign** (`src/pitloom/__main__.py`,
+  `src/pitloom/assemble/`)
    - User-friendly argparse-based CLI with input-centric subcommands
      (`project`, `wheel`, `model`, `env`, `merge`, `ids`) and a smart
      entrypoint `loom generate [TARGET]`
    - Emitted SBOM data model strictly complies with CISA 6 SBOM Types
      (Source, Build, Analyzed, Deployed, Runtime per CISA April 2023 guide)
      and SPDX 3.0.1
-   - `loom project` scans unbuilt source directories or `.tar.gz`/`.zip` sdist archives (Source SBOM)
+   - `loom project` scans unbuilt source directories or `.tar.gz`/`.zip` sdist
+     archives (Source SBOM)
    - `loom wheel` scans built `.whl` archives (Analyzed SBOM)
-   - `loom model` scans local model files or Hugging Face repositories with explicit `--offline` support (Analyzed AIBOM)
+   - `loom model` scans local model files or Hugging Face repositories with
+     explicit `--offline` support (Analyzed AIBOM)
    - `loom env` scans the active installed environment (Deployed SBOM)
    - `loom merge` stitches dynamic execution fragments (Runtime SBOM)
-   - Python API harmonized 1:1 (`pitloom.generate()`, `generate_project_sbom()`, `generate_wheel_sbom()`, `generate_model_sbom()`, `generate_env_sbom()`)
+   - Python API harmonized 1:1 (`pitloom.generate()`,
+     `generate_project_sbom()`, `generate_wheel_sbom()`,
+     `generate_model_sbom()`, `generate_env_sbom()`)
    - See [working-docs/design/cisa-sbom-lifecycle.md](../design/cisa-sbom-lifecycle.md)
    - Default output filename derived from project metadata
      (`{name}-{version}.spdx3.json`)
@@ -167,10 +173,12 @@ SPDX 3.0 compliant SBOMs in JSON-LD format.
 ## Validation with sentimentdemo
 
 > **Historical snapshot, early prototype.** The invocation and element
-> counts below predate the `source`/`analyze`/`deployed`/`ids` CLI
-> subcommands (PR #96) and provenance-as-Annotation (see
+> counts below predate the input-centric CLI subcommands
+> (`project`/`wheel`/`model`/`env`/`generate`/`ids`) and
+> provenance-as-Annotation (see
 > [annotation-provenance.md](annotation-provenance.md)) -- a current run
-> uses `loom source <path>`, not the bare positional form shown here, and
+> uses `loom project <path>` (or `loom generate <path>`), not the bare
+> un-namespaced form shown here, and
 > emits additional `Annotation` elements for provenance. Kept as a record
 > of the initial validation, not a spec for current output shape; see
 > [examples/sentimentdemo-aibom/](../../examples/sentimentdemo-aibom/) for
@@ -179,7 +187,7 @@ SPDX 3.0 compliant SBOMs in JSON-LD format.
 Successfully generated SPDX 3 SBOM for the reference repository:
 
 ```text
-$ loom /tmp/sentimentdemo -o sbom.spdx3.json
+$ loom project /tmp/sentimentdemo -o sbom.spdx3.json
 Generating SBOM for project in: /tmp/sentimentdemo
 SBOM written to: sbom.spdx3.json
 ```


### PR DESCRIPTION
## Summary

Redesign CLI and Python API around input artifacts (`project`, `wheel`, `model`, `env`, `generate`) while maintaining SPDX 3 / CISA SBOM Types compliance in output graph. Added native `.tar.gz` and `.zip` sdist metadata extraction support.

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
