### PR TITLE
Fix license-conflict detection gaps in Hatchling, poetry, and setuptools paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,14 +54,16 @@ and this project adheres to
   each hyperparameter, matching the AI-model extractors. ([#113])
 - Declared-vs-detected license conflict detection: the project directory
   (`CITATION.cff`, `codemeta.json`, `LICENSE` files) is now independently
-  scanned even when `project.license` already declares a value, and both
-  sides are compared after SPDX-expression normalization (new
+  scanned even when a license is already declared, and both sides are
+  compared after SPDX-expression normalization (new
   [`py-spdx-license`](https://github.com/JPEWdev/py-spdx-license)
   dependency), so casing or equivalent-but-differently-written expressions
-  aren't misreported as conflicts. On a genuine disagreement, both
-  `hasDeclaredLicense` and `hasConcludedLicense` are recorded alongside a
-  new `provenance/conflict/1` Annotation; the mechanism is generic across
-  fields, not license-specific. ([#121])
+  aren't misreported as conflicts. Works uniformly across all project
+  extraction paths (CLI/library, Hatchling build hook, poetry-only,
+  setuptools-only), via one shared resolver every path calls. On a genuine
+  disagreement, both `hasDeclaredLicense` and `hasConcludedLicense` are
+  recorded alongside a new `provenance/conflict/1` Annotation; the
+  mechanism is generic across fields, not license-specific. ([#121])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to
   are recorded (pointing at the two different licenses) alongside a new
   `provenance/conflict/1` Annotation naming both candidates and their
   source. Generic across fields, not license-specific, for future reuse.
+  ([#121])
 
 ### Changed
 
@@ -94,6 +95,7 @@ and this project adheres to
 [#116]: https://github.com/bact/pitloom/pull/116
 [#117]: https://github.com/bact/pitloom/pull/117
 [#118]: https://github.com/bact/pitloom/pull/118
+[#121]: https://github.com/bact/pitloom/pull/121
 
 ## [0.12.0] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ and this project adheres to
 - `pitloom.loom`'s `set_model(hyperparameters=...)` and
   `set_model_hyperparameters()` now record exact per-key provenance for
   each hyperparameter, matching the AI-model extractors. ([#113])
+- Declared-vs-detected license conflict detection: the project's own
+  directory is now independently scanned for a `LICENSE` file even when
+  `project.license` already declares a value, so both can be compared.
+  When they disagree, both `hasDeclaredLicense` and `hasConcludedLicense`
+  are recorded (pointing at the two different licenses) alongside a new
+  `provenance/conflict/1` Annotation naming both candidates and their
+  source. Generic across fields, not license-specific, for future reuse.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,14 +52,16 @@ and this project adheres to
 - `pitloom.loom`'s `set_model(hyperparameters=...)` and
   `set_model_hyperparameters()` now record exact per-key provenance for
   each hyperparameter, matching the AI-model extractors. ([#113])
-- Declared-vs-detected license conflict detection: the project's own
-  directory is now independently scanned for a `LICENSE` file even when
-  `project.license` already declares a value, so both can be compared.
-  When they disagree, both `hasDeclaredLicense` and `hasConcludedLicense`
-  are recorded (pointing at the two different licenses) alongside a new
-  `provenance/conflict/1` Annotation naming both candidates and their
-  source. Generic across fields, not license-specific, for future reuse.
-  ([#121])
+- Declared-vs-detected license conflict detection: the project directory
+  (`CITATION.cff`, `codemeta.json`, `LICENSE` files) is now independently
+  scanned even when `project.license` already declares a value, and both
+  sides are compared after SPDX-expression normalization (new
+  [`py-spdx-license`](https://github.com/JPEWdev/py-spdx-license)
+  dependency), so casing or equivalent-but-differently-written expressions
+  aren't misreported as conflicts. On a genuine disagreement, both
+  `hasDeclaredLicense` and `hasConcludedLicense` are recorded alongside a
+  new `provenance/conflict/1` Annotation; the mechanism is generic across
+  fields, not license-specific. ([#121])
 
 ### Changed
 

--- a/docs/metadata-provenance.md
+++ b/docs/metadata-provenance.md
@@ -101,20 +101,40 @@ every field's source regardless.
 
 ## How a license source is chosen
 
-Pitloom checks these in order and uses the first hit:
+For the project's own declared license (`project.license` in
+`pyproject.toml`), Pitloom also independently checks the project
+directory for a `LICENSE`/`LICENSE.*` file (or `CITATION.cff`/
+`codemeta.json`), matched against known SPDX licenses via `licenseid`
+(`method: licenseid_detection`) -- a second opinion, checked regardless
+of whether a declared value was already found.
 
-1. `project.license` in `pyproject.toml` (a literal SPDX expression, or a
-   `{file = "..."}`/`{text = "..."}` table).
-2. If that's absent or not directly usable, a `LICENSE`/`LICENSE.*` file
-   in the project directory, matched against known SPDX licenses via
-   `licenseid` (`method: licenseid_detection`).
+- If only one of the two exists, only that one is recorded, as
+  `hasDeclaredLicense` or `hasConcludedLicense` respectively.
+- If both exist and **agree**, both `hasDeclaredLicense` and
+  `hasConcludedLicense` are recorded, pointing at the same license.
+- If both exist and **disagree**, both are still recorded -- pointing at
+  two different licenses -- and Pitloom adds a `conflict` Annotation
+  (`field: "license"`) on the package listing both candidates and where
+  each came from, so the disagreement is visible rather than one value
+  silently overriding the other:
 
-**Current limitation:** if both a declared value (step 1) and a detected
-`LICENSE` file (step 2) are present *and disagree*, Pitloom does not
-flag the conflict -- the declared value silently wins, and there is no
-provenance marker recording that a detected alternative existed. This is
-a known, documented gap (tracked as "G2" in the design docs), not yet
-implemented.
+  ```json
+  {
+    "schema": "https://pitloom.dev/provenance/conflict/1",
+    "kind": "conflict",
+    "field": "license",
+    "candidates": [
+      {"value": "MIT", "role": "declared", "source": "Source: pyproject.toml | Field: project.license"},
+      {"value": "Apache-2.0", "role": "detected", "source": "Source: LICENSE | Method: licenseid_detection | Tool: licenseid==0.3.0"}
+    ]
+  }
+  ```
+
+  `role` says *whose* determination each candidate is: `declared` is the
+  project's own stated claim; `detected` is Pitloom's own algorithmic
+  match. (Two further roles, `externalReported` and `inferred`, are
+  reserved for future candidate sources -- a linked GitHub/Hugging Face
+  Hub API, or an AI agent's inference -- not built yet.)
 
 For the full design rationale, current implementation status, and code
 citations behind both sections above, see

--- a/docs/metadata-provenance.md
+++ b/docs/metadata-provenance.md
@@ -103,10 +103,18 @@ every field's source regardless.
 
 For the project's own declared license (`project.license` in
 `pyproject.toml`), Pitloom also independently checks the project
-directory for a `LICENSE`/`LICENSE.*` file (or `CITATION.cff`/
-`codemeta.json`), matched against known SPDX licenses via `licenseid`
-(`method: licenseid_detection`) -- a second opinion, checked regardless
-of whether a declared value was already found.
+directory for a second opinion -- `CITATION.cff`, then `codemeta.json`,
+then a `LICENSE`/`LICENSE.*` file -- checked regardless of whether a
+declared value was already found. A `CITATION.cff`/`codemeta.json` value
+that's already a bare SPDX id is used as-is; anything else (typically a
+`LICENSE` file's full text) is matched against known SPDX licenses via
+`licenseid` (`method: licenseid_detection`). Either way counts as
+Pitloom's own independent-detection procedure. Both sides are normalized
+before comparison -- not just casing (a declared `"mit"` and a detected
+`"MIT"` are recognized as the same license), but also equivalent compound
+expressions written differently (`"MIT AND MIT"` and plain `"MIT"`;
+`"MIT OR Apache-2.0"` and `"Apache-2.0 OR MIT"` all normalize to the same
+value) -- so none of these are misreported as a conflict.
 
 - If only one of the two exists, only that one is recorded, as
   `hasDeclaredLicense` or `hasConcludedLicense` respectively.
@@ -131,8 +139,9 @@ of whether a declared value was already found.
   ```
 
   `role` says *whose* determination each candidate is: `declared` is the
-  project's own stated claim; `detected` is Pitloom's own algorithmic
-  match. (Two further roles, `externalReported` and `inferred`, are
+  project's own stated claim; `detected` is Pitloom's own independent
+  directory-search procedure's result. (Two further roles,
+  `externalReported` and `inferred`, are
   reserved for future candidate sources -- a linked GitHub/Hugging Face
   Hub API, or an AI agent's inference -- not built yet.)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
     "hatchling>=1.28.0",
     "licenseid>=0.3.0",
     "pipdeptree>=2.21.0",
+    "py-spdx-license>=0.0.1,<1",
     "pyproject-metadata>=0.12.1",
     "rfc8785>=0.1.4",
     "spdx-python-model>=0.0.6",
@@ -185,6 +186,10 @@ module = "fickling.*"
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = "h5py.*"
+
+[[tool.mypy.overrides]]
+ignore_missing_imports = true
+module = "py_spdx_license.*"
 
 # safetensors safe_open and sys.modules typing changed across library versions.
 # These modules carry type: ignore comments that may be needed on older versions

--- a/skills/enrich/SKILL.md
+++ b/skills/enrich/SKILL.md
@@ -47,8 +47,19 @@ small, standalone SPDX 3 JSON file and let Pitloom merge it on the next
 generation run. See `references/examples.md` for a full worked example.
 
 Every inferred field's `comment` (or the fragment's
-`CreationInfo.comment`) must carry a provenance marker in this exact form,
-so it is never confused with authoritative, extracted metadata:
+`CreationInfo.comment`) must carry a provenance marker, so it is never
+confused with authoritative, extracted metadata. When you know your own
+agent name, vendor, and today's date, include them -- Pitloom cannot
+verify this, but it makes the record more useful to a reviewer than a
+generic placeholder:
+
+```text
+Source: <your agent name> (<vendor>) | Method: inference | Date: <ISO 8601 date>
+```
+
+For example: `Source: Claude Code (Anthropic) | Method: inference | Date:
+2026-08-10`. If you don't know your own name/vendor, fall back to the
+generic form rather than guessing:
 
 ```text
 Source: AI agent | Method: inference

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -25,6 +25,7 @@ from pitloom.core.models import build_pypi_purl, generate_spdx_id
 from pitloom.core.project import PhantomDependency
 from pitloom.core.provenance import ProvenanceConfig
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
+from pitloom.extract._license import normalize_license_expression
 
 # Operators used in PEP 508 dependency specifiers, ordered longest-first to
 # avoid splitting on a prefix of a multi-character operator (e.g. "==" before "=").
@@ -290,8 +291,18 @@ def build_license_elements(
             None,
         )
 
+    # Normalize both candidates to a canonical SPDX license expression before
+    # comparing or creating elements -- otherwise a mere casing difference
+    # (declared "mit", detected "MIT") or an equivalent-but-differently-
+    # spelled compound expression ("MIT AND MIT" vs "MIT") would be
+    # misreported as a genuine conflict and create two separate license
+    # elements for one license. Unrecognized values pass through unchanged
+    # (see normalize_license_expression).
+    canonical_declared_id = normalize_license_expression(license_id.strip())
+    canonical_concluded_id = normalize_license_expression(concluded_license_id.strip())
+
     declared_spdx_id = _get_or_create_license_element(
-        license_id,
+        canonical_declared_id,
         license_provenance,
         creation_info,
         doc_name,
@@ -301,7 +312,7 @@ def build_license_elements(
         encoder=encoder,
     )
     concluded_spdx_id = _get_or_create_license_element(
-        concluded_license_id,
+        canonical_concluded_id,
         concluded_license_provenance or license_provenance,
         creation_info,
         doc_name,
@@ -328,16 +339,16 @@ def build_license_elements(
         doc_uuid,
     )
 
-    if license_id.strip() != concluded_license_id.strip():
+    if canonical_declared_id != canonical_concluded_id:
         candidates: list[ConflictCandidate] = [
             {
-                "value": license_id,
+                "value": canonical_declared_id,
                 "role": "declared",
                 "source": license_provenance,
                 "ref": declared_spdx_id,
             },
             {
-                "value": concluded_license_id,
+                "value": canonical_concluded_id,
                 "role": "detected",
                 "source": concluded_license_provenance or license_provenance,
                 "ref": concluded_spdx_id,

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -25,7 +25,10 @@ from pitloom.core.models import build_pypi_purl, generate_spdx_id
 from pitloom.core.project import PhantomDependency
 from pitloom.core.provenance import ProvenanceConfig
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
-from pitloom.extract._license import normalize_license_expression
+from pitloom.extract._license import (
+    normalize_license_expression,
+    tag_license_normalization,
+)
 
 # Operators used in PEP 508 dependency specifiers, ordered longest-first to
 # avoid splitting on a prefix of a multi-character operator (e.g. "==" before "=").
@@ -301,9 +304,23 @@ def build_license_elements(
     canonical_declared_id = normalize_license_expression(license_id.strip())
     canonical_concluded_id = normalize_license_expression(concluded_license_id.strip())
 
+    # Flag when normalization actually rewrote a candidate's value (e.g. a
+    # casing fix or a dedup/reorder of a compound expression), and record
+    # the py-spdx-license version that did it -- so a G2 candidate's
+    # evidence stays auditable even when its stored value differs from what
+    # the source literally said. No-op when normalization was a pass-through.
+    declared_provenance = tag_license_normalization(
+        license_provenance, license_id, canonical_declared_id
+    )
+    concluded_provenance = tag_license_normalization(
+        concluded_license_provenance or license_provenance,
+        concluded_license_id,
+        canonical_concluded_id,
+    )
+
     declared_spdx_id = _get_or_create_license_element(
         canonical_declared_id,
-        license_provenance,
+        declared_provenance,
         creation_info,
         doc_name,
         doc_uuid,
@@ -313,7 +330,7 @@ def build_license_elements(
     )
     concluded_spdx_id = _get_or_create_license_element(
         canonical_concluded_id,
-        concluded_license_provenance or license_provenance,
+        concluded_provenance,
         creation_info,
         doc_name,
         doc_uuid,
@@ -344,13 +361,13 @@ def build_license_elements(
             {
                 "value": canonical_declared_id,
                 "role": "declared",
-                "source": license_provenance,
+                "source": declared_provenance,
                 "ref": declared_spdx_id,
             },
             {
                 "value": canonical_concluded_id,
                 "role": "detected",
-                "source": concluded_license_provenance or license_provenance,
+                "source": concluded_provenance,
                 "ref": concluded_spdx_id,
             },
         ]

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -15,7 +15,9 @@ from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.assemble.spdx3.provenance import (
     TRANSPARENT_SOURCES,
+    ConflictCandidate,
     ProvenanceEncoder,
+    build_conflict_annotation,
     emit_provenance,
     parse_provenance_value,
 )
@@ -163,6 +165,67 @@ def _is_license_concluded(parsed_prov: dict[str, str]) -> bool:
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
+def _get_or_create_license_element(
+    license_id: str,
+    license_provenance: str,
+    creation_info: spdx3.CreationInfo,
+    doc_name: str,
+    doc_uuid: str,
+    exporter: Spdx3JsonExporter,
+    *,
+    provenance_config: ProvenanceConfig | None = None,
+    encoder: ProvenanceEncoder | None = None,
+) -> str:
+    """Get or create a ``SimpleLicensingText`` element for *license_id*, deduped
+    by license-id string, and return its spdxId."""
+    existing_spdx_id = exporter.find_license(license_id)
+    if existing_spdx_id:
+        return existing_spdx_id
+
+    name_str = license_id.strip()
+    if "\n" in name_str:
+        name_str = name_str.split("\n")[0]
+    if len(name_str) > 60:
+        name_str = name_str[:57] + "..."
+
+    license_text = spdx3.simplelicensing_SimpleLicensingText(
+        spdxId=generate_spdx_id("License", doc_name=doc_name, doc_uuid=doc_uuid),
+        creationInfo=creation_info,
+    )
+    license_text.name = name_str
+    license_text.simplelicensing_licenseText = license_id
+    exporter.add_license(license_text)
+    emit_provenance(
+        subject=license_text,
+        provenance={"license": license_provenance},
+        creation_info=creation_info,
+        doc_name=doc_name,
+        doc_uuid=doc_uuid,
+        exporter=exporter,
+        provenance_config=provenance_config,
+        encoder=encoder,
+    )
+    return require_spdx_id(license_text)
+
+
+def _build_license_relationship(
+    package_spdx_id: str,
+    license_spdx_id: str,
+    relationship_type: str,
+    creation_info: spdx3.CreationInfo,
+    doc_name: str,
+    doc_uuid: str,
+) -> spdx3.Relationship:
+    return spdx3.Relationship(
+        spdxId=generate_spdx_id("Relationship", doc_name=doc_name, doc_uuid=doc_uuid),
+        creationInfo=creation_info,
+        from_=package_spdx_id,
+        relationshipType=relationship_type,
+        to=[license_spdx_id],
+    )
+
+
+# pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
 def build_license_elements(
     license_id: str,
     package_spdx_id: str,
@@ -172,69 +235,124 @@ def build_license_elements(
     doc_uuid: str,
     exporter: Spdx3JsonExporter,
     *,
+    concluded_license_id: str | None = None,
+    concluded_license_provenance: str | None = None,
     provenance_config: ProvenanceConfig | None = None,
     encoder: ProvenanceEncoder | None = None,
 ) -> tuple[spdx3.Relationship | None, spdx3.Relationship | None]:
-    """Get or create a SimpleLicensingText element and build its declared/concluded
-    license relationships."""
-    existing_spdx_id = exporter.find_license(license_id)
-    if existing_spdx_id:
-        license_spdx_id = existing_spdx_id
-    else:
-        name_str = license_id.strip()
-        if "\n" in name_str:
-            name_str = name_str.split("\n")[0]
-        if len(name_str) > 60:
-            name_str = name_str[:57] + "..."
+    """Get or create SimpleLicensingText element(s) and build declared/concluded
+    license relationships.
 
-        license_text = spdx3.simplelicensing_SimpleLicensingText(
-            spdxId=generate_spdx_id("License", doc_name=doc_name, doc_uuid=doc_uuid),
-            creationInfo=creation_info,
-        )
-        license_text.name = name_str
-        license_text.simplelicensing_licenseText = license_id
-        exporter.add_license(license_text)
-        emit_provenance(
-            subject=license_text,
-            provenance={"license": license_provenance},
-            creation_info=creation_info,
-            doc_name=doc_name,
-            doc_uuid=doc_uuid,
-            exporter=exporter,
+    Single-candidate mode (*concluded_license_id* omitted, the default):
+    unchanged behavior -- one element, classified as declared XOR concluded
+    via :func:`_is_license_concluded` on *license_provenance*.
+
+    Two-candidate mode (G2, *concluded_license_id* given -- currently only the
+    main project package path supplies this, since it's the only one with a
+    local directory to independently detect a second opinion from): *license_id*
+    is always the declared value, *concluded_license_id* the independently
+    detected one. Both relationships are built unconditionally, whether or not
+    the two agree -- when they *do* agree, both point at the same deduped
+    license element. When they disagree, an additional G2 conflict Annotation
+    is emitted on *package_spdx_id* recording both candidates; see
+    :func:`~pitloom.assemble.spdx3.provenance.build_conflict_annotation`.
+    """
+    if concluded_license_id is None:
+        license_spdx_id = _get_or_create_license_element(
+            license_id,
+            license_provenance,
+            creation_info,
+            doc_name,
+            doc_uuid,
+            exporter,
             provenance_config=provenance_config,
             encoder=encoder,
         )
-        license_spdx_id = require_spdx_id(license_text)
-
-    parsed_prov = parse_provenance_value(license_provenance)
-    is_concluded = _is_license_concluded(parsed_prov)
-
-    rel_has_declared_license: spdx3.Relationship | None = None
-    rel_has_concluded_license: spdx3.Relationship | None = None
-
-    if is_concluded:
-        rel_has_concluded_license = spdx3.Relationship(
-            spdxId=generate_spdx_id(
-                "Relationship",
-                doc_name=doc_name,
-                doc_uuid=doc_uuid,
+        parsed_prov = parse_provenance_value(license_provenance)
+        if _is_license_concluded(parsed_prov):
+            return None, _build_license_relationship(
+                package_spdx_id,
+                license_spdx_id,
+                spdx3.RelationshipType.hasConcludedLicense,
+                creation_info,
+                doc_name,
+                doc_uuid,
+            )
+        return (
+            _build_license_relationship(
+                package_spdx_id,
+                license_spdx_id,
+                spdx3.RelationshipType.hasDeclaredLicense,
+                creation_info,
+                doc_name,
+                doc_uuid,
             ),
-            creationInfo=creation_info,
-            from_=package_spdx_id,
-            relationshipType=spdx3.RelationshipType.hasConcludedLicense,
-            to=[license_spdx_id],
+            None,
         )
-    else:
-        rel_has_declared_license = spdx3.Relationship(
-            spdxId=generate_spdx_id(
-                "Relationship",
-                doc_name=doc_name,
-                doc_uuid=doc_uuid,
-            ),
-            creationInfo=creation_info,
-            from_=package_spdx_id,
-            relationshipType=spdx3.RelationshipType.hasDeclaredLicense,
-            to=[license_spdx_id],
+
+    declared_spdx_id = _get_or_create_license_element(
+        license_id,
+        license_provenance,
+        creation_info,
+        doc_name,
+        doc_uuid,
+        exporter,
+        provenance_config=provenance_config,
+        encoder=encoder,
+    )
+    concluded_spdx_id = _get_or_create_license_element(
+        concluded_license_id,
+        concluded_license_provenance or license_provenance,
+        creation_info,
+        doc_name,
+        doc_uuid,
+        exporter,
+        provenance_config=provenance_config,
+        encoder=encoder,
+    )
+
+    rel_has_declared_license = _build_license_relationship(
+        package_spdx_id,
+        declared_spdx_id,
+        spdx3.RelationshipType.hasDeclaredLicense,
+        creation_info,
+        doc_name,
+        doc_uuid,
+    )
+    rel_has_concluded_license = _build_license_relationship(
+        package_spdx_id,
+        concluded_spdx_id,
+        spdx3.RelationshipType.hasConcludedLicense,
+        creation_info,
+        doc_name,
+        doc_uuid,
+    )
+
+    if license_id.strip() != concluded_license_id.strip():
+        candidates: list[ConflictCandidate] = [
+            {
+                "value": license_id,
+                "role": "declared",
+                "source": license_provenance,
+                "ref": declared_spdx_id,
+            },
+            {
+                "value": concluded_license_id,
+                "role": "detected",
+                "source": concluded_license_provenance or license_provenance,
+                "ref": concluded_spdx_id,
+            },
+        ]
+        exporter.add_annotation(
+            build_conflict_annotation(
+                subject_spdx_id=package_spdx_id,
+                field="license",
+                candidates=candidates,
+                creation_info=creation_info,
+                annotation_spdx_id=generate_spdx_id(
+                    "Annotation", doc_name=doc_name, doc_uuid=doc_uuid
+                ),
+            )
         )
 
     return rel_has_declared_license, rel_has_concluded_license

--- a/src/pitloom/assemble/spdx3/document.py
+++ b/src/pitloom/assemble/spdx3/document.py
@@ -286,6 +286,12 @@ def build(
             doc_name=metadata.name,
             doc_uuid=doc_uuid,
             exporter=exporter,
+            # G2: only the pyproject.toml [project]-path extractor populates
+            # license_concluded (independent directory scan) -- None here for
+            # any other backend, which keeps this the original single-value
+            # behavior unchanged.
+            concluded_license_id=metadata.license_concluded,
+            concluded_license_provenance=metadata.provenance.get("license_concluded"),
             provenance_config=prov_cfg,
             encoder=encoder,
         )

--- a/src/pitloom/assemble/spdx3/provenance.py
+++ b/src/pitloom/assemble/spdx3/provenance.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import base64
 import json
 import math
-from typing import Any, Protocol
+from typing import Any, Protocol, TypedDict
 
 from spdx_python_model.bindings import v3_0_1 as spdx3
 
@@ -42,6 +42,9 @@ UNIFICATION_SCHEMA_URL = "https://pitloom.dev/provenance/unification/1"
 
 #: Statement-schema URL for a preserved verbatim artifact-metadata blob (P1).
 ARTIFACT_METADATA_SCHEMA_URL = "https://pitloom.dev/provenance/artifact-metadata/1"
+
+#: Statement-schema URL for a multi-source field-value disagreement (G2).
+CONFLICT_SCHEMA_URL = "https://pitloom.dev/provenance/conflict/1"
 
 #: Transparent, re-readable manifest sources. A field read verbatim from one of
 #: these (no extraction ``method``) is *low* signal in minimal mode: its value
@@ -149,14 +152,14 @@ class PitloomV1Encoder:
     """Pitloom's own simple JSON schema (the default)."""
 
     schema_id = "pitloom/1"
-    schema_url = "https://pitloom.dev/provenance/1"
+    schema_url = "https://pitloom.dev/provenance/fields/1"
     content_type = "application/json"
 
     def encode(self, provenance: dict[str, str]) -> str:
         fields = {
             field: parse_provenance_value(src) for field, src in provenance.items()
         }
-        envelope = {"schema": self.schema_url, "fields": fields}
+        envelope = {"schema": self.schema_url, "kind": "fields", "fields": fields}
         # sort_keys keeps output byte-stable for reproducible builds.
         return json.dumps(envelope, ensure_ascii=False, sort_keys=True)
 
@@ -321,10 +324,82 @@ def build_unification_annotation(
     """
     statement = {
         "schema": UNIFICATION_SCHEMA_URL,
-        "event": "unification",
+        "kind": "unification",
         "criterion": criterion,
         "unified": sorted(unified_ids),
         "fragments": sorted(fragments),
+    }
+    return _build_json_annotation(
+        subject_spdx_id, statement, creation_info, annotation_spdx_id
+    )
+
+
+class _ConflictCandidateRequired(TypedDict):
+    value: str
+    role: str
+    source: str
+
+
+class ConflictCandidate(_ConflictCandidateRequired, total=False):
+    """One source's reported value for a field under dispute (G2).
+
+    ``role`` is an epistemic-process label -- *whose* determination this is,
+    not which native SPDX slot it maps to (that mapping is a separate,
+    per-field, per-caller decision -- see :func:`build_conflict_annotation`):
+
+    * ``"declared"`` -- the subject's own stated claim, however observed
+      (read locally, or relayed unedited by a third party).
+    * ``"detected"`` -- Pitloom's own deterministic algorithm's
+      determination, whatever the input's origin.
+    * ``"externalReported"`` -- some other party's own determination or
+      opinion, relayed without Pitloom re-deriving it -- and not the
+      subject's own claim either.
+    * ``"inferred"`` -- an AI agent's non-deterministic reasoning/judgment.
+
+    ``source`` follows the existing ``"Key: Value | Key: Value"`` provenance
+    string convention (:func:`parse_provenance_value`). ``ref`` is the
+    spdxId of a native element this candidate maps to, when one exists (e.g.
+    the license text element for a ``"declared"``/``"detected"`` license
+    candidate) -- omitted when the candidate has no native counterpart.
+    """
+
+    ref: str
+
+
+def build_conflict_annotation(
+    subject_spdx_id: str,
+    field: str,
+    candidates: list[ConflictCandidate],
+    creation_info: spdx3.CreationInfo,
+    annotation_spdx_id: str,
+) -> spdx3.Annotation:
+    """Return an Annotation recording that multiple sources disagree on
+    *field*'s value for *subject_spdx_id* (G2).
+
+    Generic across fields -- license is the first field this fires for, but
+    the mechanism (several sources reporting different values for the same
+    field) applies to any field; a future field just supplies its own
+    *candidates*. SPDX has no native home for the *disagreement itself*: even
+    when individual candidate values do have a native slot (a license's
+    ``hasDeclaredLicense``/``hasConcludedLicense``), SPDX only ever has two
+    such slots, so a 3rd+ candidate -- and the fact that any of them
+    conflict -- has nowhere native to go regardless of field.
+
+    Only call this when candidates actually disagree; full agreement across
+    all known candidates has nothing extrinsic to assert.
+
+    Args:
+        subject_spdx_id: The element the disputed field belongs to (e.g. the
+            package, for license).
+        field: The field name in dispute (``"license"`` today).
+        candidates: Every known source's reported value, non-empty.
+        annotation_spdx_id: The Annotation's own id.
+    """
+    statement = {
+        "schema": CONFLICT_SCHEMA_URL,
+        "kind": "conflict",
+        "field": field,
+        "candidates": candidates,
     }
     return _build_json_annotation(
         subject_spdx_id, statement, creation_info, annotation_spdx_id
@@ -359,6 +434,7 @@ def build_source_metadata_annotation(
         return None
     statement = {
         "schema": ARTIFACT_METADATA_SCHEMA_URL,
+        "kind": "artifact-metadata",
         "format": source_format,
         "metadata": metadata,
     }

--- a/src/pitloom/core/project.py
+++ b/src/pitloom/core/project.py
@@ -70,6 +70,7 @@ class ProjectMetadata:
     readme: str | None = None
     requires_python: str | None = None
     license_name: str | None = None
+    license_concluded: str | None = None
     keywords: list[str] = field(default_factory=list)
     authors: list[dict[str, str]] = field(default_factory=list)
     urls: dict[str, str] = field(default_factory=dict)

--- a/src/pitloom/core/project.py
+++ b/src/pitloom/core/project.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass, field
 
 
@@ -78,3 +79,40 @@ class ProjectMetadata:
     dependencies: list[str] = field(default_factory=list)
     provenance: dict[str, str] = field(default_factory=dict)
     files: list[ProjectFile] = field(default_factory=list)
+
+
+def merge_project_metadata(
+    primary: ProjectMetadata, secondary: ProjectMetadata
+) -> ProjectMetadata:
+    """Merge two :class:`ProjectMetadata` instances, *primary* winning
+    field-by-field; *secondary* fills gaps where *primary*'s value is falsy.
+
+    Iterates :func:`dataclasses.fields` instead of hand-listing every field,
+    so a newly added :class:`ProjectMetadata` field (like ``license_concluded``,
+    added for G2) is merged automatically with the same default rule -- no
+    call site needs updating when the schema grows. This replaces two
+    previously-duplicated, independently-drifting implementations
+    (``pyproject.py``'s old ``_merge_with_poetry``, ``setuptools.py``'s old
+    ``merge_metadata``) that each hand-listed every field and had to be kept
+    in sync by hand; ``license_concluded`` was missing from one of them until
+    this fix, precisely because that discipline had already lapsed once.
+
+    Two fields are special-cased rather than "primary if truthy else
+    secondary":
+
+    - ``name`` -- always *primary*'s, even if empty (a project's own name is
+      never meaningfully "filled in" from a secondary/fallback source).
+    - ``provenance`` -- dict-merged, *primary*'s entries winning on key
+      conflict, rather than replaced wholesale.
+
+    Every other field: *primary*'s value when truthy, else *secondary*'s.
+    """
+    merged = dataclasses.replace(primary)
+    merged.provenance = {**secondary.provenance, **primary.provenance}
+    for f in dataclasses.fields(ProjectMetadata):
+        if f.name in ("name", "provenance"):
+            continue
+        primary_value = getattr(primary, f.name)
+        if not primary_value:
+            setattr(merged, f.name, getattr(secondary, f.name))
+    return merged

--- a/src/pitloom/core/project.py
+++ b/src/pitloom/core/project.py
@@ -46,6 +46,7 @@ class PhantomDependency:
 
 
 @dataclass
+# pylint: disable-next=too-many-instance-attributes
 class ProjectMetadata:
     """Format-neutral representation of project metadata with provenance tracking.
 

--- a/src/pitloom/extract/_license.py
+++ b/src/pitloom/extract/_license.py
@@ -24,6 +24,8 @@ from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
 from licenseid import AggregatedLicenseMatcher
+from py_spdx_license import ParseError as SpdxExpressionParseError
+from py_spdx_license import parse as parse_spdx_expression
 
 _logger = logging.getLogger(__name__)
 
@@ -31,6 +33,22 @@ try:
     _LICENSEID_VERSION: str | None = _pkg_version("licenseid")
 except PackageNotFoundError:
     _LICENSEID_VERSION = None
+
+try:
+    _PY_SPDX_LICENSE_VERSION: str | None = _pkg_version("py-spdx-license")
+except PackageNotFoundError:
+    _PY_SPDX_LICENSE_VERSION = None
+
+#: Matches AND/OR/WITH/NOT only when they stand alone as their own token
+#: (whitespace/paren-delimited on both sides) -- exactly what SPDX expression
+#: syntax requires of a real operator. Deliberately *not* a plain ``\b`` word
+#: boundary: ``\b`` also fires at hyphens, which would mangle a hyphen-glued
+#: identifier that merely contains "and"/"or"/"with" as a substring (a real
+#: SPDX id like ``GPL-2.0-or-later``, or a custom ``LicenseRef-my-or-license``)
+#: into wrongly-cased ``-OR-``.
+_SPDX_OPERATOR_CASING_RE = re.compile(
+    r"(?<![\w-])(and|or|with|not)(?![\w-])", re.IGNORECASE
+)
 
 # Heuristic: single-token SPDX License IDs and expressions like "GPL-3.0-or-later"
 _SPDX_LICENSE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9.\-+]*$")
@@ -116,6 +134,44 @@ def canonicalize_license_id(raw: str) -> str:
     except Exception as exc:  # pylint: disable=broad-exception-caught
         _logger.debug("Failed to canonicalize license id %r: %s", raw, exc)
     return raw
+
+
+def normalize_license_expression(raw: str) -> str:
+    """Return *raw* normalized to a canonical SPDX license expression, or
+    *raw* unchanged when it can't be parsed as one.
+
+    Handles what :func:`canonicalize_license_id` cannot: a *compound*
+    expression (``"MIT AND MIT"``, ``"Apache-2.0 OR MIT"``) is deduplicated
+    and canonically reordered via ``py_spdx_license`` -- so two candidates
+    that are semantically the same license, just spelled differently, are
+    recognized as equal rather than misreported as a G2 conflict
+    (``"MIT AND MIT"`` and ``"MIT OR Apache-2.0"``/``"Apache-2.0 OR MIT"``
+    both normalize to the same string regardless of input ordering). A bare
+    id is also canonicalized to its recognized SPDX casing as a side effect
+    of parsing (``"mit"`` -> ``"MIT"``), same as :func:`canonicalize_license_id`.
+
+    Before parsing, ``AND``/``OR``/``WITH``/``NOT`` are case-normalized to
+    uppercase when they appear as their own whitespace/paren-delimited token
+    (SPDX expression syntax is operator-case-strict; a lowercase ``"mit and
+    mit"`` would otherwise fail to parse at all) -- but *only* when
+    isolated like that, so a hyphen-glued identifier that merely contains
+    "and"/"or"/"with" as a substring (``"GPL-2.0-or-later"``, a custom
+    ``"LicenseRef-my-or-license"``) is never touched.
+
+    Falls back to :func:`canonicalize_license_id` when the (operator-cased)
+    string can't be parsed as a valid SPDX expression at all -- e.g. genuinely
+    malformed syntax (unbalanced parens, a missing operand) -- so a simple
+    bare id still gets at least casing normalization even in that case.
+    """
+    operator_cased = _SPDX_OPERATOR_CASING_RE.sub(
+        lambda m: m.group(1).upper(), raw.strip()
+    )
+    try:
+        node = parse_spdx_expression(operator_cased, allow_unknown=True)
+        return str(node.sort().to_string())
+    except SpdxExpressionParseError as exc:
+        _logger.debug("Failed to parse SPDX expression %r: %s", raw, exc)
+    return canonicalize_license_id(raw)
 
 
 def find_license_files(project_dir: Path) -> list[Path]:

--- a/src/pitloom/extract/_license.py
+++ b/src/pitloom/extract/_license.py
@@ -19,11 +19,18 @@ from __future__ import annotations
 import json
 import logging
 import re
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
 from licenseid import AggregatedLicenseMatcher
 
 _logger = logging.getLogger(__name__)
+
+try:
+    _LICENSEID_VERSION: str | None = _pkg_version("licenseid")
+except PackageNotFoundError:
+    _LICENSEID_VERSION = None
 
 # Heuristic: single-token SPDX License IDs and expressions like "GPL-3.0-or-later"
 _SPDX_LICENSE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9.\-+]*$")
@@ -235,6 +242,41 @@ def collect_license_candidates(project_dir: Path) -> list[tuple[str, str]]:
     return candidates
 
 
+def _with_tool_tag(provenance: str) -> str:
+    """Append the ``licenseid`` library version to a detection provenance string.
+
+    A ``licenseid_detection`` result is only as reproducible as the license
+    database of the library version that produced it -- record which one ran,
+    so a ``detected``-role G2 candidate's evidence stays auditable across
+    library upgrades. Falls back to the bare string when the installed
+    version can't be resolved (e.g. an unusual/editable install).
+    """
+    if _LICENSEID_VERSION is None:
+        return provenance
+    return f"{provenance} | Tool: licenseid=={_LICENSEID_VERSION}"
+
+
+def detect_independent_license(project_dir: Path) -> tuple[str | None, str | None]:
+    """Detect a license purely from project-directory files (``CITATION.cff``,
+    ``codemeta.json``, license files), ignoring any already-declared value.
+
+    Used to independently corroborate or conflict-check a declared license
+    (G2) -- unlike :func:`detect_license_for_project`, this never considers a
+    caller-supplied hint, so its result is a genuine second opinion.
+
+    Returns ``(None, None)`` when nothing in *project_dir* yields a license.
+    """
+    for value, source in collect_license_candidates(project_dir):
+        if _looks_like_spdx_license_id(value) or _looks_like_spdx_license_expression(
+            value
+        ):
+            return value, source
+        detected = detect_license_from_text(value)
+        if detected:
+            return detected, _with_tool_tag(f"{source} | Method: licenseid_detection")
+    return None, None
+
+
 def detect_license_for_project(
     project_dir: Path,
     license_hint: str | None = None,
@@ -247,8 +289,7 @@ def detect_license_for_project(
        (caller should set provenance from the original metadata field).
     2. *license_hint* is a compound SPDX License Expression -> returned unchanged.
     3. *license_hint* is license text -> run :func:`detect_license_from_text`.
-    4. Search ``CITATION.cff``, ``codemeta.json``, and license files in
-       *project_dir*.
+    4. :func:`detect_independent_license` over *project_dir*.
 
     Returns ``(None, None)`` when no license can be determined.
     """
@@ -262,17 +303,11 @@ def detect_license_for_project(
         # Hint is likely license text -- try detection first
         detected = detect_license_from_text(hint)
         if detected:
-            return detected, "Method: licenseid_detection"
+            return detected, _with_tool_tag("Method: licenseid_detection")
 
-    # Search project directory sources
-    for value, source in collect_license_candidates(project_dir):
-        if _looks_like_spdx_license_id(value) or _looks_like_spdx_license_expression(
-            value
-        ):
-            return value, source
-        detected = detect_license_from_text(value)
-        if detected:
-            return detected, f"{source} | Method: licenseid_detection"
+    directory_id, directory_prov = detect_independent_license(project_dir)
+    if directory_id:
+        return directory_id, directory_prov
 
     # Fall back to the raw hint (non-standard string) rather than returning None
     if license_hint and license_hint.strip():

--- a/src/pitloom/extract/_license.py
+++ b/src/pitloom/extract/_license.py
@@ -174,6 +174,26 @@ def normalize_license_expression(raw: str) -> str:
     return canonicalize_license_id(raw)
 
 
+def tag_license_normalization(provenance: str, raw: str, normalized: str) -> str:
+    """Append a note to *provenance* when :func:`normalize_license_expression`
+    actually changed *raw* to *normalized* (e.g. ``"mit"`` -> ``"MIT"``,
+    ``"MIT AND MIT"`` -> ``"MIT"``), recording the ``py-spdx-license``
+    version that did it.
+
+    A no-op (returns *provenance* unchanged) when *raw* and *normalized*
+    already match -- nothing to flag. Mirrors :func:`_with_tool_tag`'s
+    pattern for ``licenseid``, so a G2 candidate whose declared-side value
+    was rewritten before comparison stays auditable against the exact
+    normalizer version that rewrote it, not just "some normalization ran".
+    """
+    if raw.strip() == normalized:
+        return provenance
+    note = f"{provenance} | Normalized-From: {raw.strip()}"
+    if _PY_SPDX_LICENSE_VERSION is None:
+        return note
+    return f"{note} | Normalizer: py-spdx-license=={_PY_SPDX_LICENSE_VERSION}"
+
+
 def find_license_files(project_dir: Path) -> list[Path]:
     """Return existing license files in *project_dir* in priority order.
 
@@ -331,6 +351,39 @@ def detect_independent_license(project_dir: Path) -> tuple[str | None, str | Non
         if detected:
             return detected, _with_tool_tag(f"{source} | Method: licenseid_detection")
     return None, None
+
+
+def resolve_license_concluded(
+    has_declared_license: bool, project_dir: Path
+) -> tuple[str | None, str | None]:
+    """Return ``(concluded_id, concluded_provenance)`` -- G2's independent
+    second opinion -- or ``(None, None)`` when there's no declared value to
+    compare it against.
+
+    **Every extractor that resolves a project's own declared license must
+    call this alongside its own declared-value resolution.** This is the
+    single, canonical G2 entry point precisely so a *new* extraction path
+    can't silently omit conflict detection the way the Hatchling build-hook
+    path (:func:`~pitloom.extract.hatchling.metadata_from_hatchling`)
+    originally did -- it called :func:`detect_license_for_project` directly
+    and never ran the independent directory scan at all, so G2 only ever
+    fired via the CLI's :func:`~pitloom.extract.pyproject.read_pyproject`.
+    If you're adding a new project-metadata extractor, call this too; see
+    ``tests/test_hatch_hook.py``'s
+    ``test_metadata_from_hatchling_matches_read_pyproject_for_license_conflict``
+    for the cross-path regression test this class of gap needs.
+
+    Args:
+        has_declared_license: Whether the caller's own metadata source
+            already resolved *some* declared value (however obtained --
+            a bare id, a license file reference, license text). When
+            ``False``, there's nothing to compare a second opinion against,
+            so no scan is performed.
+        project_dir: Project root directory to independently scan.
+    """
+    if not has_declared_license:
+        return None, None
+    return detect_independent_license(project_dir)
 
 
 def detect_license_for_project(

--- a/src/pitloom/extract/hatchling.py
+++ b/src/pitloom/extract/hatchling.py
@@ -23,9 +23,12 @@ from pathlib import Path
 from typing import Any
 
 from pitloom.core.models import normalize_dependency_specifier
-from pitloom.core.project import ProjectMetadata
-from pitloom.extract._license import detect_license_for_project
-from pitloom.extract.pyproject import _merge_with_poetry, _try_read_poetry
+from pitloom.core.project import ProjectMetadata, merge_project_metadata
+from pitloom.extract._license import (
+    detect_license_for_project,
+    resolve_license_concluded,
+)
+from pitloom.extract.pyproject import _try_read_poetry
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -51,7 +54,7 @@ def _poetry_fallback_metadata(project_dir: Path) -> ProjectMetadata | None:
         return None
     with open(pyproject_path, "rb") as f:
         data: dict[str, Any] = tomllib.load(f)
-    return _try_read_poetry(data)
+    return _try_read_poetry(data, project_dir)
 
 
 def _authors_from_data(authors_data: dict[str, list[str]]) -> list[dict[str, str]]:
@@ -162,6 +165,16 @@ def metadata_from_hatchling(
     elif license_name:
         provenance["license"] = _field_provenance("license")
 
+    # G2: independently scan project_dir for a second opinion when a license
+    # was declared, exactly like read_pyproject() does for the CLI path --
+    # via the shared resolve_license_concluded() so this can't drift out of
+    # sync again (see its docstring for why this was previously missing here).
+    license_concluded, license_concluded_prov = resolve_license_concluded(
+        bool(license_hint), project_dir
+    )
+    if license_concluded and license_concluded_prov:
+        provenance["license_concluded"] = license_concluded_prov
+
     metadata = ProjectMetadata(
         name=core.raw_name,
         version=version,
@@ -169,6 +182,7 @@ def metadata_from_hatchling(
         readme=readme,
         requires_python=requires_python,
         license_name=license_name,
+        license_concluded=license_concluded,
         keywords=list(core.keywords or []),
         authors=authors,
         urls=urls,
@@ -180,7 +194,7 @@ def metadata_from_hatchling(
     # read_pyproject() does for the CLI path (project fields always win).
     poetry_meta = _poetry_fallback_metadata(project_dir)
     if poetry_meta is not None:
-        metadata = _merge_with_poetry(metadata, poetry_meta)
+        metadata = merge_project_metadata(metadata, poetry_meta)
 
     return metadata
 

--- a/src/pitloom/extract/poetry.py
+++ b/src/pitloom/extract/poetry.py
@@ -64,6 +64,10 @@ from typing import Any
 
 from pitloom.core.config import PitloomConfig, _read_pitloom_config
 from pitloom.core.project import ProjectMetadata
+from pitloom.extract._license import (
+    detect_license_for_project,
+    resolve_license_concluded,
+)
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -94,13 +98,14 @@ def read_poetry(pyproject_path: Path) -> tuple[ProjectMetadata, PitloomConfig]:
     with open(pyproject_path, "rb") as f:
         data: dict[str, Any] = tomllib.load(f)
 
-    metadata = extract_poetry_metadata(data)
+    metadata = extract_poetry_metadata(data, pyproject_path.parent)
     pitloom_config = _read_pitloom_config(data)
     return metadata, pitloom_config
 
 
 def extract_poetry_metadata(
     data: dict[str, Any],
+    project_dir: Path,
 ) -> ProjectMetadata:
     """Extract :class:`~pitloom.core.project.ProjectMetadata` from pre-loaded data.
 
@@ -111,6 +116,11 @@ def extract_poetry_metadata(
 
     Args:
         data: Full parsed ``pyproject.toml`` dict.
+        project_dir: Project root directory -- used for the same license
+            fallback-detection and G2 independent-scan every other project
+            extractor performs; see
+            :func:`~pitloom.extract._license.resolve_license_concluded`'s
+            docstring for why every extractor must call it.
 
     Returns:
         A populated :class:`~pitloom.core.project.ProjectMetadata`.
@@ -129,33 +139,19 @@ def extract_poetry_metadata(
     version = (poetry.get("version") or "").strip() or None
     description = (poetry.get("description") or "").strip() or None
 
-    readme_raw = poetry.get("readme")
-    if isinstance(readme_raw, list):
-        readme: str | None = readme_raw[0].strip() if readme_raw else None
-    elif isinstance(readme_raw, str):
-        readme = readme_raw.strip() or None
-    else:
-        readme = None
+    readme = _parse_poetry_readme(poetry.get("readme"))
 
-    license_name = (poetry.get("license") or "").strip() or None
+    license_name, license_concluded, license_prov = _resolve_poetry_license(
+        poetry, project_dir
+    )
 
     raw_keywords = poetry.get("keywords", [])
     keywords: list[str] = raw_keywords if isinstance(raw_keywords, list) else []
 
     authors = _parse_poetry_authors(poetry.get("authors", []))
+    urls = _parse_poetry_urls(poetry)
 
-    urls: dict[str, str] = {}
-    for toml_key, label in (
-        ("homepage", "Homepage"),
-        ("repository", "Repository"),
-        ("documentation", "Documentation"),
-    ):
-        val = poetry.get(toml_key)
-        if isinstance(val, str) and val.strip():
-            urls[label] = val.strip()
-
-    deps_raw: dict[str, Any] = poetry.get("dependencies", {})
-    dependencies, requires_python = _parse_poetry_deps(deps_raw)
+    dependencies, requires_python = _parse_poetry_deps(poetry.get("dependencies", {}))
 
     prov: dict[str, str] = {
         "name": "Source: pyproject.toml | Field: tool.poetry.name",
@@ -166,8 +162,7 @@ def extract_poetry_metadata(
         prov["description"] = "Source: pyproject.toml | Field: tool.poetry.description"
     if readme:
         prov["readme"] = "Source: pyproject.toml | Field: tool.poetry.readme"
-    if license_name:
-        prov["license"] = "Source: pyproject.toml | Field: tool.poetry.license"
+    prov.update(license_prov)
     if authors:
         prov["authors"] = "Source: pyproject.toml | Field: tool.poetry.authors"
         prov["copyright_text"] = (
@@ -196,6 +191,7 @@ def extract_poetry_metadata(
         readme=readme,
         requires_python=requires_python,
         license_name=license_name,
+        license_concluded=license_concluded,
         keywords=keywords,
         authors=authors,
         urls=urls,
@@ -207,6 +203,65 @@ def extract_poetry_metadata(
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
+
+
+def _parse_poetry_readme(readme_raw: Any) -> str | None:
+    """Normalize ``[tool.poetry].readme``, which may be a bare string or a
+    list of strings (multiple readme files -- only the first is used)."""
+    if isinstance(readme_raw, list):
+        return readme_raw[0].strip() if readme_raw else None
+    if isinstance(readme_raw, str):
+        return readme_raw.strip() or None
+    return None
+
+
+def _parse_poetry_urls(poetry: dict[str, Any]) -> dict[str, str]:
+    """Collect ``homepage``/``repository``/``documentation`` into a URL dict."""
+    urls: dict[str, str] = {}
+    for toml_key, label in (
+        ("homepage", "Homepage"),
+        ("repository", "Repository"),
+        ("documentation", "Documentation"),
+    ):
+        val = poetry.get(toml_key)
+        if isinstance(val, str) and val.strip():
+            urls[label] = val.strip()
+    return urls
+
+
+def _resolve_poetry_license(
+    poetry: dict[str, Any], project_dir: Path
+) -> tuple[str | None, str | None, dict[str, str]]:
+    """Resolve ``[tool.poetry]``'s declared license, falling back to
+    directory detection when absent, plus G2's independent second opinion.
+
+    Returns ``(license_name, license_concluded, license_prov)`` -- pulled
+    out of :func:`extract_poetry_metadata` so its own local-variable count
+    stays under pylint's ``too-many-locals`` threshold; ``license_prov`` is
+    ready to merge into the caller's provenance dict directly.
+    """
+    license_name = (poetry.get("license") or "").strip() or None
+    has_declared_license = bool(license_name)
+    license_prov_override: str | None = None
+    if not license_name:
+        # No [tool.poetry] license declared -- fall back to directory
+        # detection, same baseline every other extractor has.
+        license_name, license_prov_override = detect_license_for_project(project_dir)
+    # G2: independently scan for a second opinion when a license *was*
+    # declared, via the shared resolver every extractor must call.
+    license_concluded, license_concluded_prov = resolve_license_concluded(
+        has_declared_license, project_dir
+    )
+
+    license_prov: dict[str, str] = {}
+    if license_name:
+        license_prov["license"] = (
+            license_prov_override
+            or "Source: pyproject.toml | Field: tool.poetry.license"
+        )
+    if license_concluded and license_concluded_prov:
+        license_prov["license_concluded"] = license_concluded_prov
+    return license_name, license_concluded, license_prov
 
 
 def _parse_poetry_authors(authors: list[Any]) -> list[dict[str, str]]:

--- a/src/pitloom/extract/pyproject.py
+++ b/src/pitloom/extract/pyproject.py
@@ -20,12 +20,12 @@ from pyproject_metadata import StandardMetadata
 
 from pitloom.core.config import PitloomConfig, _read_pitloom_config
 from pitloom.core.models import normalize_dependency_specifier
-from pitloom.core.project import ProjectMetadata
+from pitloom.core.project import ProjectMetadata, merge_project_metadata
 from pitloom.extract._license import (
     _looks_like_spdx_license_expression,
     _looks_like_spdx_license_id,
-    detect_independent_license,
     detect_license_for_project,
+    resolve_license_concluded,
 )
 from pitloom.extract.poetry import extract_poetry_metadata
 
@@ -73,7 +73,7 @@ def read_pyproject(pyproject_path: Path) -> tuple[ProjectMetadata, PitloomConfig
 
     if not project_data or not name:
         # No [project] section (or no name) -- try [tool.poetry] as primary source.
-        poetry_meta = _try_read_poetry(data)
+        poetry_meta = _try_read_poetry(data, pyproject_path.parent)
         if poetry_meta is not None:
             return poetry_meta, pitloom_config
         license_name, license_prov = detect_license_for_project(pyproject_path.parent)
@@ -117,17 +117,15 @@ def read_pyproject(pyproject_path: Path) -> tuple[ProjectMetadata, PitloomConfig
 
     license_name, license_prov = _extract_and_detect_license(std, pyproject_path.parent)
 
-    # G2: when project.license declares a value, independently scan the
-    # project directory (ignoring that declared value) for a second opinion
-    # to compare it against -- without this, a declared value that already
-    # looks like a valid SPDX id short-circuits before the LICENSE file is
-    # ever read, so there would be nothing to disagree with.
-    license_concluded: str | None = None
-    license_concluded_prov: str | None = None
-    if std.license:
-        license_concluded, license_concluded_prov = detect_independent_license(
-            pyproject_path.parent
-        )
+    # G2: independently scan the project directory for a second opinion to
+    # compare the declared value against, via the shared resolver every
+    # project-metadata extractor must call (see its docstring) -- without
+    # this, a declared value that already looks like a valid SPDX id would
+    # short-circuit before the LICENSE file is ever read, so there would be
+    # nothing to disagree with.
+    license_concluded, license_concluded_prov = resolve_license_concluded(
+        bool(std.license), pyproject_path.parent
+    )
 
     provenance = _build_provenance(
         data.get("project", {}), version_source, license_prov
@@ -151,9 +149,9 @@ def read_pyproject(pyproject_path: Path) -> tuple[ProjectMetadata, PitloomConfig
     )
 
     # Fill any remaining gaps from [tool.poetry] (project fields win).
-    poetry_meta = _try_read_poetry(data)
+    poetry_meta = _try_read_poetry(data, pyproject_path.parent)
     if poetry_meta is not None:
-        metadata = _merge_with_poetry(metadata, poetry_meta)
+        metadata = merge_project_metadata(metadata, poetry_meta)
 
     return metadata, pitloom_config
 
@@ -381,45 +379,12 @@ def _read_version_from_file(file_path: Path) -> str | None:
 
 def _try_read_poetry(
     data: dict[str, Any],
+    project_dir: Path,
 ) -> ProjectMetadata | None:
     """Return poetry metadata when ``[tool.poetry]`` is present, else ``None``."""
     if not data.get("tool", {}).get("poetry"):
         return None
     try:
-        return extract_poetry_metadata(data)
+        return extract_poetry_metadata(data, project_dir)
     except (ValueError, KeyError):
         return None
-
-
-def _merge_with_poetry(
-    primary: ProjectMetadata,
-    secondary: ProjectMetadata,
-) -> ProjectMetadata:
-    """Return *primary* with empty/falsy fields filled from *secondary*.
-
-    ``primary`` is always the ``[project]`` metadata; ``secondary`` is the
-    ``[tool.poetry]`` metadata.  Provenance entries are merged with primary
-    entries winning on key conflicts.
-    """
-
-    def _pick(p: Any, s: Any) -> Any:
-        return p if p else s
-
-    return ProjectMetadata(
-        name=primary.name,
-        version=_pick(primary.version, secondary.version),
-        description=_pick(primary.description, secondary.description),
-        readme=_pick(primary.readme, secondary.readme),
-        requires_python=_pick(primary.requires_python, secondary.requires_python),
-        license_name=_pick(primary.license_name, secondary.license_name),
-        # license_concluded is independent-directory detection, computed only
-        # for [project]-section metadata (primary) -- [tool.poetry] never
-        # sets it, so just carry primary's value through unchanged.
-        license_concluded=primary.license_concluded,
-        keywords=_pick(primary.keywords, secondary.keywords),
-        authors=_pick(primary.authors, secondary.authors),
-        urls=_pick(primary.urls, secondary.urls),
-        dependencies=_pick(primary.dependencies, secondary.dependencies),
-        provenance={**secondary.provenance, **primary.provenance},
-        files=_pick(primary.files, secondary.files),
-    )

--- a/src/pitloom/extract/pyproject.py
+++ b/src/pitloom/extract/pyproject.py
@@ -24,6 +24,7 @@ from pitloom.core.project import ProjectMetadata
 from pitloom.extract._license import (
     _looks_like_spdx_license_expression,
     _looks_like_spdx_license_id,
+    detect_independent_license,
     detect_license_for_project,
 )
 from pitloom.extract.poetry import extract_poetry_metadata
@@ -116,6 +117,24 @@ def read_pyproject(pyproject_path: Path) -> tuple[ProjectMetadata, PitloomConfig
 
     license_name, license_prov = _extract_and_detect_license(std, pyproject_path.parent)
 
+    # G2: when project.license declares a value, independently scan the
+    # project directory (ignoring that declared value) for a second opinion
+    # to compare it against -- without this, a declared value that already
+    # looks like a valid SPDX id short-circuits before the LICENSE file is
+    # ever read, so there would be nothing to disagree with.
+    license_concluded: str | None = None
+    license_concluded_prov: str | None = None
+    if std.license:
+        license_concluded, license_concluded_prov = detect_independent_license(
+            pyproject_path.parent
+        )
+
+    provenance = _build_provenance(
+        data.get("project", {}), version_source, license_prov
+    )
+    if license_concluded and license_concluded_prov:
+        provenance["license_concluded"] = license_concluded_prov
+
     metadata = ProjectMetadata(
         name=std.name,
         version=str(std.version) if std.version else None,
@@ -123,13 +142,12 @@ def read_pyproject(pyproject_path: Path) -> tuple[ProjectMetadata, PitloomConfig
         readme=_extract_readme(std, readme_override),
         requires_python=str(std.requires_python) if std.requires_python else None,
         license_name=license_name,
+        license_concluded=license_concluded,
         keywords=std.keywords or [],
         authors=_extract_authors(std),
         urls=std.urls or {},
         dependencies=[normalize_dependency_specifier(str(d)) for d in std.dependencies],
-        provenance=_build_provenance(
-            data.get("project", {}), version_source, license_prov
-        ),
+        provenance=provenance,
     )
 
     # Fill any remaining gaps from [tool.poetry] (project fields win).
@@ -394,6 +412,10 @@ def _merge_with_poetry(
         readme=_pick(primary.readme, secondary.readme),
         requires_python=_pick(primary.requires_python, secondary.requires_python),
         license_name=_pick(primary.license_name, secondary.license_name),
+        # license_concluded is independent-directory detection, computed only
+        # for [project]-section metadata (primary) -- [tool.poetry] never
+        # sets it, so just carry primary's value through unchanged.
+        license_concluded=primary.license_concluded,
         keywords=_pick(primary.keywords, secondary.keywords),
         authors=_pick(primary.authors, secondary.authors),
         urls=_pick(primary.urls, secondary.urls),

--- a/src/pitloom/extract/setuptools.py
+++ b/src/pitloom/extract/setuptools.py
@@ -16,7 +16,7 @@ When multiple sources are present, fields are merged with this priority order
 
 1. ``pyproject.toml [project]`` -- handled upstream by
    :func:`~pitloom.extract.pyproject.read_pyproject`; merged via
-   :func:`merge_metadata` by the assembler.
+   :func:`~pitloom.core.project.merge_project_metadata` by the assembler.
 2. ``setup.cfg [metadata]`` / ``[options]``
 3. ``setup.py`` ``setup()`` keyword arguments (AST-extracted literals only)
 
@@ -50,7 +50,11 @@ from typing import Any
 
 from pitloom.core.config import PitloomConfig
 from pitloom.core.creation import Creator, Tool
-from pitloom.core.project import ProjectMetadata
+from pitloom.core.project import ProjectMetadata, merge_project_metadata
+from pitloom.extract._license import (
+    detect_license_for_project,
+    resolve_license_concluded,
+)
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -156,16 +160,46 @@ def read_setuptools(project_dir: Path) -> tuple[ProjectMetadata, PitloomConfig]:
         )
 
     if cfg_metadata is not None and py_metadata is not None:
-        return merge_metadata(cfg_metadata, py_metadata), cfg_config
+        metadata = merge_project_metadata(cfg_metadata, py_metadata)
+    elif cfg_metadata is not None:
+        metadata = cfg_metadata
+    else:
+        # Only setup.py succeeded -- the branches above already ruled out
+        # "both None" and "cfg_metadata set", so py_metadata must be set here.
+        if py_metadata is None:
+            raise RuntimeError("unreachable: py_metadata must be set here")
+        metadata = py_metadata
+        cfg_config = PitloomConfig()
 
-    if cfg_metadata is not None:
-        return cfg_metadata, cfg_config
+    metadata = _resolve_setuptools_license(metadata, project_dir)
+    return metadata, cfg_config
 
-    # Only setup.py succeeded -- the branches above already ruled out
-    # "both None" and "cfg_metadata set", so py_metadata must be set here.
-    if py_metadata is None:
-        raise RuntimeError("unreachable: py_metadata must be set here")
-    return py_metadata, PitloomConfig()
+
+def _resolve_setuptools_license(
+    metadata: ProjectMetadata, project_dir: Path
+) -> ProjectMetadata:
+    """Apply the same license resolution every project extractor uses,
+    to the merged setup.cfg/setup.py result: fall back to directory
+    detection when neither declared a license, and independently scan for
+    a second opinion (G2) when one did -- previously this path only ever
+    read the ``license =``/``license=`` field verbatim, with no fallback
+    detection and no G2 conflict check at all. See
+    :func:`~pitloom.extract._license.resolve_license_concluded`'s docstring
+    for why every extractor must call it.
+    """
+    if metadata.license_name:
+        concluded, concluded_prov = resolve_license_concluded(True, project_dir)
+        if concluded and concluded_prov:
+            metadata.license_concluded = concluded
+            metadata.provenance["license_concluded"] = concluded_prov
+        return metadata
+
+    detected, detected_prov = detect_license_for_project(project_dir)
+    if detected:
+        metadata.license_name = detected
+        if detected_prov:
+            metadata.provenance["license"] = detected_prov
+    return metadata
 
 
 # pylint: disable=too-many-locals
@@ -415,56 +449,6 @@ def read_setup_py(
         provenance=prov,
     )
     return project_metadata, PitloomConfig()
-
-
-def merge_metadata(
-    primary: ProjectMetadata,
-    secondary: ProjectMetadata,
-) -> ProjectMetadata:
-    """Merge two :class:`~pitloom.core.project.ProjectMetadata` objects.
-
-    The primary takes precedence field-by-field: for each attribute, the
-    primary value is used when non-empty/truthy; otherwise the secondary
-    value fills the gap.  The primary ``name`` is always kept.
-
-    Provenance entries from both sources are merged, with primary
-    provenance overriding secondary on key conflicts.
-
-    Typical usage::
-
-        # pyproject.toml wins; setup.cfg fills missing fields
-        merged = merge_metadata(pyproject_meta, setup_cfg_meta)
-
-        # setup.cfg wins over setup.py
-        merged = merge_metadata(cfg_meta, py_meta)
-
-    Args:
-        primary: Higher-priority metadata source.
-        secondary: Lower-priority metadata source used as fallback.
-
-    Returns:
-        A new :class:`~pitloom.core.project.ProjectMetadata` with merged fields.
-    """
-
-    def _pick(p: Any, s: Any) -> Any:
-        return p if p else s
-
-    merged_provenance = {**secondary.provenance, **primary.provenance}
-
-    return ProjectMetadata(
-        name=primary.name,
-        version=_pick(primary.version, secondary.version),
-        description=_pick(primary.description, secondary.description),
-        readme=_pick(primary.readme, secondary.readme),
-        requires_python=_pick(primary.requires_python, secondary.requires_python),
-        license_name=_pick(primary.license_name, secondary.license_name),
-        keywords=_pick(primary.keywords, secondary.keywords),
-        authors=_pick(primary.authors, secondary.authors),
-        urls=_pick(primary.urls, secondary.urls),
-        dependencies=_pick(primary.dependencies, secondary.dependencies),
-        provenance=merged_provenance,
-        files=_pick(primary.files, secondary.files),
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_annotation_provenance.py
+++ b/tests/test_annotation_provenance.py
@@ -17,10 +17,13 @@ from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.assemble.spdx3.provenance import (
     ARTIFACT_METADATA_SCHEMA_URL,
+    CONFLICT_SCHEMA_URL,
     DEFAULT_SCHEMA_ID,
     UNIFICATION_SCHEMA_URL,
+    ConflictCandidate,
     PitloomV1Encoder,
     ProvenanceEncoder,
+    build_conflict_annotation,
     build_provenance_annotation,
     build_provenance_comment,
     build_source_metadata_annotation,
@@ -110,7 +113,7 @@ def test_pitloom_v1_encoder_produces_valid_json_with_schema_marker() -> None:
     encoder = PitloomV1Encoder()
     body = encoder.encode({"name": "Source: pyproject.toml | Field: project.name"})
     parsed = json.loads(body)
-    assert parsed["schema"] == "https://pitloom.dev/provenance/1"
+    assert parsed["schema"] == "https://pitloom.dev/provenance/fields/1"
     assert parsed["fields"]["name"] == {
         "source": "pyproject.toml",
         "location": "project.name",
@@ -605,11 +608,83 @@ def test_build_unification_annotation_shape_and_determinism() -> None:
     assert ann.statement is not None
     statement = json.loads(ann.statement)
     assert statement["schema"] == UNIFICATION_SCHEMA_URL
-    assert statement["event"] == "unification"
+    assert statement["kind"] == "unification"
     assert statement["criterion"] == "sha256"
     # Lists are sorted for byte-stability.
     assert statement["unified"] == ["urn:doc#File-4", "urn:doc#File-9"]
     assert statement["fragments"] == ["a/frag.json", "b/frag.json"]
+
+
+# ---------------------------------------------------------------------------
+# build_conflict_annotation (G2)
+# ---------------------------------------------------------------------------
+
+
+def test_build_conflict_annotation_shape_and_determinism() -> None:
+    ci = _make_ci()
+    candidates: list[ConflictCandidate] = [
+        {
+            "value": "MIT",
+            "role": "declared",
+            "source": "Source: pyproject.toml | Field: project.license",
+            "ref": "urn:doc#License-1",
+        },
+        {
+            "value": "Apache-2.0",
+            "role": "detected",
+            "source": "Source: LICENSE | Method: licenseid_detection | Tool: licenseid==0.3.0",
+            "ref": "urn:doc#License-2",
+        },
+    ]
+    ann = build_conflict_annotation(
+        subject_spdx_id="urn:doc#Package-1",
+        field="license",
+        candidates=candidates,
+        creation_info=ci,
+        annotation_spdx_id="urn:doc#Annotation-conflict-1",
+    )
+    assert ann.spdxId == "urn:doc#Annotation-conflict-1"
+    assert ann.contentType == "application/json"
+    assert ann.annotationType == spdx3.AnnotationType.other
+    assert ann.subject == "urn:doc#Package-1"
+    assert ann.statement is not None
+    statement = json.loads(ann.statement)
+    assert statement["schema"] == CONFLICT_SCHEMA_URL
+    assert statement["kind"] == "conflict"
+    assert statement["field"] == "license"
+    assert statement["candidates"] == candidates
+
+    # Byte-stable across two builds with the same input.
+    ann2 = build_conflict_annotation(
+        subject_spdx_id="urn:doc#Package-1",
+        field="license",
+        candidates=candidates,
+        creation_info=ci,
+        annotation_spdx_id="urn:doc#Annotation-conflict-1",
+    )
+    assert ann.statement == ann2.statement
+
+
+def test_build_conflict_annotation_generic_field_not_license_specific() -> None:
+    """The mechanism is field-agnostic -- license is only the first field
+    wired up to it, per the G2 design (any field's multi-source disagreement
+    can reuse the same schema)."""
+    ci = _make_ci()
+    candidates: list[ConflictCandidate] = [
+        {"value": "1.0.0", "role": "declared", "source": "Source: pyproject.toml"},
+        {"value": "1.0.1", "role": "detected", "source": "Source: build metadata"},
+    ]
+    ann = build_conflict_annotation(
+        subject_spdx_id="urn:doc#Package-1",
+        field="version",
+        candidates=candidates,
+        creation_info=ci,
+        annotation_spdx_id="urn:doc#Annotation-conflict-2",
+    )
+    statement = json.loads(ann.statement)
+    assert statement["field"] == "version"
+    # "ref" is optional per candidate -- absent here, not required.
+    assert "ref" not in statement["candidates"][0]
 
 
 # ---------------------------------------------------------------------------
@@ -632,6 +707,7 @@ def test_build_source_metadata_annotation_embeds_verbatim() -> None:
     assert ann.statement is not None
     statement = json.loads(ann.statement)
     assert statement["schema"] == ARTIFACT_METADATA_SCHEMA_URL
+    assert statement["kind"] == "artifact-metadata"
     assert statement["format"] == "gguf"
     # native value types preserved; bytes base64-encoded.
     assert statement["metadata"]["block_count"] == 32

--- a/tests/test_annotation_provenance.py
+++ b/tests/test_annotation_provenance.py
@@ -632,7 +632,9 @@ def test_build_conflict_annotation_shape_and_determinism() -> None:
         {
             "value": "Apache-2.0",
             "role": "detected",
-            "source": "Source: LICENSE | Method: licenseid_detection | Tool: licenseid==0.3.0",
+            "source": (
+                "Source: LICENSE | Method: licenseid_detection | Tool: licenseid==0.3.0"
+            ),
             "ref": "urn:doc#License-2",
         },
     ]
@@ -681,6 +683,7 @@ def test_build_conflict_annotation_generic_field_not_license_specific() -> None:
         creation_info=ci,
         annotation_spdx_id="urn:doc#Annotation-conflict-2",
     )
+    assert ann.statement is not None
     statement = json.loads(ann.statement)
     assert statement["field"] == "version"
     # "ref" is optional per candidate -- absent here, not required.

--- a/tests/test_core_project.py
+++ b/tests/test_core_project.py
@@ -1,0 +1,142 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for pitloom.core.project: ProjectMetadata and merge_project_metadata()."""
+
+import tempfile
+from pathlib import Path
+
+from pitloom.core.project import ProjectMetadata, merge_project_metadata
+from pitloom.extract._license import resolve_license_concluded
+
+# ---------------------------------------------------------------------------
+# merge_project_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_merge_project_metadata_primary_wins() -> None:
+    """A truthy primary value is kept, even when secondary also has one."""
+    primary = ProjectMetadata(name="primary-pkg", version="1.0.0")
+    secondary = ProjectMetadata(name="secondary-pkg", version="2.0.0")
+    merged = merge_project_metadata(primary, secondary)
+    assert merged.version == "1.0.0"
+
+
+def test_merge_project_metadata_secondary_fills_gaps() -> None:
+    """A falsy primary field (None/empty) is filled from secondary."""
+    primary = ProjectMetadata(name="pkg", version="1.0.0", description=None)
+    secondary = ProjectMetadata(
+        name="pkg", version="9.9.9", description="from secondary"
+    )
+    merged = merge_project_metadata(primary, secondary)
+    assert merged.description == "from secondary"
+    # Truthy primary field is untouched even though this asserts the same gap-fill call.
+    assert merged.version == "1.0.0"
+
+
+def test_merge_project_metadata_name_always_primary() -> None:
+    """``name`` is special-cased: always primary's, even if empty -- never
+    silently filled in from a secondary/fallback source."""
+    primary = ProjectMetadata(name="")
+    secondary = ProjectMetadata(name="secondary-name")
+    merged = merge_project_metadata(primary, secondary)
+    assert merged.name == ""
+
+
+def test_merge_project_metadata_provenance_merged() -> None:
+    """provenance dicts are merged, primary's entries winning on key conflict."""
+    primary = ProjectMetadata(
+        name="pkg", provenance={"name": "Source: primary", "version": "Source: primary"}
+    )
+    secondary = ProjectMetadata(
+        name="pkg",
+        provenance={"version": "Source: secondary", "description": "Source: secondary"},
+    )
+    merged = merge_project_metadata(primary, secondary)
+    assert merged.provenance == {
+        "name": "Source: primary",
+        "version": "Source: primary",
+        "description": "Source: secondary",
+    }
+
+
+def test_merge_project_metadata_empty_lists_filled_from_secondary() -> None:
+    """An empty list/dict counts as falsy and is filled from secondary,
+    same rule as scalar fields."""
+    primary = ProjectMetadata(name="pkg", keywords=[], urls={}, dependencies=[])
+    secondary = ProjectMetadata(
+        name="pkg",
+        keywords=["a", "b"],
+        urls={"Homepage": "https://example.com"},
+        dependencies=["requests>=2.0"],
+    )
+    merged = merge_project_metadata(primary, secondary)
+    assert merged.keywords == ["a", "b"]
+    assert merged.urls == {"Homepage": "https://example.com"}
+    assert merged.dependencies == ["requests>=2.0"]
+
+
+def test_merge_project_metadata_license_concluded_preserved() -> None:
+    """Regression for the specific bug this function was introduced to fix:
+    a newly added field (license_concluded, for G2) must merge with the
+    same default rule as every other field automatically -- no call site
+    needs updating when the schema grows. Before this generic merge
+    replaced the two hand-listed implementations, license_concluded was
+    missing from one of them and silently dropped."""
+    primary = ProjectMetadata(name="pkg", license_name="MIT", license_concluded=None)
+    secondary = ProjectMetadata(
+        name="pkg", license_name="MIT", license_concluded="Apache-2.0"
+    )
+    merged = merge_project_metadata(primary, secondary)
+    assert merged.license_concluded == "Apache-2.0"
+
+
+def test_merge_project_metadata_does_not_mutate_inputs() -> None:
+    """Neither *primary* nor *secondary* is modified by the merge."""
+    primary = ProjectMetadata(name="pkg", provenance={"name": "Source: primary"})
+    secondary = ProjectMetadata(
+        name="pkg", version="2.0.0", provenance={"version": "Source: secondary"}
+    )
+    merge_project_metadata(primary, secondary)
+    assert primary.version is None
+    assert primary.provenance == {"name": "Source: primary"}
+    assert secondary.provenance == {"version": "Source: secondary"}
+
+
+# ---------------------------------------------------------------------------
+# resolve_license_concluded (the shared G2 entry point every extractor calls)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_license_concluded_no_declared_value_skips_scan() -> None:
+    """When the caller has no declared value at all, there's nothing to
+    compare a second opinion against -- no directory scan is performed."""
+    with tempfile.TemporaryDirectory() as d:
+        tmp_path = Path(d)
+        (tmp_path / "LICENSE").write_text("MIT", encoding="utf-8")
+        concluded, concluded_prov = resolve_license_concluded(False, tmp_path)
+    assert concluded is None
+    assert concluded_prov is None
+
+
+def test_resolve_license_concluded_declared_value_scans_directory() -> None:
+    """When the caller *does* have a declared value, the directory is
+    independently scanned for a second opinion."""
+    with tempfile.TemporaryDirectory() as d:
+        tmp_path = Path(d)
+        (tmp_path / "LICENSE").write_text("MIT", encoding="utf-8")
+        concluded, concluded_prov = resolve_license_concluded(True, tmp_path)
+    assert concluded == "MIT"
+    assert concluded_prov is not None
+    assert "LICENSE" in concluded_prov
+
+
+def test_resolve_license_concluded_no_license_file_present() -> None:
+    """A declared value with nothing in the directory to compare against
+    yields no second opinion, not a spurious conflict."""
+    with tempfile.TemporaryDirectory() as d:
+        concluded, concluded_prov = resolve_license_concluded(True, Path(d))
+    assert concluded is None
+    assert concluded_prov is None

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1672,3 +1672,181 @@ def test_build_model_base_model_lineage() -> None:
     ]
     assert len(lineage_rels) == 1
     assert lineage_rels[0].get("comment") == "base_model_relation:finetune"
+
+
+# ---------------------------------------------------------------------------
+# G2: declared-vs-detected license conflict, main project package
+# ---------------------------------------------------------------------------
+
+
+def _license_relationships(
+    graph: list[dict[str, Any]], subject_id: str
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    rels = [e for e in graph if e.get("type") == "Relationship"]
+    declared = [
+        r
+        for r in rels
+        if r.get("relationshipType") == "hasDeclaredLicense"
+        and r.get("from") == subject_id
+    ]
+    concluded = [
+        r
+        for r in rels
+        if r.get("relationshipType") == "hasConcludedLicense"
+        and r.get("from") == subject_id
+    ]
+    return declared, concluded
+
+
+def test_generate_project_sbom_license_conflict_end_to_end() -> None:
+    """Declared MIT + an independently-detected Apache-2.0 LICENSE file:
+    both hasDeclaredLicense and hasConcludedLicense are emitted (pointing at
+    two distinct license elements), plus one G2 conflict Annotation on the
+    main package."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+license = "MIT"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        (tmppath / "pyproject.toml").write_text(pyproject_content)
+        (tmppath / "LICENSE").write_text("Apache License\nVersion 2.0" + "x" * 200)
+
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="Apache-2.0",
+        ):
+            sbom_json = generate_project_sbom(tmppath)
+
+        graph = json.loads(sbom_json)["@graph"]
+        main_package = next(
+            e
+            for e in graph
+            if e.get("type") == "software_Package" and e["name"] == "test-package"
+        )
+        declared, concluded = _license_relationships(graph, main_package["spdxId"])
+        assert len(declared) == 1
+        assert len(concluded) == 1
+
+        license_elems = {
+            e["spdxId"]: e
+            for e in graph
+            if e.get("type") == "simplelicensing_SimpleLicensingText"
+        }
+        declared_license = license_elems[declared[0]["to"][0]]
+        concluded_license = license_elems[concluded[0]["to"][0]]
+        assert declared_license["simplelicensing_licenseText"] == "MIT"
+        assert concluded_license["simplelicensing_licenseText"] == "Apache-2.0"
+        assert declared_license["spdxId"] != concluded_license["spdxId"]
+
+        annotations = [e for e in graph if e.get("type") == "Annotation"]
+        conflict_anns = [
+            a
+            for a in annotations
+            if a.get("subject") == main_package["spdxId"]
+            and json.loads(a["statement"]).get("kind") == "conflict"
+        ]
+        assert len(conflict_anns) == 1
+        statement = json.loads(conflict_anns[0]["statement"])
+        assert statement["field"] == "license"
+        roles = {c["role"] for c in statement["candidates"]}
+        assert roles == {"declared", "detected"}
+
+
+def test_generate_project_sbom_license_agrees_no_conflict_annotation() -> None:
+    """Declared and independently-detected license agree: both relationships
+    still emitted, pointing at the *same* element, but no conflict Annotation."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+license = "MIT"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        (tmppath / "pyproject.toml").write_text(pyproject_content)
+        (tmppath / "LICENSE").write_text("MIT License\n\nPermission" + "x" * 200)
+
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="MIT",
+        ):
+            sbom_json = generate_project_sbom(tmppath)
+
+        graph = json.loads(sbom_json)["@graph"]
+        main_package = next(
+            e
+            for e in graph
+            if e.get("type") == "software_Package" and e["name"] == "test-package"
+        )
+        declared, concluded = _license_relationships(graph, main_package["spdxId"])
+        assert len(declared) == 1
+        assert len(concluded) == 1
+        assert declared[0]["to"][0] == concluded[0]["to"][0]
+
+        annotations = [e for e in graph if e.get("type") == "Annotation"]
+        conflict_anns = [
+            a
+            for a in annotations
+            if json.loads(a["statement"]).get("kind") == "conflict"
+        ]
+        assert conflict_anns == []
+
+
+def test_generate_project_sbom_license_declared_only_no_license_file() -> None:
+    """Declared license, no LICENSE file in the project: unchanged
+    single-relationship behavior (regression check against pre-G2 output)."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+license = "MIT"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        (tmppath / "pyproject.toml").write_text(pyproject_content)
+
+        sbom_json = generate_project_sbom(tmppath)
+
+        graph = json.loads(sbom_json)["@graph"]
+        main_package = next(
+            e
+            for e in graph
+            if e.get("type") == "software_Package" and e["name"] == "test-package"
+        )
+        declared, concluded = _license_relationships(graph, main_package["spdxId"])
+        assert len(declared) == 1
+        assert len(concluded) == 0
+
+
+def test_generate_project_sbom_license_conflict_byte_identical_across_runs() -> None:
+    """Determinism: two independent generations from the same input produce
+    byte-identical output, including the new conflict Annotation."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+license = "MIT"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        (tmppath / "pyproject.toml").write_text(pyproject_content)
+        (tmppath / "LICENSE").write_text("Apache License\nVersion 2.0" + "x" * 200)
+
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="Apache-2.0",
+        ):
+            creation_metadata = CreationMetadata(
+                creation_datetime="2026-01-01T00:00:00Z"
+            )
+            sbom_json_1 = generate_project_sbom(
+                tmppath, creation_metadata=creation_metadata
+            )
+            sbom_json_2 = generate_project_sbom(
+                tmppath, creation_metadata=creation_metadata
+            )
+
+        assert sbom_json_1 == sbom_json_2

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1786,6 +1786,56 @@ license = "MIT"
         assert len(concluded) == 1
         assert declared[0]["to"][0] == concluded[0]["to"][0]
 
+
+def test_generate_project_sbom_license_case_only_difference_not_a_conflict() -> None:
+    """Regression: a declared `license = "mit"` (valid but non-canonically
+    cased -- kept verbatim since Pitloom never rewrites a bare SPDX id) and
+    an independently-detected canonical "MIT" from the LICENSE file must be
+    recognized as the *same* license, not flagged as G2 conflict. Before the
+    canonicalization fix, this produced a spurious conflict Annotation and
+    two separate license elements for what is one license."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+license = "mit"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        (tmppath / "pyproject.toml").write_text(pyproject_content)
+        (tmppath / "LICENSE").write_text("MIT License\n\nPermission" + "x" * 200)
+
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="MIT",
+        ):
+            sbom_json = generate_project_sbom(tmppath)
+
+        graph = json.loads(sbom_json)["@graph"]
+        main_package = next(
+            e
+            for e in graph
+            if e.get("type") == "software_Package" and e["name"] == "test-package"
+        )
+        declared, concluded = _license_relationships(graph, main_package["spdxId"])
+        assert len(declared) == 1
+        assert len(concluded) == 1
+        assert declared[0]["to"][0] == concluded[0]["to"][0]
+
+        license_elems = [
+            e for e in graph if e.get("type") == "simplelicensing_SimpleLicensingText"
+        ]
+        assert len(license_elems) == 1
+        assert license_elems[0]["simplelicensing_licenseText"] == "MIT"
+
+        annotations = [e for e in graph if e.get("type") == "Annotation"]
+        conflict_anns = [
+            a
+            for a in annotations
+            if json.loads(a["statement"]).get("kind") == "conflict"
+        ]
+        assert conflict_anns == []
+
         annotations = [e for e in graph if e.get("type") == "Annotation"]
         conflict_anns = [
             a

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1755,6 +1755,54 @@ license = "MIT"
         assert roles == {"declared", "detected"}
 
 
+def test_generate_project_sbom_license_conflict_flags_declared_normalization() -> None:
+    """Declared "mit" (valid but non-canonically cased) + a genuinely
+    conflicting detected Apache-2.0: the conflict Annotation's declared
+    candidate ``source`` is flagged with the raw value normalize_license_
+    expression() rewrote it from, plus the py-spdx-license version that did
+    it -- wiring the previously-dead _PY_SPDX_LICENSE_VERSION into actual
+    output (not just the case-only-agreement path, which never reaches the
+    conflict branch at all)."""
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+license = "mit"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        (tmppath / "pyproject.toml").write_text(pyproject_content)
+        (tmppath / "LICENSE").write_text("Apache License\nVersion 2.0" + "x" * 200)
+
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="Apache-2.0",
+        ):
+            sbom_json = generate_project_sbom(tmppath)
+
+        graph = json.loads(sbom_json)["@graph"]
+        main_package = next(
+            e
+            for e in graph
+            if e.get("type") == "software_Package" and e["name"] == "test-package"
+        )
+        annotations = [e for e in graph if e.get("type") == "Annotation"]
+        conflict_anns = [
+            a
+            for a in annotations
+            if a.get("subject") == main_package["spdxId"]
+            and json.loads(a["statement"]).get("kind") == "conflict"
+        ]
+        assert len(conflict_anns) == 1
+        statement = json.loads(conflict_anns[0]["statement"])
+        declared_candidate = next(
+            c for c in statement["candidates"] if c["role"] == "declared"
+        )
+        assert declared_candidate["value"] == "MIT"
+        assert "Normalized-From: mit" in declared_candidate["source"]
+        assert "Normalizer: py-spdx-license==" in declared_candidate["source"]
+
+
 def test_generate_project_sbom_license_agrees_no_conflict_annotation() -> None:
     """Declared and independently-detected license agree: both relationships
     still emitted, pointing at the *same* element, but no conflict Annotation."""

--- a/tests/test_hatch_hook.py
+++ b/tests/test_hatch_hook.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 import rfc8785
@@ -860,6 +861,80 @@ def test_metadata_from_hatchling_matches_read_pyproject_for_noncanonical_name() 
         ) == compute_doc_uuid(
             cli_meta.name, cli_meta.version or "x", cli_meta.dependencies
         )
+
+
+CONFLICT_PYPROJECT = """\
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "testpkg"
+version = "1.0.0"
+license = "MIT"
+"""
+
+
+def test_metadata_from_hatchling_matches_read_pyproject_for_license_conflict() -> None:
+    """CLI and hook paths must agree on G2 when the declared license and an
+    independently-detected LICENSE file disagree.
+
+    Regression guard for the systemic gap ``resolve_license_concluded()``
+    exists to close: the Hatchling build-hook path
+    (:func:`~pitloom.extract.hatchling.metadata_from_hatchling`) originally
+    called :func:`~pitloom.extract._license.detect_license_for_project`
+    directly and never ran the independent directory scan at all, so G2
+    only ever fired via the CLI's
+    :func:`~pitloom.extract.pyproject.read_pyproject`. Both paths must now
+    resolve the same ``license_concluded`` value for the same project.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        write_pyproject(tmp_path, CONFLICT_PYPROJECT)
+        (tmp_path / "LICENSE").write_text(
+            "Apache License\nVersion 2.0" + "x" * 200, encoding="utf-8"
+        )
+
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="Apache-2.0",
+        ):
+            cli_meta, _ = read_pyproject(tmp_path / "pyproject.toml")
+            hatch_pm = hatchling_metadata_core.ProjectMetadata(
+                str(tmp_path), PluginManager()
+            )
+            hook_meta = metadata_from_hatchling(hatch_pm, tmp_path)
+
+        assert cli_meta.license_name == "MIT"
+        assert hook_meta.license_name == "MIT"
+        assert cli_meta.license_concluded == "Apache-2.0"
+        assert hook_meta.license_concluded == cli_meta.license_concluded
+
+
+def test_metadata_from_hatchling_matches_read_pyproject_for_license_agreement() -> None:
+    """Same as above, but declared and detected agree: both paths must
+    still populate ``license_concluded`` (equal to the declared value),
+    not just leave it unset -- G2 records both sides regardless of
+    agreement."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        write_pyproject(tmp_path, CONFLICT_PYPROJECT)
+        (tmp_path / "LICENSE").write_text(
+            "MIT License\n\nPermission" + "x" * 200, encoding="utf-8"
+        )
+
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="MIT",
+        ):
+            cli_meta, _ = read_pyproject(tmp_path / "pyproject.toml")
+            hatch_pm = hatchling_metadata_core.ProjectMetadata(
+                str(tmp_path), PluginManager()
+            )
+            hook_meta = metadata_from_hatchling(hatch_pm, tmp_path)
+
+        assert cli_meta.license_concluded == "MIT"
+        assert hook_meta.license_concluded == "MIT"
 
 
 def test_metadata_from_hatchling_maps_urls() -> None:

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import pytest
 
 from pitloom.extract._license import (
+    _PY_SPDX_LICENSE_VERSION,
     _looks_like_spdx_license_expression,
     _looks_like_spdx_license_id,
     _read_license_from_citation_cff,
@@ -24,6 +25,7 @@ from pitloom.extract._license import (
     detect_license_from_text,
     find_license_files,
     normalize_license_expression,
+    tag_license_normalization,
 )
 
 # ---------------------------------------------------------------------------
@@ -649,3 +651,46 @@ def test_normalize_license_expression_keeps_precedence_significant_parens() -> N
     # Parens overriding default precedence are a different expression --
     # must not collapse to the same normalized string as the other two.
     assert significant_parens != no_parens
+
+
+# ---------------------------------------------------------------------------
+# tag_license_normalization
+# ---------------------------------------------------------------------------
+
+
+def test_tag_license_normalization_noop_when_unchanged() -> None:
+    """No normalization happened (raw already canonical): provenance is
+    returned unchanged, nothing to flag."""
+    prov = "Source: pyproject.toml | Field: project.license"
+    assert tag_license_normalization(prov, "MIT", "MIT") == prov
+
+
+def test_tag_license_normalization_flags_casing_change() -> None:
+    """A casing-only rewrite ("mit" -> "MIT") is flagged with the raw value
+    and, when the library is installed, the py-spdx-license version that
+    did the rewrite -- wiring the previously-dead _PY_SPDX_LICENSE_VERSION
+    into actual output."""
+    prov = "Source: pyproject.toml | Field: project.license"
+    tagged = tag_license_normalization(prov, "mit", "MIT")
+    assert tagged.startswith(prov)
+    assert "Normalized-From: mit" in tagged
+    if _PY_SPDX_LICENSE_VERSION is not None:
+        assert f"Normalizer: py-spdx-license=={_PY_SPDX_LICENSE_VERSION}" in tagged
+
+
+def test_tag_license_normalization_flags_compound_dedup() -> None:
+    """A compound-expression dedup ("MIT AND MIT" -> "MIT") is flagged the
+    same way as a bare casing change -- any value rewrite counts."""
+    prov = "Source: LICENSE | Method: licenseid_detection"
+    tagged = tag_license_normalization(prov, "MIT AND MIT", "MIT")
+    assert "Normalized-From: MIT AND MIT" in tagged
+
+
+def test_tag_license_normalization_strips_raw_whitespace() -> None:
+    """*raw* is compared and recorded stripped, matching how callers pass
+    already-``.strip()``-able values (e.g. ``license_id.strip()`` at the
+    deps.py call site)."""
+    prov = "Source: pyproject.toml | Field: project.license"
+    assert tag_license_normalization(prov, "MIT", "MIT") == prov
+    tagged = tag_license_normalization(prov, "  mit  ", "MIT")
+    assert "Normalized-From: mit" in tagged

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -19,6 +19,7 @@ from pitloom.extract._license import (
     _read_license_from_codemeta_json,
     canonicalize_license_id,
     collect_license_candidates,
+    detect_independent_license,
     detect_license_for_project,
     detect_license_from_text,
     find_license_files,
@@ -439,3 +440,74 @@ def test_detect_project_from_license_file_integration() -> None:
             f"Expected SPDX License ID, got: {result_id!r}"
         )
         assert prov is not None and "LICENSE" in prov and "licenseid_detection" in prov
+
+
+# ---------------------------------------------------------------------------
+# detect_independent_license (G2)
+# ---------------------------------------------------------------------------
+
+
+def test_detect_independent_license_ignores_hint_entirely() -> None:
+    """Unlike detect_license_for_project, there is no hint parameter at all --
+    only the project directory is ever consulted."""
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d)
+        (p / "LICENSE").write_text(_MIT_TEXT)
+        result_id, prov = detect_independent_license(p)
+    if result_id is not None:
+        assert _looks_like_spdx_license_id(result_id)
+        assert prov is not None and "LICENSE" in prov
+
+
+def test_detect_independent_license_no_sources_returns_none() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        result_id, prov = detect_independent_license(Path(d))
+    assert result_id is None
+    assert prov is None
+
+
+def test_detect_independent_license_bare_id_no_detection_method() -> None:
+    """A bare SPDX id found via CITATION.cff needs no licenseid detection --
+    no Tool: tag on a value that was just read, not determined."""
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d)
+        (p / "codemeta.json").write_text('{"license": "MIT"}')
+        result_id, prov = detect_independent_license(p)
+    assert result_id == "MIT"
+    assert prov == "Source: codemeta.json | Field: license"
+    assert "Tool:" not in prov
+
+
+def test_detect_independent_license_tags_licenseid_tool_version() -> None:
+    """A licenseid_detection result carries the library version it ran under
+    (G2's detected-role source-recording enhancement) -- reproducible against
+    the exact detector version, not just "licenseid was involved somewhere"."""
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d)
+        (p / "LICENSE").write_text(_MIT_TEXT)
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="MIT",
+        ):
+            result_id, prov = detect_independent_license(p)
+    assert result_id == "MIT"
+    assert prov is not None
+    assert "Method: licenseid_detection" in prov
+    assert "| Tool: licenseid==" in prov
+
+
+def test_detect_license_for_project_delegates_directory_scan() -> None:
+    """detect_license_for_project's own directory-search fallback now goes
+    through detect_independent_license -- same result, same Tool: tagging,
+    confirming the extraction didn't change external behavior."""
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d)
+        (p / "LICENSE").write_text(_MIT_TEXT)
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="MIT",
+        ):
+            via_project, prov_project = detect_license_for_project(p)
+            via_independent, prov_independent = detect_independent_license(p)
+    assert via_project == via_independent == "MIT"
+    assert prov_project == prov_independent

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -23,6 +23,7 @@ from pitloom.extract._license import (
     detect_license_for_project,
     detect_license_from_text,
     find_license_files,
+    normalize_license_expression,
 )
 
 # ---------------------------------------------------------------------------
@@ -511,3 +512,140 @@ def test_detect_license_for_project_delegates_directory_scan() -> None:
             via_independent, prov_independent = detect_independent_license(p)
     assert via_project == via_independent == "MIT"
     assert prov_project == prov_independent
+
+
+# ---------------------------------------------------------------------------
+# normalize_license_expression (G2 canonicalization; independent of the
+# conflict-resolution machinery in deps.py -- these test the pure function).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("mit", "MIT"),
+        ("MIT", "MIT"),
+        ("bsd-3-clause", "BSD-3-Clause"),
+        ("BSD-3-Clause", "BSD-3-Clause"),
+        # Recognized even though it contains what looks like an operator
+        # substring ("-OR-") -- it's a single, database-known license id,
+        # not a compound expression, so it canonicalizes as a whole token
+        # to the database's own casing (distinct from the *unrecognized*
+        # hyphenated-identifier cases below, which must stay untouched).
+        ("GPL-2.0-OR-LATER", "GPL-2.0-or-later"),
+        ("gpl-2.0-or-later", "GPL-2.0-or-later"),
+    ],
+)
+def test_normalize_license_expression_bare_id_casing(raw: str, expected: str) -> None:
+    """A bare id is canonicalized to its recognized SPDX casing, same as
+    canonicalize_license_id -- normalize_license_expression must not regress
+    this for the simple, non-compound case."""
+    assert normalize_license_expression(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["MIT AND MIT", "(MIT AND MIT)", "MIT and MIT", "(mit and mit)", "mit AND mit"],
+)
+def test_normalize_license_expression_dedups_conjunction(raw: str) -> None:
+    """A license AND'd with itself -- however cased, parenthesized, or
+    spelled -- normalizes to the single license, not a compound string."""
+    assert normalize_license_expression(raw) == "MIT"
+
+
+def test_normalize_license_expression_canonical_ordering_is_order_independent() -> None:
+    """A OR B and B OR A are the same license choice -- both orderings must
+    normalize to one identical string, so a G2 comparison between them
+    (candidates entered in different orders from different sources) doesn't
+    misreport a conflict."""
+    a = normalize_license_expression("MIT OR Apache-2.0")
+    b = normalize_license_expression("Apache-2.0 OR MIT")
+    assert a == b
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "GPL-2.0-or-later",  # recognized id, but already canonical -- no-op
+        "LicenseRef-my-or-license",  # unrecognized -- must pass through verbatim
+        "LicenseRef-and-tool",
+        "LicenseRef-with-exception-name",
+    ],
+)
+def test_normalize_license_expression_never_mangles_hyphenated_identifiers(
+    raw: str,
+) -> None:
+    """The operator-casing preprocessing must never touch and/or/with/not
+    when it's hyphen-glued into an identifier rather than standing alone as
+    its own token -- regression test for the bug caught during design
+    (a naive \\b-word-boundary regex corrupted these into e.g. "-OR-")."""
+    assert normalize_license_expression(raw) == raw
+
+
+def test_normalize_license_expression_unrecognized_value_passes_through() -> None:
+    """A non-SPDX / vendor-specific string that isn't a parseable expression
+    at all is returned unchanged, not mangled or rejected."""
+    assert normalize_license_expression("gemma") == "gemma"
+
+
+def test_normalize_license_expression_malformed_syntax_falls_back_gracefully() -> None:
+    """Genuinely malformed SPDX expression syntax (unbalanced parens) must not
+    raise -- falls back to canonicalize_license_id's own (also
+    graceful-on-failure) behavior rather than propagating a ParseError."""
+    malformed = "((unbalanced"
+    assert normalize_license_expression(malformed) == canonicalize_license_id(malformed)
+
+
+def test_normalize_license_expression_idempotent() -> None:
+    """Normalizing an already-normalized expression returns it unchanged --
+    required for the G2 comparison to be stable (declared side and detected
+    side may each independently call this)."""
+    once = normalize_license_expression("MIT OR Apache-2.0")
+    twice = normalize_license_expression(once)
+    assert once == twice
+
+
+@pytest.mark.parametrize(
+    "without_parens,with_parens",
+    [
+        # Real-world regression source: github.com/aquasecurity/trivy/
+        # discussions/10139 -- Trivy reports the same license expression
+        # with and without a redundant outer paren across scans of the
+        # same package, breaking policy rules that compare against one
+        # fixed string. These are that report's own four example pairs.
+        (
+            "GPL-3.0-or-later WITH GCC-exception-3.1",
+            "(GPL-3.0-or-later WITH GCC-exception-3.1)",
+        ),
+        ("MIT AND GPL-3.0-only", "(MIT AND GPL-3.0-only)"),
+        ("MPL-2.0 AND MIT", "(MPL-2.0 AND MIT)"),
+        ("BSD-3-Clause AND IJG AND Zlib", "(BSD-3-Clause AND IJG AND Zlib)"),
+    ],
+)
+def test_normalize_license_expression_strips_redundant_outer_parens(
+    without_parens: str, with_parens: str
+) -> None:
+    """A paren that doesn't change meaning (wraps an already-unambiguous
+    expression) must normalize identically whether present or not."""
+    assert normalize_license_expression(without_parens) == normalize_license_expression(
+        with_parens
+    )
+
+
+def test_normalize_license_expression_keeps_precedence_significant_parens() -> None:
+    """Unlike the redundant-paren case above, a paren that changes the
+    parse (overrides AND-binds-tighter-than-OR default precedence) is
+    semantically load-bearing and must NOT be normalized away -- otherwise
+    two genuinely different licenses would collapse into one string."""
+    no_parens = normalize_license_expression("MIT AND Apache-2.0 OR BSD-3-Clause")
+    redundant_parens = normalize_license_expression(
+        "(MIT AND Apache-2.0) OR BSD-3-Clause"
+    )
+    significant_parens = normalize_license_expression(
+        "MIT AND (Apache-2.0 OR BSD-3-Clause)"
+    )
+    # Explicit parens matching the default precedence change nothing.
+    assert no_parens == redundant_parens
+    # Parens overriding default precedence are a different expression --
+    # must not collapse to the same normalized string as the other two.
+    assert significant_parens != no_parens

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -7,6 +7,7 @@
 
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -863,3 +864,96 @@ dependencies = ["typing_extensions>=4.0", "zope.interface>=5.0"]
             "typing-extensions>=4.0",
             "zope-interface>=5.0",
         ]
+
+
+# ---------------------------------------------------------------------------
+# license_concluded (G2: declared-vs-detected disagreement)
+# ---------------------------------------------------------------------------
+
+
+def _write_pyproject(tmppath: Path, license_line: str = 'license = "MIT"\n') -> Path:
+    pyproject_content = f"""
+[project]
+name = "test-package"
+version = "1.0.0"
+{license_line}"""
+    pyproject_path = tmppath / "pyproject.toml"
+    pyproject_path.write_text(pyproject_content)
+    return pyproject_path
+
+
+def test_license_concluded_populated_on_conflict() -> None:
+    """A declared MIT license and an independently-detected Apache-2.0
+    LICENSE file both surface -- declared value untouched, concluded value
+    is the independent detection, disagreement visible to the caller."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = _write_pyproject(tmppath)
+        (tmppath / "LICENSE").write_text("Apache License\nVersion 2.0" + "x" * 200)
+
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="Apache-2.0",
+        ):
+            metadata, _ = read_pyproject(pyproject_path)
+
+        assert metadata.license_name == "MIT"
+        assert metadata.license_concluded == "Apache-2.0"
+        assert metadata.provenance["license"] == (
+            "Source: pyproject.toml | Field: project.license"
+        )
+        concluded_prov = metadata.provenance["license_concluded"]
+        assert "LICENSE" in concluded_prov
+        assert "Method: licenseid_detection" in concluded_prov
+        assert "Tool: licenseid==" in concluded_prov
+
+
+def test_license_concluded_matches_declared_no_conflict() -> None:
+    """Declared and independently-detected agree -- concluded is still
+    populated (needed to build the second native relationship), just equal."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = _write_pyproject(tmppath)
+        (tmppath / "LICENSE").write_text("MIT License\n\nPermission" + "x" * 200)
+
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="MIT",
+        ):
+            metadata, _ = read_pyproject(pyproject_path)
+
+        assert metadata.license_name == "MIT"
+        assert metadata.license_concluded == "MIT"
+
+
+def test_license_concluded_none_when_no_license_file() -> None:
+    """Declared value present, nothing in the directory to independently
+    detect from -- concluded stays unset, single-relationship path."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = _write_pyproject(tmppath)
+
+        metadata, _ = read_pyproject(pyproject_path)
+
+        assert metadata.license_name == "MIT"
+        assert metadata.license_concluded is None
+        assert "license_concluded" not in metadata.provenance
+
+
+def test_license_concluded_none_when_nothing_declared() -> None:
+    """No project.license field at all -- G2's independent-scan gate never
+    fires (license_name itself already comes from pure detection in this
+    case, existing pre-G2 behavior, unaffected)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = _write_pyproject(tmppath, license_line="")
+        (tmppath / "LICENSE").write_text("MIT License\n\nPermission" + "x" * 200)
+
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="MIT",
+        ):
+            metadata, _ = read_pyproject(pyproject_path)
+
+        assert metadata.license_name == "MIT"
+        assert metadata.license_concluded is None

--- a/tests/test_poetry.py
+++ b/tests/test_poetry.py
@@ -7,6 +7,7 @@
 
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -204,7 +205,8 @@ def test_extract_basic_fields() -> None:
             }
         }
     }
-    metadata = extract_poetry_metadata(data)
+    with tempfile.TemporaryDirectory() as d:
+        metadata = extract_poetry_metadata(data, Path(d))
     assert metadata.name == "my-pkg"
     assert metadata.version == "1.2.3"
     assert metadata.description == "A test package"
@@ -229,7 +231,8 @@ def test_extract_dependencies() -> None:
             }
         }
     }
-    metadata = extract_poetry_metadata(data)
+    with tempfile.TemporaryDirectory() as d:
+        metadata = extract_poetry_metadata(data, Path(d))
     assert metadata.requires_python == ">=3.10,<4.0.0"
     assert any("requests" in d for d in metadata.dependencies)
     assert any("numpy" in d for d in metadata.dependencies)
@@ -238,7 +241,8 @@ def test_extract_dependencies() -> None:
 
 def test_extract_readme_string() -> None:
     data = {"tool": {"poetry": {"name": "pkg", "readme": "README.md"}}}
-    metadata = extract_poetry_metadata(data)
+    with tempfile.TemporaryDirectory() as d:
+        metadata = extract_poetry_metadata(data, Path(d))
     assert metadata.readme == "README.md"
 
 
@@ -246,19 +250,20 @@ def test_extract_readme_list() -> None:
     data = {
         "tool": {"poetry": {"name": "pkg", "readme": ["README.md", "CHANGELOG.md"]}}
     }
-    metadata = extract_poetry_metadata(data)
+    with tempfile.TemporaryDirectory() as d:
+        metadata = extract_poetry_metadata(data, Path(d))
     assert metadata.readme == "README.md"
 
 
 def test_extract_missing_section_raises() -> None:
     with pytest.raises(ValueError, match=r"\[tool\.poetry\]"):
-        extract_poetry_metadata({})
+        extract_poetry_metadata({}, Path("."))
 
 
 def test_extract_missing_name_raises() -> None:
     data = {"tool": {"poetry": {"version": "1.0"}}}
     with pytest.raises(ValueError, match="name is required"):
-        extract_poetry_metadata(data)
+        extract_poetry_metadata(data, Path("."))
 
 
 def test_extract_provenance_sources() -> None:
@@ -272,7 +277,8 @@ def test_extract_provenance_sources() -> None:
             }
         }
     }
-    metadata = extract_poetry_metadata(data)
+    with tempfile.TemporaryDirectory() as d:
+        metadata = extract_poetry_metadata(data, Path(d))
     assert "tool.poetry.name" in metadata.provenance.get("name", "")
     assert "tool.poetry.version" in metadata.provenance.get("version", "")
     assert "tool.poetry.description" in metadata.provenance.get("description", "")
@@ -514,3 +520,92 @@ def test_fixture_read_pyproject_falls_back_to_poetry() -> None:
     metadata, _ = read_pyproject(POETRY_FIXTURE / "pyproject.toml")
     assert metadata.name == "mistral_inference"
     assert metadata.version == "1.6.0"
+
+
+# ---------------------------------------------------------------------------
+# G2: license fallback detection / conflict (poetry-only path)
+#
+# Regression coverage for the poetry-only extraction path, which previously
+# had zero license detection capability beyond reading the declared
+# [tool.poetry] license field verbatim -- no fallback directory detection,
+# no independent second-opinion scan. See resolve_license_concluded()'s
+# docstring in _license.py for why every extractor must call it.
+# ---------------------------------------------------------------------------
+
+
+def test_extract_poetry_metadata_license_fallback_detection() -> None:
+    """No [tool.poetry] license declared: falls back to directory
+    detection, same baseline every other extractor has."""
+    data = {"tool": {"poetry": {"name": "pkg", "version": "1.0.0"}}}
+    with tempfile.TemporaryDirectory() as d:
+        tmp_path = Path(d)
+        (tmp_path / "LICENSE").write_text("MIT", encoding="utf-8")
+        metadata = extract_poetry_metadata(data, tmp_path)
+    assert metadata.license_name == "MIT"
+    assert metadata.license_concluded is None
+    assert "LICENSE" in (metadata.provenance.get("license") or "")
+
+
+def test_extract_poetry_metadata_license_conflict() -> None:
+    """Declared MIT + independently-detected Apache-2.0: G2 populates
+    license_concluded with the detected value (and its own provenance),
+    distinct from the declared license_name."""
+    data = {"tool": {"poetry": {"name": "pkg", "version": "1.0.0", "license": "MIT"}}}
+    with tempfile.TemporaryDirectory() as d:
+        tmp_path = Path(d)
+        (tmp_path / "LICENSE").write_text("Apache License", encoding="utf-8")
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="Apache-2.0",
+        ):
+            metadata = extract_poetry_metadata(data, tmp_path)
+    assert metadata.license_name == "MIT"
+    assert metadata.license_concluded == "Apache-2.0"
+    assert "LICENSE" in (metadata.provenance.get("license_concluded") or "")
+
+
+def test_read_poetry_matches_read_pyproject_fallback_for_license_conflict() -> None:
+    """``read_poetry()`` (direct poetry-only entry point) and
+    ``read_pyproject()``'s own fallback-to-``[tool.poetry]`` branch (no
+    ``[project]`` section) must agree on G2 for the same project --
+    cross-path regression guard for the same "different extractor path,
+    same bug class" gap ``resolve_license_concluded()``'s docstring warns
+    about, applied to the poetry paths rather than Hatchling."""
+    content = """
+[tool.poetry]
+name = "poetry-pkg"
+version = "1.0.0"
+license = "MIT"
+"""
+    with tempfile.TemporaryDirectory() as d:
+        tmp_path = Path(d)
+        (tmp_path / "pyproject.toml").write_text(content)
+        (tmp_path / "LICENSE").write_text("Apache License", encoding="utf-8")
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="Apache-2.0",
+        ):
+            direct_meta, _ = read_poetry(tmp_path / "pyproject.toml")
+            fallback_meta, _ = read_pyproject(tmp_path / "pyproject.toml")
+
+    assert direct_meta.license_name == "MIT"
+    assert fallback_meta.license_name == "MIT"
+    assert direct_meta.license_concluded == "Apache-2.0"
+    assert fallback_meta.license_concluded == direct_meta.license_concluded
+
+
+def test_extract_poetry_metadata_license_agrees() -> None:
+    """Declared and independently-detected license agree: license_concluded
+    is still populated (equal to the declared value) -- G2 records both
+    sides regardless of agreement, only the Annotation is conflict-gated."""
+    data = {"tool": {"poetry": {"name": "pkg", "version": "1.0.0", "license": "MIT"}}}
+    with tempfile.TemporaryDirectory() as d:
+        tmp_path = Path(d)
+        (tmp_path / "LICENSE").write_text("MIT License", encoding="utf-8")
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="MIT",
+        ):
+            metadata = extract_poetry_metadata(data, tmp_path)
+    assert metadata.license_name == "MIT"
+    assert metadata.license_concluded == "MIT"

--- a/tests/test_provenance_integration.py
+++ b/tests/test_provenance_integration.py
@@ -268,7 +268,7 @@ def test_provenance_annotations_do_not_duplicate_native_values() -> None:
 
     # The license detection *method* is residual signal, but the license value
     # itself lives in the SimpleLicensingText element.
-    schema_url = "https://pitloom.dev/provenance/1"
+    schema_url = "https://pitloom.dev/provenance/fields/1"
     license_statements = [
         stmt
         for a in annotations

--- a/tests/test_setuptools.py
+++ b/tests/test_setuptools.py
@@ -8,14 +8,13 @@
 import logging
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from pitloom.core.creation import Creator
-from pitloom.core.project import ProjectMetadata
 from pitloom.extract.setuptools import (
     detect_build_backend,
-    merge_metadata,
     read_setup_cfg,
     read_setup_py,
     read_setuptools,
@@ -621,87 +620,85 @@ def test_read_setuptools_no_name_falls_through_to_setup_py() -> None:
 
 
 # ---------------------------------------------------------------------------
-# merge_metadata
+# G2: license fallback detection / conflict (setuptools-only path)
+#
+# Regression coverage for the setuptools-only extraction path, which
+# previously only ever read the declared license verbatim -- no fallback
+# directory detection, no independent second-opinion scan. See
+# resolve_license_concluded()'s docstring in _license.py for why every
+# extractor must call it, and _resolve_setuptools_license() for why this
+# runs once at the read_setuptools() dispatcher level rather than per-file.
 # ---------------------------------------------------------------------------
 
 
-def test_merge_metadata_primary_wins() -> None:
-    """Primary field values are never overwritten by secondary."""
-    primary = ProjectMetadata(
-        name="primary-pkg",
-        version="2.0",
-        description="Primary description",
+def test_read_setuptools_license_fallback_detection_cfg_only() -> None:
+    """No license declared in setup.cfg: falls back to directory detection,
+    same baseline every other extractor has."""
+    cfg = "[metadata]\nname = pkg\nversion = 1.0\n"
+    with tempfile.TemporaryDirectory() as d:
+        tmp_path = Path(d)
+        (tmp_path / "setup.cfg").write_text(cfg)
+        (tmp_path / "LICENSE").write_text("MIT", encoding="utf-8")
+        metadata, _ = read_setuptools(tmp_path)
+    assert metadata.license_name == "MIT"
+    assert metadata.license_concluded is None
+
+
+def test_read_setuptools_license_conflict_cfg_only() -> None:
+    """Declared MIT in setup.cfg + independently-detected Apache-2.0:
+    license_concluded is populated with the detected value."""
+    cfg = "[metadata]\nname = pkg\nversion = 1.0\nlicense = MIT\n"
+    with tempfile.TemporaryDirectory() as d:
+        tmp_path = Path(d)
+        (tmp_path / "setup.cfg").write_text(cfg)
+        (tmp_path / "LICENSE").write_text("Apache License", encoding="utf-8")
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="Apache-2.0",
+        ):
+            metadata, _ = read_setuptools(tmp_path)
+    assert metadata.license_name == "MIT"
+    assert metadata.license_concluded == "Apache-2.0"
+    assert "LICENSE" in (metadata.provenance.get("license_concluded") or "")
+
+
+def test_read_setuptools_license_conflict_py_only() -> None:
+    """Same conflict scenario, declared via setup.py alone (no setup.cfg)."""
+    py = (
+        "from setuptools import setup\n"
+        "setup(name='pkg', version='1.0', license='MIT')\n"
     )
-    secondary = ProjectMetadata(
-        name="secondary-pkg",
-        version="1.0",
-        description="Secondary description",
-        license_name="MIT",
-    )
-    merged = merge_metadata(primary, secondary)
-
-    assert merged.name == "primary-pkg"
-    assert merged.version == "2.0"
-    assert merged.description == "Primary description"
-    # Gap filled from secondary
-    assert merged.license_name == "MIT"
+    with tempfile.TemporaryDirectory() as d:
+        tmp_path = Path(d)
+        (tmp_path / "setup.py").write_text(py)
+        (tmp_path / "LICENSE").write_text("Apache License", encoding="utf-8")
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="Apache-2.0",
+        ):
+            metadata, _ = read_setuptools(tmp_path)
+    assert metadata.license_name == "MIT"
+    assert metadata.license_concluded == "Apache-2.0"
 
 
-def test_merge_metadata_secondary_fills_gaps() -> None:
-    """Secondary fills all None or empty fields left by primary."""
-    primary = ProjectMetadata(name="pkg", version="1.0")
-    secondary = ProjectMetadata(
-        name="secondary",
-        version="0.1",
-        description="From secondary",
-        requires_python=">=3.9",
-        keywords=["x", "y"],
-        authors=[{"name": "Author"}],
-        dependencies=["dep>=1.0"],
-        urls={"Homepage": "https://example.com"},
-    )
-    merged = merge_metadata(primary, secondary)
-
-    assert merged.name == "pkg"
-    assert merged.version == "1.0"
-    assert merged.description == "From secondary"
-    assert merged.requires_python == ">=3.9"
-    assert merged.keywords == ["x", "y"]
-    assert merged.authors == [{"name": "Author"}]
-    assert "dep>=1.0" in merged.dependencies
-    assert merged.urls == {"Homepage": "https://example.com"}
-
-
-def test_merge_metadata_provenance_merged() -> None:
-    """Provenance dicts are merged with primary entries winning on conflict."""
-    primary = ProjectMetadata(
-        name="pkg",
-        version="1.0",
-        provenance={
-            "name": "Source: pyproject.toml",
-            "version": "Source: pyproject.toml",
-        },
-    )
-    secondary = ProjectMetadata(
-        name="pkg2",
-        version="0.1",
-        description="desc",
-        provenance={"name": "Source: setup.cfg", "description": "Source: setup.cfg"},
-    )
-    merged = merge_metadata(primary, secondary)
-
-    # Primary wins on conflict
-    assert merged.provenance["name"] == "Source: pyproject.toml"
-    # Secondary fills missing keys
-    assert merged.provenance["description"] == "Source: setup.cfg"
-
-
-def test_merge_metadata_empty_lists_filled_from_secondary() -> None:
-    """Empty lists in primary are treated as gaps and filled from secondary."""
-    primary = ProjectMetadata(name="pkg", version="1.0", keywords=[])
-    secondary = ProjectMetadata(name="s", version="0", keywords=["a", "b"])
-    merged = merge_metadata(primary, secondary)
-    assert merged.keywords == ["a", "b"]
+def test_read_setuptools_license_resolution_runs_once_when_both_files_present() -> None:
+    """When both setup.cfg and setup.py exist, license resolution (fallback
+    detection / G2) runs once at the read_setuptools() dispatcher level, not
+    once per file -- avoids a redundant duplicate directory scan."""
+    cfg = "[metadata]\nname = cfg-pkg\nversion = 1.0\nlicense = MIT\n"
+    py = "from setuptools import setup\nsetup(name='py-pkg', version='2.0')\n"
+    with tempfile.TemporaryDirectory() as d:
+        tmp_path = Path(d)
+        (tmp_path / "setup.cfg").write_text(cfg)
+        (tmp_path / "setup.py").write_text(py)
+        (tmp_path / "LICENSE").write_text("MIT License", encoding="utf-8")
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="MIT",
+        ) as mock_detect:
+            metadata, _ = read_setuptools(tmp_path)
+    assert metadata.license_concluded == "MIT"
+    assert mock_detect.call_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_spdx3_compliance.py
+++ b/tests/test_spdx3_compliance.py
@@ -658,7 +658,7 @@ dependencies = ["requests>=2.28.0"]
             assert _CONTENT_TYPE_RE.match(content_type)
             # statement must be valid JSON carrying the pitloom/1 schema marker.
             statement = json.loads(ann["statement"])
-            assert statement["schema"] == "https://pitloom.dev/provenance/1"
+            assert statement["schema"] == "https://pitloom.dev/provenance/fields/1"
 
 
 def test_spdx3_provenance_format_annotation_omits_comment() -> None:

--- a/tests/test_spdx3_dataset.py
+++ b/tests/test_spdx3_dataset.py
@@ -292,7 +292,7 @@ def test_add_datasets_provenance_annotation_and_comment() -> None:
     assert len(dataset_annotations) == 1
     assert dataset_annotations[0]["contentType"] == "application/json"
     statement = json.loads(dataset_annotations[0]["statement"])
-    assert statement["schema"] == "https://pitloom.dev/provenance/1"
+    assert statement["schema"] == "https://pitloom.dev/provenance/fields/1"
     assert statement["fields"]["name"]["source"] == "test.json"
 
 

--- a/working-docs/design/adoption-surfaces.md
+++ b/working-docs/design/adoption-surfaces.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-07-05
-Last-Modified: 2026-07-05
+Last-Modified: 2026-08-10
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -21,7 +21,18 @@ Hatchling build, a training script, a GitHub workflow, an AI coding agent --
 gets a thin, native-feeling entry point onto the same core engine. All
 surfaces below converge on the same `DocumentModel` -> assemble -> export
 pipeline, so the SBOM shape and guarantees (determinism, schema compliance,
-provenance tracking) are identical regardless of which surface produced it.
+provenance tracking) are meant to be identical regardless of which surface
+produced it.
+
+That convergence is a design intent, not an automatic guarantee: the
+project-metadata extraction step upstream of `DocumentModel` still has one
+implementation per surface family (`pyproject.py`'s `[project]` path for
+the CLI/library, `hatchling.py` for the build hook, `poetry.py` and
+`setuptools.py` for the poetry-only/setuptools-only fallback paths), and
+each has drifted out of sync with the others before -- see "Keeping
+surfaces consistent" below. Treat "identical regardless of surface" as
+the thing to keep re-verifying, not a property that, once true, stays
+true on its own.
 
 ## The surfaces
 
@@ -79,6 +90,35 @@ fragment, with every inferred field marked `Source: AI agent | Method:
 inference`, so the result stays transparent and auditable. See
 [sbom-enrichment.md](sbom-enrichment.md) for the full data-source model
 this builds on.
+
+## Keeping surfaces consistent: product owners (proposed, not yet implemented)
+
+Growing the number of surfaces (this doc currently lists seven) makes it
+progressively easier for a feature or bugfix to land correctly on one
+surface's underlying extraction path while silently missing another's --
+not because anyone decided to skip it, but because no single person is
+looking at all seven every time. The motivating instance: the G2
+declared-vs-concluded license conflict check shipped wired into the CLI's
+`pyproject.py` path, but the Hatchling build hook (`hatchling.py`) called
+the lower-level detection function directly and skipped the independent
+directory scan G2 depends on -- so every Hatchling-built project silently
+got zero G2 conflict detection until a later review caught it. The fix
+(`resolve_license_concluded` as one shared entry point every extraction
+path calls, described in
+[annotation-provenance.md](../implementation/annotation-provenance.md))
+closes that specific gap, but doesn't stop the *next* new field or feature
+from repeating the pattern on some other surface.
+
+[Issue #122](https://github.com/bact/pitloom/issues/122) proposes
+assigning a **product owner** to each usage surface (CLI, Python API,
+Python decorator/`pitloom.loom`, Hatchling build hook, AI-agent Skills,
+Claude Code plugin, GitHub Action) who reviews any feature or bugfix that
+touches their surface before it lands, against review instructions and
+acceptance criteria suited to that surface. This is documented here as
+the proposed answer to "how do we stop this class of gap from
+recurring" -- **not yet implemented**: no owners are assigned, and no
+review-instructions/acceptance-criteria set exists per surface yet. Track
+implementation on issue #122.
 
 ## What is intentionally not in scope yet
 

--- a/working-docs/design/metadata-provenance.md
+++ b/working-docs/design/metadata-provenance.md
@@ -29,10 +29,10 @@ information in the SBOM comes from. This is essential for:
 > lineage, dataset creator, and fragment-origin `imports` are now emitted
 > as native SPDX constructs with no provenance residual for the value
 > itself; only enrichment `CreationInfo` (N3) remains, blocked on the
-> unbuilt `enrich/` subpackage. Two Phase-1 use cases are also still
-> design-only, not five-of-six-implies-nearly-done: G2 (multi-source
-> license disagreement detection) and A2 (superseded identity across
-> builds). See
+> unbuilt `enrich/` subpackage. G2 (multi-source disagreement detection)
+> is now implemented for license, and generalized to any field for when
+> future candidate sources land. A2 (superseded identity across builds)
+> remains design-only. See
 > [`working-docs/implementation/annotation-provenance.md`](../implementation/annotation-provenance.md)
 > §10 for the full design, current status, and code citations for all
 > pending items, and

--- a/working-docs/design/sbom-enrichment.md
+++ b/working-docs/design/sbom-enrichment.md
@@ -146,12 +146,17 @@ third-party fragment producers (see
    fragment into the final SBOM.
 
 Every inferred field carries a provenance marker in its `comment` --
-`Source: AI agent | Method: inference` -- reusing the same provenance
-convention documented in [metadata-provenance.md](metadata-provenance.md),
-so agent-derived content is always distinguishable from Pitloom's own
-extraction and from other configured enrichment sources. This keeps the
-result auditable: a reviewer can grep for `AI agent` in the SBOM to see
-exactly what was inferred rather than extracted.
+`Source: <agent name> (<vendor>) | Method: inference | Date: <ISO 8601
+date>` when the agent knows its own identity, else the generic `Source:
+AI agent | Method: inference` -- reusing the same `role: "inferred"`
+provenance convention documented in
+[metadata-provenance.md](metadata-provenance.md) and in
+[annotation-provenance.md](../implementation/annotation-provenance.md)'s
+G2 role vocabulary, so agent-derived content is always distinguishable
+from Pitloom's own extraction and from other configured enrichment
+sources. This keeps the result auditable: a reviewer can grep for `AI
+agent` or `Method: inference` in the SBOM to see exactly what was
+inferred rather than extracted.
 
 See `skills/enrich/SKILL.md` and
 `skills/enrich/references/examples.md` for the full agent-facing

--- a/working-docs/implementation/annotation-provenance.md
+++ b/working-docs/implementation/annotation-provenance.md
@@ -797,9 +797,19 @@ URL `https://pitloom.dev/provenance/conflict/1`, envelope:
 }
 ```
 
-Only emitted when candidates actually disagree (normalized); full
-agreement emits no Annotation — both native relationships still get
-built, just pointing at the same license element, and there's nothing
+Only emitted when candidates actually disagree after normalization
+(`_license.py` `normalize_license_expression`, built on the
+[`py-spdx-license`](https://github.com/JPEWdev/py-spdx-license) parser —
+a plain `.strip()` comparison alone would false-positive not just on
+casing differences (declared `"mit"` vs. detected `"MIT"`) but on
+equivalent-yet-differently-spelled compound expressions too (`"MIT AND
+MIT"` vs. `"MIT"`; `"MIT OR Apache-2.0"` vs. `"Apache-2.0 OR MIT"`) — so
+both candidate values are parsed, deduplicated, and canonically reordered
+before both the comparison and the license-element lookup/creation. A
+value that fails to parse as a valid SPDX expression at all falls back to
+`canonicalize_license_id`'s bare-id casing lookup, then to the raw string
+unchanged. Full agreement emits no Annotation — both native relationships
+still get built, just pointing at the same license element, and there's nothing
 extrinsic left to assert.
 
 **`role` vocabulary** — an epistemic-process label (*whose* determination
@@ -810,14 +820,23 @@ method category):
 
 - `declared` — the subject's own stated claim, however observed (read
   locally, or relayed unedited by a third party).
-- `detected` — Pitloom's own deterministic algorithm's determination,
-  whatever the input's origin (locality of the *input* never matters;
-  locality of the *determination* does — Pitloom fetching a remote file
-  and running its own `licenseid` match on it is still `detected`). Not
-  named "extracted": `extract/` is already Pitloom's own name for the
-  whole read-a-value pipeline stage, and `declared` is also extracted in
-  that sense — "extracted" would have collided with `declared` instead
-  of contrasting with it.
+- `detected` — Pitloom's own independent-verification *procedure*'s
+  determination, whatever the input's origin (locality of the *input*
+  never matters; locality of the *determination* does — Pitloom fetching a
+  remote file and running its own `licenseid` match on it is still
+  `detected`). "Procedure," not "algorithm ran": the license implementation
+  (`detect_independent_license`) is a multi-step search — `CITATION.cff`,
+  then `codemeta.json`, then license files, applying `licenseid` text
+  matching only where a value isn't already a bare SPDX id — and a step
+  that resolves via a direct bare-id read still counts as `detected`,
+  because it was Pitloom's own independently-consulted secondary source,
+  not a re-read of the subject's primary declared field. What decides the
+  role is *whose search procedure* produced the value, not whether every
+  individual step needed fuzzy text matching. Not named "extracted":
+  `extract/` is already Pitloom's own name for the whole read-a-value
+  pipeline stage, and `declared` is also extracted in that sense —
+  "extracted" would have collided with `declared` instead of contrasting
+  with it.
 - `externalReported` — some *other* party's own determination or opinion,
   relayed without Pitloom re-deriving it, and not the subject's own claim
   either (a paper's interpretation, an unrelated org's assessment, or
@@ -892,8 +911,41 @@ with; now the independent scan always runs alongside it.
 `concluded_license_provenance` params (`None` default — the three other
 call sites, dependency and AI-model licenses, are unaffected, since
 neither has a local second source to detect from today): when given, both
+candidates are run through `normalize_license_expression` before both the
+comparison and the license-element lookup/creation, then both
 `hasDeclaredLicense` and `hasConcludedLicense` are always built, and a G2
 conflict Annotation is added on disagreement.
+
+`normalize_license_expression` (also in `_license.py`) is the new,
+stronger canonicalization step: operator casing (`AND`/`OR`/`WITH`/`NOT`)
+is normalized first — but only when the operator stands alone as its own
+whitespace/paren-delimited token, never when it's hyphen-glued into an
+identifier (`GPL-2.0-or-later`, a custom `LicenseRef-my-or-license`) —
+then the result is parsed and canonically sorted via `py-spdx-license`
+(a new base dependency). This both canonicalizes bare-id casing (same as
+`canonicalize_license_id`, which it falls back to on a parse failure) and
+dedupes/reorders compound expressions, which `canonicalize_license_id`
+alone never handled.
+
+**Real-world validation.** This is not a hypothetical gap:
+[Trivy discussion #10139](https://github.com/aquasecurity/trivy/discussions/10139)
+reports scanning the same package and getting the same license expression
+back with and without a redundant outer paren
+(`GPL-3.0-or-later WITH GCC-exception-3.1` vs.
+`(GPL-3.0-or-later WITH GCC-exception-3.1)`), breaking policy rules that
+compare against one fixed string. Checked `normalize_license_expression`
+against all four of that report's example pairs — every pair normalizes
+to an identical string. Separately verified the harder case, where a
+paren is *not* redundant: for mixed `AND`/`OR` expressions,
+`MIT AND Apache-2.0 OR BSD-3-Clause` (no parens, relies on `AND` binding
+tighter than `OR` per the SPDX spec) and
+`(MIT AND Apache-2.0) OR BSD-3-Clause` (explicit parens matching that
+same default precedence) both normalize to `Apache-2.0 AND MIT OR
+BSD-3-Clause`, while `MIT AND (Apache-2.0 OR BSD-3-Clause)` (parens
+*overriding* default precedence, semantically different) correctly stays
+distinct and keeps its now-necessary paren. So the normalization strips
+parens exactly when they're redundant and keeps them exactly when they're
+load-bearing — not a blanket strip-all-parens heuristic.
 
 **Future candidate sources (not built — `enrich/`-territory network or
 agent work, cross-referenced to

--- a/working-docs/implementation/annotation-provenance.md
+++ b/working-docs/implementation/annotation-provenance.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-07-20
-Last-Modified: 2026-08-08
+Last-Modified: 2026-08-10
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -900,12 +900,40 @@ license (no 3rd/4th native slot exists).
 [`_license.py`](../../src/pitloom/extract/_license.py)
 `detect_independent_license` — independently scans the project directory
 (`CITATION.cff`, `codemeta.json`, license files), *ignoring* any declared
-value, so there's a genuine second opinion to compare against. Called
-from [`pyproject.py`](../../src/pitloom/extract/pyproject.py)'s
-`read_pyproject` whenever `project.license` is present — previously, a
-declared value that already looked like a valid SPDX id short-circuited
+value, so there's a genuine second opinion to compare against. Previously,
+a declared value that already looked like a valid SPDX id short-circuited
 before the `LICENSE` file was ever read, so there was nothing to disagree
 with; now the independent scan always runs alongside it.
+
+`resolve_license_concluded` (also in `_license.py`) is the single, shared
+G2 entry point every project-metadata extractor calls — not just
+`pyproject.py`'s `[project]` path. It exists because the four extraction
+paths (CLI's [`pyproject.py`](../../src/pitloom/extract/pyproject.py)
+`read_pyproject`, the [`hatchling.py`](../../src/pitloom/extract/hatchling.py)
+build-hook path, the poetry-only
+[`poetry.py`](../../src/pitloom/extract/poetry.py) `read_poetry`, and the
+setuptools-only [`setuptools.py`](../../src/pitloom/extract/setuptools.py)
+`read_setuptools`) were each written and evolving independently. G2 first
+shipped wired only into the CLI path; a later review found the Hatchling
+build hook called `detect_license_for_project` directly and never ran the
+independent scan at all, so G2 silently never fired for any Hatchling-built
+project. Rather than patch that one path, all four now call the same
+`resolve_license_concluded` (and, for the poetry-only and setuptools-only
+paths, the same directory-detection fallback when nothing is declared) so
+a future fifth extraction path can't reintroduce the same gap by omission.
+Cross-path regression tests
+(`test_metadata_from_hatchling_matches_read_pyproject_for_license_conflict`
+in `tests/test_hatch_hook.py`,
+`test_read_poetry_matches_read_pyproject_fallback_for_license_conflict` in
+`tests/test_poetry.py`) assert the paths agree on the same project. The
+same review also found the Hatchling and CLI paths each hand-listed their
+own `[tool.poetry]`-gap-fill field merge (`_merge_with_poetry` in
+`pyproject.py`, `merge_metadata` in `setuptools.py`); both were replaced
+by [`core/project.py`](../../src/pitloom/core/project.py)'s
+`merge_project_metadata`, which iterates `dataclasses.fields()` instead of
+naming every field by hand, so a newly added `ProjectMetadata` field
+merges automatically without a call site needing to be updated (see its
+own docstring for the field-drift history that motivated this).
 [`deps.py`](../../src/pitloom/assemble/spdx3/deps.py)
 `build_license_elements` gained `concluded_license_id`/
 `concluded_license_provenance` params (`None` default — the three other
@@ -970,10 +998,12 @@ forgotten:
   (author-stated) / `hasConcludedLicense` (Pitloom-detected). Originally
   shipped mirrored (single winning value classified as one or the other,
   "no inference yet") in PR [#105](https://github.com/bact/pitloom/pull/105);
-  the main project package path now populates both independently when a
-  second, directory-detected opinion exists (G2, above) — dependency and
-  AI-model license paths remain single-value/mirrored, no local second
-  source to detect from. Residual: the detection evidence.
+  the main project package now populates both independently when a second,
+  directory-detected opinion exists (G2, above), across all four
+  project-metadata extraction paths (CLI, Hatchling build hook,
+  poetry-only, setuptools-only) — dependency and AI-model license paths
+  remain single-value/mirrored, no local second source to detect from.
+  Residual: the detection evidence.
 - [ ] **N3 — Who/when enriched** → a second `CreationInfo` per enrichment run.
   Residual: which field + before/after value + inferred marker (E1/E2). (Blocked on `enrich/` subpackage)
 - [x] **N4 — External identifiers** (DOI, arXiv, repo / model-card URL) →

--- a/working-docs/implementation/annotation-provenance.md
+++ b/working-docs/implementation/annotation-provenance.md
@@ -689,23 +689,39 @@ Both parsed/validated in `core/config.py` (`_read_provenance_settings`),
 threaded through `build`/`build_model` and the `generate_*` / hatch-hook
 entry points exactly as `provenance_format`/`schema` already were.
 
+### Statement envelope convention (2026-08-10)
+
+Every Pitloom statement schema shares the same two leading keys, so a
+consumer can dispatch mechanically without pattern-matching prose:
+
+- `"schema"` — the full versioned URL (`https://pitloom.dev/provenance/
+  <kind>/<version>`, or `.../fields/<version>` for the default field-level
+  schema).
+- `"kind"` — a short string, always equal to the schema URL's own `<kind>`
+  path segment (`"fields"`, `"unification"`, `"artifact-metadata"`,
+  `"conflict"`).
+
+Compound JSON keys use `camelCase`, matching the surrounding SPDX 3
+JSON-LD style already used everywhere in the same document (`spdxId`,
+`creationInfo`, `annotationType`). None of the four current schemas ends
+up needing a compound key — G2's `candidates` list settled on flat,
+single-word fields (`value`/`role`/`source`/`ref`) once it moved to an
+open candidate-list design instead of fixed `declaredLicenseId`-style
+pairs — but the convention is stated explicitly so the next schema that
+*does* need one (E1/E2, whenever `enrich/` lands) doesn't have to
+re-derive it. Established retroactively across all four schemas this
+session (none had shipped in a release yet, so no compatibility
+constraint).
+
 ### Use-case catalog (why the Annotation earns its place)
 
 - **Generation** — G1 inferred/detected/AI-generated qualifier (necessary,
   **implemented**: `licenseid_detection`, `inferred_from_authors` have no
-  native assertedness marker); G2 multi-source license disagreement
-  (necessary on conflict, **not implemented — design only**: license source
-  is picked by fixed priority in
-  [`pyproject.py`](../../src/pitloom/extract/pyproject.py) `_resolve_license_hint`
-  — `project.license` text/file wins if present, else fall back to
-  `detect_license_for_project`'s `licenseid` match — and
-  [`deps.py`](../../src/pitloom/assemble/spdx3/deps.py) `_is_license_concluded`
-  only classifies that single winning value as declared-vs-concluded by its
-  recorded `method`; nothing ever compares a declared value against a
-  detected one or flags disagreement between them); G3 declared constraint
-  vs resolved version (useful, **implemented** — SPDX keeps only the
-  resolved version); G4 sub-file location in opaque AI formats (useful,
-  **implemented**).
+  native assertedness marker); **G2 multi-source disagreement** (necessary
+  on conflict, **implemented for license**, generalized beyond license — see
+  the dedicated subsection below); G3 declared constraint vs resolved
+  version (useful, **implemented** — SPDX keeps only the resolved version);
+  G4 sub-file location in opaque AI formats (useful, **implemented**).
 - **Aggregation** — A1 unification rationale (necessary, **implemented**):
   `_merge_fragment_set` records `(survivor, criterion, dropped_id, fragment)`
   for a **SHA-256 content-equality** match — a genuinely distinct id folded
@@ -720,8 +736,12 @@ entry points exactly as `provenance_format`/`schema` already were.
   record survives anywhere. Lower priority than A1: it's a cross-build fact
   (comparing this SBOM to a previous one), not something expressible within
   one SBOM generation.
-- **Enrichment** — E1 override lineage, E2 AI-inferred-vs-extracted marker
-  (both necessary; design-only — the `enrich/` subpackage is unbuilt).
+- **Enrichment** — E1 override lineage, E2 AI-inferred-vs-non-inferred
+  marker (both necessary; design-only — the `enrich/` subpackage is
+  unbuilt). E2's "non-inferred" pole is any of G2's `declared`/`detected`/
+  `externalReported` roles below — same vocabulary, reused rather than a
+  separate "extracted" word (which would have collided with `extract/`,
+  Pitloom's own name for the whole read-a-value pipeline stage).
 - **Preservation** — P1 verbatim original AI-model metadata
   (`provenance/artifact-metadata/1`), config-gated, complements the lossy
   native mapping when the artifact isn't shipped. `raw_metadata` captured
@@ -754,6 +774,137 @@ entry points exactly as `provenance_format`/`schema` already were.
   re-extractable). A future fix, if needed, should truncate with an explicit,
   visible marker (e.g. `"_truncated": true`) rather than cutting silently.
 
+### G2 — multi-source disagreement (2026-08-10, generalized, license implemented)
+
+License is the first field this fires for, but the *mechanism* — several
+sources reporting different values for the same field — applies to any
+field. Built as a generic schema from the start so a future field or
+candidate source never requires another schema redesign.
+
+**Where it lives.** [`provenance.py`](../../src/pitloom/assemble/spdx3/provenance.py)
+`ConflictCandidate` (a `TypedDict`) + `build_conflict_annotation`. Schema
+URL `https://pitloom.dev/provenance/conflict/1`, envelope:
+
+```json
+{
+  "schema": "https://pitloom.dev/provenance/conflict/1",
+  "kind": "conflict",
+  "field": "license",
+  "candidates": [
+    {"value": "MIT", "role": "declared", "source": "Source: pyproject.toml | Field: project.license", "ref": "<spdxId of hasDeclaredLicense target>"},
+    {"value": "Apache-2.0", "role": "detected", "source": "Source: LICENSE | Method: licenseid_detection | Tool: licenseid==0.3.0", "ref": "<spdxId of hasConcludedLicense target>"}
+  ]
+}
+```
+
+Only emitted when candidates actually disagree (normalized); full
+agreement emits no Annotation — both native relationships still get
+built, just pointing at the same license element, and there's nothing
+extrinsic left to assert.
+
+**`role` vocabulary** — an epistemic-process label (*whose* determination
+this is), deliberately not "which native SPDX slot it maps to" (that
+would have overloaded SPDX's own `hasConcludedLicense` meaning, "the
+SBOM creator's final determination," a graph-placement outcome, not a
+method category):
+
+- `declared` — the subject's own stated claim, however observed (read
+  locally, or relayed unedited by a third party).
+- `detected` — Pitloom's own deterministic algorithm's determination,
+  whatever the input's origin (locality of the *input* never matters;
+  locality of the *determination* does — Pitloom fetching a remote file
+  and running its own `licenseid` match on it is still `detected`). Not
+  named "extracted": `extract/` is already Pitloom's own name for the
+  whole read-a-value pipeline stage, and `declared` is also extracted in
+  that sense — "extracted" would have collided with `declared` instead
+  of contrasting with it.
+- `externalReported` — some *other* party's own determination or opinion,
+  relayed without Pitloom re-deriving it, and not the subject's own claim
+  either (a paper's interpretation, an unrelated org's assessment, or
+  another system's own algorithmic conclusion — GitHub's own
+  license-detector badge is still GitHub's determination, not Pitloom's,
+  even though GitHub's detector is itself rule-based internally —
+  "rule-based" was never the right test, "whose algorithm" is). No native
+  slot exists for this role by nature, not because it lost a priority
+  race against a local `declared` candidate.
+- `inferred` — an AI agent's non-deterministic reasoning/judgment. Same
+  word E2 already reserves for this.
+
+**Decision rule:** ask "whose determination is this," never "was the
+data local or remote" and never "was a rule-based algorithm involved
+somewhere" (a third-party service's own rule-based detector is still
+`externalReported`, because the algorithm wasn't Pitloom's).
+
+**Source-recording convention, per role** — each role's `source` string
+records identity appropriate to *that* answerer, using the existing
+generic `"Key: Value | Key: Value"` parser (no parser change needed for
+any of these):
+
+- `declared` — unchanged: `"Source: <file> | Field: <field>"`.
+- `detected` — **implemented**: gains a `Tool:` segment with the
+  detection library's version (`importlib.metadata.version("licenseid")`),
+  e.g. `"Source: LICENSE | Method: licenseid_detection | Tool:
+  licenseid==0.3.0"` — a detection result is only as reproducible as the
+  library version that produced it.
+- `externalReported` (future convention, not built) — `"Source: <service
+  name> | Endpoint: <API path/version> | Retrieved: <ISO 8601 date>"`.
+  Fits API-style sources (HF Hub, GitHub API); a non-API external source
+  (a paper, a scraped webpage) will need its own, less endpoint-centric
+  shape, worked out when that source type is actually built.
+- `inferred` (future convention, not built) — the answerer isn't Pitloom
+  at all; inference happens in an agent process entirely outside
+  Pitloom's own Python code, so it has to be the *agent's own
+  self-reported* identity: `"Source: <agent name> (<vendor>) | Method:
+  inference | Date: <ISO 8601 date>"`, e.g. `"Source: Claude Code
+  (Anthropic) | Method: inference | Date: 2026-08-10"`. Pitloom cannot
+  verify this at merge time — same trust model the `enrich` skill's
+  existing generic `"Source: AI agent | Method: inference"` marker
+  already has, just more specific when the agent knows its own identity.
+
+**Role → native relationship mapping is today's default policy, not an
+inherent law.** For license: `declared` → `hasDeclaredLicense`,
+`detected` → `hasConcludedLicense` (the only place the word "concluded"
+appears — as SPDX's own relationship-type name, applied to the `detected`
+candidate). This is a policy choice made *because* Pitloom's detector has
+no confidence score today — its one output is the only candidate
+determination available to call "concluded," not because a detected
+value is inherently more trustworthy than a declared one. A bad/spurious
+detection can and does produce a wrong `hasConcludedLicense` — a
+pre-existing limitation of the single detector itself, not something G2
+introduces. Once multiple detectors or confidence scoring exist, this
+mapping is where a smarter policy would plug in (e.g. falling back to
+`declared` when `detected` confidence is low) — future work, not built.
+`externalReported` and `inferred` never map to a native relationship for
+license (no 3rd/4th native slot exists).
+
+**What's actually built (v1, license only).**
+[`_license.py`](../../src/pitloom/extract/_license.py)
+`detect_independent_license` — independently scans the project directory
+(`CITATION.cff`, `codemeta.json`, license files), *ignoring* any declared
+value, so there's a genuine second opinion to compare against. Called
+from [`pyproject.py`](../../src/pitloom/extract/pyproject.py)'s
+`read_pyproject` whenever `project.license` is present — previously, a
+declared value that already looked like a valid SPDX id short-circuited
+before the `LICENSE` file was ever read, so there was nothing to disagree
+with; now the independent scan always runs alongside it.
+[`deps.py`](../../src/pitloom/assemble/spdx3/deps.py)
+`build_license_elements` gained `concluded_license_id`/
+`concluded_license_provenance` params (`None` default — the three other
+call sites, dependency and AI-model licenses, are unaffected, since
+neither has a local second source to detect from today): when given, both
+`hasDeclaredLicense` and `hasConcludedLicense` are always built, and a G2
+conflict Annotation is added on disagreement.
+
+**Future candidate sources (not built — `enrich/`-territory network or
+agent work, cross-referenced to
+[`sbom-enrichment.md`](../design/sbom-enrichment.md)'s existing source
+table):** HF Hub API (`externalReported`), GitHub via `ExternalRef`
+(`detected` if Pitloom runs its own scan on the fetched file,
+`externalReported` if relaying GitHub's own license badge), a linked
+paper (`externalReported`), README/source-comment agent inference
+(`inferred`). The schema already has the `role` slots waiting for all of
+these — no further schema change needed when they land.
+
 ### Phase 2 (documented; built after this Annotation work): native-first backfill
 
 Several facts still live only in an Annotation/comment but have a real SPDX
@@ -764,8 +915,13 @@ forgotten:
 - [x] **N1 — Fragment origin** → `SpdxDocument.imports` + `ExternalMap` (per
   source fragment). Residual in Annotation: the unification *criterion* only. (PR [#108](https://github.com/bact/pitloom/pull/108))
 - [x] **N2 — Declared vs. concluded license** → distinct `hasDeclaredLicense`
-  (author-stated) / `hasConcludedLicense` (Pitloom-detected). Today they are
-  mirrored (`deps.py`, "no inference yet"). Residual: the detection evidence. (PR [#105](https://github.com/bact/pitloom/pull/105))
+  (author-stated) / `hasConcludedLicense` (Pitloom-detected). Originally
+  shipped mirrored (single winning value classified as one or the other,
+  "no inference yet") in PR [#105](https://github.com/bact/pitloom/pull/105);
+  the main project package path now populates both independently when a
+  second, directory-detected opinion exists (G2, above) — dependency and
+  AI-model license paths remain single-value/mirrored, no local second
+  source to detect from. Residual: the detection evidence.
 - [ ] **N3 — Who/when enriched** → a second `CreationInfo` per enrichment run.
   Residual: which field + before/after value + inferred marker (E1/E2). (Blocked on `enrich/` subpackage)
 - [x] **N4 — External identifiers** (DOI, arXiv, repo / model-card URL) →


### PR DESCRIPTION
## Summary

Record information conflicts and how they are resolved, using standardized vocab.

Wires them into Hatchling/poetry-only/setuptools-only extractors via a shared resolver and generic metadata merge, adds normalization provenance, cross-path regression tests, and doc/CHANGELOG updates.

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
