### PR TITLE
Rename AI skills to sbom-generate/sbom-enrich, add sbom-validate skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,12 +1,13 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "pitloom",
   "owner": {
     "name": "Arthit Suriyawongkul",
     "email": "suriyawa@tcd.ie",
     "url": "https://github.com/bact/pitloom"
   },
-  "description": "Generate and enrich SPDX 3 SBOMs/AIBOMs for Python projects and AI models using Pitloom.",
+  "metadata": {
+    "description": "Generate, enrich, and validate SPDX 3 SBOMs/AIBOMs for Python projects and AI models using Pitloom."
+  },
   "plugins": [
     {
       "name": "pitloom",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,9 +1,7 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "pitloom",
-  "displayName": "Pitloom",
   "version": "0.12.0",
-  "description": "Generate and enrich SPDX 3 SBOMs/AIBOMs for Python projects and AI models using Pitloom.",
+  "description": "Generate, enrich, and validate SPDX 3 SBOMs/AIBOMs for Python projects and AI models using Pitloom.",
   "author": {
     "name": "Arthit Suriyawongkul",
     "url": "https://github.com/bact/pitloom"
@@ -11,5 +9,5 @@
   "homepage": "https://github.com/bact/pitloom",
   "repository": "https://github.com/bact/pitloom",
   "license": "Apache-2.0",
-  "keywords": ["sbom", "spdx", "supply-chain-security", "bom", "aibom", "provenance", "transparency", "metadata", "gguf", "onnx", "safetensors", "ai-sbom", "software-supply-chain-security"]
+  "keywords": ["sbom", "spdx", "supply-chain-security", "bom", "aibom", "provenance", "transparency", "metadata", "gguf", "onnx", "safetensors", "ai-sbom", "software-supply-chain-security", "validation"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to
 
 ### Added
 
-- Initial support of SKILL.md and Claude Code plugin ([#96])
+- Initial support of SKILL.md and Claude Code plugin: `sbom-generate`,
+  `sbom-enrich`, and `sbom-validate` Skills ([#96])
 - Redesign CLI and Python API around input artifacts
   (project, wheel, model, env, generate) while maintaining CISA SBOM Types
   compliance in output graph ([#96], [#114])

--- a/README.md
+++ b/README.md
@@ -225,30 +225,35 @@ for inputs, outputs, and more recipes.
 
 ### Use Pitloom as an AI-agent skill
 
-`skills/sbom/` and `skills/enrich/` are ready-to-install
-[Agent Skills](https://www.anthropic.com/) for Claude Code and the Claude
-Agent SDK: `sbom` generates an SBOM on request; `enrich` augments an
-existing one with detail read from a README or model card, via Pitloom's
-fragment system.
+`skills/sbom-generate/`, `skills/sbom-enrich/`, and `skills/sbom-validate/`
+are ready-to-install [Agent Skills](https://www.anthropic.com/) for
+Claude Code and the Claude Agent SDK: `sbom-generate` generates an SBOM
+on request; `sbom-enrich` augments an existing one with detail read from
+a README or model card, via Pitloom's fragment system; `sbom-validate`
+checks any SPDX 3 document's schema/shape conformance.
 
 ```bash
 mkdir -p ~/.claude/skills   # or .claude/skills for a project-scoped install
-cp -r /path/to/pitloom/skills/sbom /path/to/pitloom/skills/enrich ~/.claude/skills/
+cp -r /path/to/pitloom/skills/sbom-generate \
+      /path/to/pitloom/skills/sbom-enrich \
+      /path/to/pitloom/skills/sbom-validate ~/.claude/skills/
 ```
 
 Once installed, either ask in plain language ("generate an SBOM for this
-project", "enrich this SBOM with the dataset it was trained on") or
-invoke a skill explicitly with `/sbom [target]` / `/enrich [sbom-file]`.
-Generate first, enrich second -- `enrich` needs a Pitloom-generated SBOM
-to already exist:
+project", "enrich this SBOM with the dataset it was trained on",
+"validate this SBOM") or invoke a skill explicitly with
+`/sbom-generate [target]` / `/sbom-enrich [sbom-file]` /
+`/sbom-validate [sbom-file]`. Generate first, enrich and validate
+second -- `sbom-enrich` needs a Pitloom-generated SBOM to already exist:
 
 ```text
-/sbom .                          # or /sbom models/my-model.safetensors
-/enrich sbom.spdx3.json
+/sbom-generate .                          # or /sbom-generate models/my-model.safetensors
+/sbom-enrich sbom.spdx3.json
+/sbom-validate sbom.spdx3.json
 ```
 
 See [docs/ai-skills-and-plugin.md](docs/ai-skills-and-plugin.md) for a
-walkthrough of both skills, or
+walkthrough of all three skills, or
 [working-docs/implementation/agent-skill.md](working-docs/implementation/agent-skill.md)
 for full install instructions.
 
@@ -262,8 +267,9 @@ repository:
 /plugin install pitloom@pitloom
 ```
 
-Once installed, both Skills are namespaced under the plugin: `/pitloom:sbom
-[target]` and `/pitloom:enrich [sbom-file]` (or just ask in plain
+Once installed, all three Skills are namespaced under the plugin:
+`/pitloom:sbom-generate [target]`, `/pitloom:sbom-enrich [sbom-file]`,
+and `/pitloom:sbom-validate [sbom-file]` (or just ask in plain
 language -- natural-language triggering works the same as standalone
 Skills). See
 [docs/ai-skills-and-plugin.md](docs/ai-skills-and-plugin.md) or

--- a/docs/ai-skills-and-plugin.md
+++ b/docs/ai-skills-and-plugin.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-08-09
-Last-Modified: 2026-08-09
+Last-Modified: 2026-08-10
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -11,46 +11,54 @@ SPDX-License-Identifier: CC0-1.0
 
 # AI Skills and the Claude Code plugin
 
-Pitloom ships two [Agent Skills][agent-skills] --
-`sbom` and `enrich` -- and bundles both as a self-hosted [Claude Code
-plugin][claude-code-plugins].
+Pitloom ships three [Agent Skills][agent-skills] -- `sbom-generate`,
+`sbom-enrich`, and `sbom-validate` -- and bundles all three as a
+self-hosted [Claude Code plugin][claude-code-plugins].
 
 [agent-skills]: https://www.anthropic.com/
 [claude-code-plugins]: https://code.claude.com/docs/en/plugins
 
-- `sbom` -- generates a base SBOM/AIBOM for a project, wheel, or AI/ML
-  model file.
-- `enrich` -- reads a README or model card and contributes inferred
+- `sbom-generate` -- generates a base SBOM/AIBOM for a project, wheel, or
+  AI/ML model file.
+- `sbom-enrich` -- reads a README or model card and contributes inferred
   detail (a license guess, a `trainedOn` dataset) back into an existing
   SBOM as a provenance-marked fragment. Requires a base SBOM to already
-  exist; run `sbom` first.
+  exist; run `sbom-generate` first.
+- `sbom-validate` -- runs the third-party `spdx3-validate` CLI against
+  any SPDX 3 JSON document (schema + SHACL), catching a missing required
+  property or a wrong relationship type that a bare `@graph`-presence
+  check cannot. Works on Pitloom's own output, a hand-authored fragment,
+  or a third-party SPDX 3 file.
 
 ## Choosing an install path
 
 | Path | Choose this when... |
 | :--- | :--- |
-| [Agent Skills](#install-as-agent-skills) | You use any agent runtime that reads Skills from a filesystem directory, and want just the two Skills, standalone. |
-| [Claude Code plugin](#install-as-a-claude-code-plugin) | You use Claude Code and want one-command install (`/plugin install`) plus namespaced explicit invocation (`/pitloom:sbom`, `/pitloom:enrich`). |
+| [Agent Skills](#install-as-agent-skills) | You use any agent runtime that reads Skills from a filesystem directory, and want any subset of the three Skills, standalone. |
+| [Claude Code plugin](#install-as-a-claude-code-plugin) | You use Claude Code and want one-command install (`/plugin install`) plus namespaced explicit invocation (`/pitloom:sbom-generate`, `/pitloom:sbom-enrich`, `/pitloom:sbom-validate`). |
 
 Both install the exact same `SKILL.md` files.
 
 ### Install as Agent Skills
 
-Copy (or symlink) `skills/sbom/` and/or `skills/enrich/` from a Pitloom
-checkout into a skills directory your agent runtime reads from:
+Copy (or symlink) any of `skills/sbom-generate/`, `skills/sbom-enrich/`,
+and `skills/sbom-validate/` from a Pitloom checkout into a skills
+directory your agent runtime reads from:
 
 ```bash
 # Project-scoped (checked into the repository, shared with the team):
 mkdir -p .claude/skills
-cp -r /path/to/pitloom/skills/sbom .claude/skills/
-cp -r /path/to/pitloom/skills/enrich .claude/skills/
+cp -r /path/to/pitloom/skills/sbom-generate .claude/skills/
+cp -r /path/to/pitloom/skills/sbom-enrich .claude/skills/
+cp -r /path/to/pitloom/skills/sbom-validate .claude/skills/
 ```
 
 ```bash
 # User-scoped (available in every project on this machine):
 mkdir -p ~/.claude/skills
-cp -r /path/to/pitloom/skills/sbom ~/.claude/skills/
-cp -r /path/to/pitloom/skills/enrich ~/.claude/skills/
+cp -r /path/to/pitloom/skills/sbom-generate ~/.claude/skills/
+cp -r /path/to/pitloom/skills/sbom-enrich ~/.claude/skills/
+cp -r /path/to/pitloom/skills/sbom-validate ~/.claude/skills/
 ```
 
 If a skill with the same name already exists at that path,
@@ -66,42 +74,45 @@ From a Claude Code session:
 ```
 
 This registers Pitloom's repository as a marketplace named `pitloom` and
-installs the `pitloom` plugin from it -- both Skills become available in
-every session immediately after.
+installs the `pitloom` plugin from it -- all three Skills become
+available in every session immediately after.
 
 ## Using the Skills
 
 Either surface triggers the same two ways:
 
 - **Natural language** -- ask in plain language, e.g. "generate an SBOM
-  for this project" or "enrich this SBOM with the dataset it was trained
-  on". The agent matches your request against each `SKILL.md`'s
-  `description` front matter and loads the matching Skill automatically.
-- **Explicit invocation** -- `/sbom [target]` and `/enrich [sbom-file]`
-  standalone; `/pitloom:sbom [target]` and `/pitloom:enrich [sbom-file]`
-  when installed as the plugin. Both arguments are optional.
+  for this project", "enrich this SBOM with the dataset it was trained
+  on", or "validate this SBOM". The agent matches your request against
+  each `SKILL.md`'s `description` front matter and loads the matching
+  Skill automatically.
+- **Explicit invocation** -- `/sbom-generate [target]`,
+  `/sbom-enrich [sbom-file]`, and `/sbom-validate [sbom-file]` standalone;
+  `/pitloom:sbom-generate [target]`, `/pitloom:sbom-enrich [sbom-file]`,
+  and `/pitloom:sbom-validate [sbom-file]` when installed as the plugin.
+  All arguments are optional.
 
 ### Generate an SBOM
 
 ```text
-/sbom .                                 # project directory, current dir
-/sbom models/my-model.safetensors       # local AI/ML model file
-/sbom mistralai/Mistral-7B-v0.1         # Hugging Face Hub model ID
+/sbom-generate .                                 # project directory, current dir
+/sbom-generate models/my-model.safetensors       # local AI/ML model file
+/sbom-generate mistralai/Mistral-7B-v0.1         # Hugging Face Hub model ID
 ```
 
 Under the hood this runs `loom generate <target>` (or the more specific
 `loom project` / `loom wheel` / `loom model`).
 
-See [`skills/sbom/references/examples.md`][sbom-examples] for the full recipe
-set.
+See [`skills/sbom-generate/references/examples.md`][sbom-generate-examples]
+for the full recipe set.
 
-[sbom-examples]: https://github.com/bact/pitloom/blob/main/skills/sbom/references/examples.md
+[sbom-generate-examples]: https://github.com/bact/pitloom/blob/main/skills/sbom-generate/references/examples.md
 
 ### Enrich an existing SBOM
 
 ```text
-/sbom .                     # generate the base SBOM first
-/enrich sbom.spdx3.json     # then enrich it
+/sbom-generate .                     # generate the base SBOM first
+/sbom-enrich sbom.spdx3.json         # then enrich it
 ```
 
 The Skill reads the project's README or the model's model card, drafts a
@@ -111,14 +122,30 @@ hand-edits the generated SBOM), registers it under
 merged. Every inferred field is marked `Source: AI agent | Method:
 inference` in its `comment`, so it is never mistaken for Pitloom's own
 extraction. See
-[`skills/enrich/references/examples.md`][enrich-examples] for a full
-worked example, including the pre-merge and post-merge validation steps.
+[`skills/sbom-enrich/references/examples.md`][sbom-enrich-examples] for a
+full worked example, including the pre-merge and post-merge validation
+steps.
 
-[enrich-examples]: https://github.com/bact/pitloom/blob/main/skills/enrich/references/examples.md
+[sbom-enrich-examples]: https://github.com/bact/pitloom/blob/main/skills/sbom-enrich/references/examples.md
+
+### Validate an SPDX 3 document
+
+```text
+/sbom-validate sbom.spdx3.json
+```
+
+Runs schema (JSON Schema) plus shape (SHACL) validation via the
+third-party `spdx3-validate` CLI. This is the mandatory post-merge check
+the `sbom-enrich` recipe above uses, but it works standalone too -- on
+any SPDX 3 JSON document, not just Pitloom's own output. See
+[`skills/sbom-validate/references/examples.md`][sbom-validate-examples]
+for multi-file and merged-graph recipes.
+
+[sbom-validate-examples]: https://github.com/bact/pitloom/blob/main/skills/sbom-validate/references/examples.md
 
 ## Verifying it works
 
 For the plugin specifically, `claude plugin validate .claude-plugin/plugin.json`
 and `claude plugin validate .claude-plugin/marketplace.json` check the
 manifests, and `claude plugin details pitloom` (after installing) lists
-both Skills and an estimated token cost.
+all three Skills and an estimated token cost.

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,8 +140,9 @@ def evaluate_model():
 
 ### AI Skills and the Claude Code plugin
 
-Pitloom ships two Anthropic Agent Skills (`sbom`, `enrich`), also
-installable as a self-hosted Claude Code plugin:
+Pitloom ships three Anthropic Agent Skills (`sbom-generate`,
+`sbom-enrich`, `sbom-validate`), also installable as a self-hosted
+Claude Code plugin:
 
 ```text
 /plugin marketplace add bact/pitloom
@@ -149,10 +150,10 @@ installable as a self-hosted Claude Code plugin:
 ```
 
 Once installed, ask in plain language ("generate an SBOM for this
-project") or invoke explicitly: `/pitloom:sbom [target]`,
-`/pitloom:enrich [sbom-file]`. See
-[AI Skills and the Claude Code plugin](ai-skills-and-plugin.md) for
-install options, usage for both generation and enrichment, and
+project") or invoke explicitly: `/pitloom:sbom-generate [target]`,
+`/pitloom:sbom-enrich [sbom-file]`, `/pitloom:sbom-validate [sbom-file]`.
+See [AI Skills and the Claude Code plugin](ai-skills-and-plugin.md) for
+install options, usage for generation, enrichment, and validation, and
 verification steps.
 
 ## Learn more

--- a/skills/sbom-enrich/SKILL.md
+++ b/skills/sbom-enrich/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: enrich
+name: sbom-enrich
 description: >-
   Use this skill when asked to enrich, augment, or add inferred detail to
   a Pitloom-generated SBOM or AIBOM -- for example inferring an unstated
@@ -9,13 +9,13 @@ description: >-
   "enrich this SBOM", "add more detail to the SBOM", "infer the dataset
   used to train this model", "fill in missing SBOM information from the
   README/model card". Requires a Pitloom-generated SBOM to already exist --
-  generate one first with the `sbom` skill if it does not.
+  generate one first with the `sbom-generate` skill if it does not.
 license: Apache-2.0
 argument-hint: "[sbom-file]"
 ---
 
 <!-- Created: 2026-07-05 -->
-<!-- Last-Modified: 2026-08-09 -->
+<!-- Last-Modified: 2026-08-10 -->
 <!-- SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul -->
 <!-- SPDX-FileType: SOURCE -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
@@ -26,13 +26,13 @@ Static extraction cannot read prose. An agent can go further than Pitloom
 alone: read the project's README or the model's model card, infer a
 plausible license or a dependency's purpose, or work out
 `trainedOn`/`testedOn` dataset relationships that no file format encodes
-explicitly. Do this only **after** a base SBOM exists (use the `sbom`
-skill first if it does not), and only when it adds real information -- do
-not fabricate detail for its own sake.
+explicitly. Do this only **after** a base SBOM exists (use the
+`sbom-generate` skill first if it does not), and only when it adds real
+information -- do not fabricate detail for its own sake.
 
 Triggers automatically on natural-language requests (see the trigger
-phrasings above), or invoke it explicitly with `/enrich [sbom-file]`
-(`/pitloom:enrich [sbom-file]` when installed via the Claude Code
+phrasings above), or invoke it explicitly with `/sbom-enrich [sbom-file]`
+(`/pitloom:sbom-enrich [sbom-file]` when installed via the Claude Code
 plugin). `sbom-file` is optional -- point it at a specific
 already-generated SBOM when a project has more than one; omit it to let
 the agent find the one to enrich.
@@ -67,8 +67,8 @@ Source: AI agent | Method: inference
 
 Steps:
 
-1. Generate a base SBOM first, if not already done (use the `sbom`
-   skill).
+1. Generate a base SBOM first, if not already done (use the
+   `sbom-generate` skill).
 2. Read the project's `README.md` / model card and any other local docs.
 3. Draft a fragment (`*.spdx3.json`) containing only the elements or
    relationships you can infer (e.g. a `dataset_DatasetPackage` plus a
@@ -108,15 +108,10 @@ Steps:
 
 6. Re-run `loom project <path>` or `loom generate <path>` (generate again) so
    the merged, enriched SBOM is written.
-7. **Post-merge check (mandatory):** validate the merged output is still
-   a conformant SPDX 3 JSON document -- a syntactically valid fragment can
-   still be missing a required property or use the wrong relationship
-   type, which only shape/SHACL validation catches:
-
-   ```bash
-   pip install spdx3-validate  # if not already installed
-   spdx3-validate --json <merged-sbom-file>
-   ```
+7. **Post-merge check (mandatory):** use the `sbom-validate` skill on
+   `<merged-sbom-file>` -- a syntactically valid fragment can still be
+   missing a required property or use the wrong relationship type, which
+   only shape/SHACL validation catches.
 
 8. Tell the user what was inferred and why, so they can review it -- this
    is provenance-tracked, agent-derived data, not ground truth.
@@ -128,6 +123,7 @@ enable/disable model, and the dataset-relationship field map, see
 ## See also
 
 - `references/examples.md` -- full worked example.
+- The sibling `sbom-validate` skill -- used for the mandatory post-merge
+  check above.
 - `docs/resources.md` in the Pitloom repository -- SPDX 3 spec, ontology,
-  and JSON Schema links, plus the `spdx3-validate` validator used in the
-  post-merge check above.
+  and JSON Schema links.

--- a/skills/sbom-enrich/references/examples.md
+++ b/skills/sbom-enrich/references/examples.md
@@ -1,12 +1,12 @@
 ---
 Created: 2026-07-05
-Last-Modified: 2026-08-09
+Last-Modified: 2026-08-10
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
 ---
 
-# Pitloom enrich skill: copy-paste recipe
+# Pitloom sbom-enrich skill: copy-paste recipe
 
 Companion to `../SKILL.md`. This recipe is meant to be run as-is or
 adapted with minimal edits.
@@ -112,15 +112,9 @@ inferred element's provenance clearly marked in its `comment`.
 
 ## 5. Post-merge check (mandatory)
 
-Validate the merged output is still a conformant SPDX 3.0.1 document --
-this catches SPDX-shape/SHACL problems (e.g. a missing required property
-or the wrong relationship type) that plain JSON-syntax validity would
-miss:
-
-```bash
-pip install spdx3-validate  # if not already installed
-spdx3-validate --json sbom.spdx3.json
-```
+Use the `sbom-validate` skill on `sbom.spdx3.json` -- this catches
+SPDX-shape/SHACL problems (e.g. a missing required property or the wrong
+relationship type) that plain JSON-syntax validity would miss.
 
 ## 6. Report back to the user
 
@@ -133,11 +127,13 @@ extraction.
 ## See also
 
 - `../SKILL.md` -- operating instructions for this skill.
-- The sibling `sbom` skill -- generates the base SBOM this recipe enriches.
+- The sibling `sbom-generate` skill -- generates the base SBOM this
+  recipe enriches.
+- The sibling `sbom-validate` skill -- used for the mandatory post-merge
+  check above.
 - `working-docs/design/sbom-enrichment.md` -- enrichment data-source table
   and the `[tool.pitloom.enrich]` enable/disable model.
 - `working-docs/design/sbom-fragments.md` -- fragment system design and
   vocabulary.
 - `docs/resources.md` in the Pitloom repository -- SPDX 3 spec, ontology,
-  and JSON Schema links, plus the `spdx3-validate` validator used in the
-  post-merge check above.
+  and JSON Schema links.

--- a/skills/sbom-generate/SKILL.md
+++ b/skills/sbom-generate/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sbom
+name: sbom-generate
 description: >-
   Use this skill whenever the user asks to generate an SBOM, an SPDX
   document, a software bill of materials, a dependency inventory, or an AI
@@ -16,7 +16,7 @@ argument-hint: "[target]"
 ---
 
 <!-- Created: 2026-07-05 -->
-<!-- Last-Modified: 2026-08-09 -->
+<!-- Last-Modified: 2026-08-10 -->
 <!-- SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul -->
 <!-- SPDX-FileType: SOURCE -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
@@ -28,11 +28,11 @@ Python projects, sdist archives, wheels, AI/ML model files, and Python
 environments. This skill drives Pitloom's existing CLI (`loom` / `pitloom`).
 
 Triggers automatically on natural-language requests (see the trigger
-phrasings above), or invoke it explicitly with `/sbom [target]`
-(`/pitloom:sbom [target]` when installed via the Claude Code plugin).
-`target` is optional -- a project directory, an sdist/wheel path, a local
-model file, or a Hugging Face model ID; omit it to default to the current
-directory.
+phrasings above), or invoke it explicitly with `/sbom-generate [target]`
+(`/pitloom:sbom-generate [target]` when installed via the Claude Code
+plugin). `target` is optional -- a project directory, an sdist/wheel path,
+a local model file, or a Hugging Face model ID; omit it to default to the
+current directory.
 
 See `references/examples.md` for copy-paste recipes.
 
@@ -107,14 +107,16 @@ loom merge .spdx3-fragments/ -o combined.spdx3.json
 
 ## Verify the result
 
-A quick `@graph`-presence sanity check is enough for most runs, but for a
-schema/shape-level conformance check, run `spdx3-validate` on the output
-too -- see `references/examples.md` for both commands.
+A quick `@graph`-presence sanity check is enough for most runs (see
+`references/examples.md`), but for a schema/shape-level conformance
+check, use the `sbom-validate` skill on the output.
 
 ## See also
 
 - `references/examples.md` -- copy-paste recipes for every target type.
+- The sibling `sbom-validate` skill -- schema/shape-level conformance
+  check for any SBOM this skill produces.
 - `docs/resources.md` in the Pitloom repository -- SPDX 3 spec, ontology,
   JSON-LD, and JSON Schema links (including the per-minor-version URL
   pattern) for looking up the exact schema/spec a generated SBOM should
-  conform to, and the `spdx3-validate` validator used to check it.
+  conform to.

--- a/skills/sbom-generate/references/examples.md
+++ b/skills/sbom-generate/references/examples.md
@@ -1,12 +1,12 @@
 ---
 Created: 2026-07-05
-Last-Modified: 2026-08-09
+Last-Modified: 2026-08-10
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
 ---
 
-# Pitloom's `sbom` skill: copy-paste recipes
+# Pitloom's `sbom-generate` skill: copy-paste recipes
 
 Companion to `../SKILL.md`. These recipes are meant to be run as-is or
 adapted with minimal edits.
@@ -72,16 +72,12 @@ print(f"Valid SPDX 3 graph with {len(d[\"@graph\"])} nodes")
 
 For a schema/shape-level conformance check -- catches a missing required
 property or wrong relationship type that the sanity check above cannot --
-run `spdx3-validate` too:
-
-```bash
-pip install spdx3-validate  # if not already installed
-spdx3-validate --json sbom.spdx3.json
-```
+use the `sbom-validate` skill on `sbom.spdx3.json`.
 
 ## See also
 
 - `../SKILL.md` -- operating instructions for this skill.
+- The sibling `sbom-validate` skill -- schema/shape-level conformance
+  check beyond the `@graph` sanity check above.
 - `docs/resources.md` in the Pitloom repository -- SPDX 3 spec, ontology,
-  and JSON Schema links, plus the `spdx3-validate` validator, for deeper
-  conformance checks beyond the `@graph` sanity check above.
+  and JSON Schema links.

--- a/skills/sbom-validate/SKILL.md
+++ b/skills/sbom-validate/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: sbom-validate
+description: >-
+  Use this skill whenever an SPDX 3 JSON document (an SBOM/AIBOM, whether
+  Pitloom-generated or not) needs a schema/shape-level conformance check --
+  after generating or enriching a Pitloom SBOM, after hand-editing or
+  merging SPDX 3 JSON, or whenever asked to validate, check, or verify an
+  SPDX 3 document against the spec. Trigger phrasings include "validate
+  this SBOM", "is this SBOM valid", "check this SBOM's SPDX conformance",
+  "validate the merged output", "run spdx3-validate on this file". A quick
+  `@graph`-presence sanity check (see the sibling `sbom-generate`/
+  `sbom-enrich` skills) is not a substitute for this: it cannot catch a
+  missing required property or a wrong relationship type, which only
+  schema/SHACL validation catches.
+license: Apache-2.0
+argument-hint: "[sbom-file]"
+---
+
+<!-- Created: 2026-08-10 -->
+<!-- Last-Modified: 2026-08-10 -->
+<!-- SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul -->
+<!-- SPDX-FileType: SOURCE -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Validate an SPDX 3 document
+
+A syntactically valid JSON file (or a file that merely contains a
+`@graph` array) can still fail the SPDX 3 spec: a missing required
+property, a relationship pointing at the wrong type, an `spdxId` that
+doesn't match its own `ExternalMap` entry. This skill runs
+[`spdx3-validate`](https://github.com/JPEWdev/spdx3-validate) -- schema
+(JSON Schema) plus shape (SHACL) validation, with SPDX-3-aware handling of
+`ExternalMap`-declared IDs that plain `pyshacl`/`check-jsonschema` gets
+wrong.
+
+Works on any SPDX 3 JSON document, not just Pitloom's own output --
+useful for a hand-authored fragment, a merged SBOM, or a third-party SPDX
+3 file.
+
+Triggers automatically on natural-language requests (see the trigger
+phrasings above), or invoke it explicitly with `/sbom-validate
+[sbom-file]` (`/pitloom:sbom-validate [sbom-file]` when installed via the
+Claude Code plugin). `sbom-file` is optional -- point it at a specific
+file when a project has more than one SBOM; omit it to let the agent find
+the one to validate.
+
+See `references/examples.md` for copy-paste recipes.
+
+## Run the validator
+
+```bash
+pip install spdx3-validate  # if not already installed
+spdx3-validate --json <sbom-file>
+```
+
+Exit code `0` means valid; a non-zero exit code means at least one
+schema or SHACL error, printed to stdout with the failing JSON path.
+
+To validate several related documents (e.g. a base SBOM plus a fragment
+that references it via `ExternalMap`) and additionally check the *merged*
+graph, pass `--json` more than once:
+
+```bash
+spdx3-validate --json base.spdx3.json --json fragment.spdx3.json
+```
+
+Add `--no-merge` to skip the merged-graph check and validate each
+document only in isolation.
+
+## Report the result
+
+- **Valid:** say so plainly; no need to reproduce validator output for a
+  clean pass.
+- **Invalid:** show the validator's error output (it already includes the
+  failing JSON path and a description) and explain in plain language what
+  it means, rather than just pasting the raw error. Do not attempt to
+  auto-fix a hand-authored fragment's SPDX-shape errors without asking --
+  the fix usually requires understanding intent (which relationship type
+  was meant, which element a dangling reference should point to).
+
+## See also
+
+- `references/examples.md` -- copy-paste recipes, including multi-file
+  and merged-graph validation.
+- The sibling `sbom-generate` and `sbom-enrich` skills -- this skill is
+  their recommended post-generation/post-merge conformance check.
+- `docs/resources.md` in the Pitloom repository -- SPDX 3 spec, ontology,
+  JSON-LD, and JSON Schema links (including the per-minor-version URL
+  pattern), plus the `spdx3-validate` validator this skill wraps.

--- a/skills/sbom-validate/references/examples.md
+++ b/skills/sbom-validate/references/examples.md
@@ -1,0 +1,75 @@
+---
+Created: 2026-08-10
+Last-Modified: 2026-08-10
+SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+SPDX-FileType: DOCUMENTATION
+SPDX-License-Identifier: CC0-1.0
+---
+
+# Pitloom's `sbom-validate` skill: copy-paste recipes
+
+Companion to `../SKILL.md`. These recipes are meant to be run as-is or
+adapted with minimal edits.
+
+## Validate a single SBOM
+
+```bash
+pip install spdx3-validate  # if not already installed
+spdx3-validate --json sbom.spdx3.json
+```
+
+## Validate quietly (no progress spinner, useful in CI logs)
+
+```bash
+spdx3-validate --json sbom.spdx3.json --quiet
+```
+
+## Validate a base SBOM plus a fragment together
+
+Checks each document individually, then the merged graph -- catches an
+`ExternalMap`-referenced `spdxId` that the fragment expects but the base
+document doesn't actually provide:
+
+```bash
+spdx3-validate --json sbom.spdx3.json --json fragments/agent-enrichment.spdx3.json
+```
+
+## Validate several documents without the merged-graph check
+
+```bash
+spdx3-validate --json a.spdx3.json --json b.spdx3.json --no-merge
+```
+
+## Force a specific SPDX version
+
+`spdx3-validate` auto-detects the SPDX version from each document's
+`@context`; override it if a document's `@context` is ambiguous or
+missing:
+
+```bash
+spdx3-validate --json sbom.spdx3.json --spdx-version 3.0.1
+```
+
+## Validate from stdin
+
+```bash
+loom project . | spdx3-validate --json -
+```
+
+## Interpreting the result
+
+- Exit code `0`: valid, no output beyond progress.
+- Non-zero exit code: at least one error, printed per-document as
+  `ERROR: JSON Schema validation failed for <file>:` or `ERROR: SHACL
+  Validation failed for <file>:`, followed by the failing JSON path(s)
+  and a description.
+
+## See also
+
+- `../SKILL.md` -- operating instructions for this skill.
+- The sibling `sbom-generate` skill -- produces the SBOM this validates.
+- The sibling `sbom-enrich` skill -- its mandatory post-merge check uses
+  this skill.
+- `docs/resources.md` in the Pitloom repository -- SPDX 3 spec, ontology,
+  and JSON Schema links, plus the `spdx3-validate` validator this skill
+  wraps.

--- a/working-docs/design/adoption-surfaces.md
+++ b/working-docs/design/adoption-surfaces.md
@@ -43,8 +43,8 @@ true on its own.
 | Hatchling build hook | You build wheels with Hatchling and want an SBOM embedded automatically, with no extra command. | [hatchling-build-hook.md](hatchling-build-hook.md) |
 | ML tracking SDK (`pitloom.loom`) | You are training or fine-tuning a model and want to capture dataset/hyperparameter/metric provenance as you go, as an SPDX fragment. | [README.md](../../README.md#python-tracking-decorator), [sbom-fragments.md](sbom-fragments.md) |
 | GitHub Action | Your project is *not* Hatchling-based (or you just want CI to produce an SBOM artefact with one `uses:` line), regardless of build backend. | [github-action.md](../implementation/github-action.md) |
-| AI-agent Skills (`sbom`, `enrich`) | You want an AI coding agent (Claude Code, the Agent SDK, or similar) to generate -- and optionally enrich -- an SBOM on request, as a first-class capability rather than an ad hoc shell command. | [agent-skill.md](../implementation/agent-skill.md) |
-| Claude Code plugin | You use Claude Code and want both Skills installable with one command (`/plugin install`), plus namespaced explicit invocation (`/pitloom:sbom`, `/pitloom:enrich`). | [claude-code-plugin.md](../implementation/claude-code-plugin.md) |
+| AI-agent Skills (`sbom-generate`, `sbom-enrich`, `sbom-validate`) | You want an AI coding agent (Claude Code, the Agent SDK, or similar) to generate -- and optionally enrich and validate -- an SBOM on request, as a first-class capability rather than an ad hoc shell command. | [agent-skill.md](../implementation/agent-skill.md) |
+| Claude Code plugin | You use Claude Code and want all three Skills installable with one command (`/plugin install`), plus namespaced explicit invocation (`/pitloom:sbom-generate`, `/pitloom:sbom-enrich`, `/pitloom:sbom-validate`). | [claude-code-plugin.md](../implementation/claude-code-plugin.md) |
 
 ## Why the Action and the Skill matter
 
@@ -60,16 +60,17 @@ backend they control. Two adoption paths were still missing:
 2. **Agent-native operation.** As AI coding agents become a normal part of
    how software gets written and maintained, "generate an SBOM for this"
    needs to be something an agent can just do, the same way it edits a
-   file or runs a test. Two **AI-agent Skills** (`skills/sbom/`,
-   `skills/enrich/`) package Pitloom's CLI as explicit, independently
-   triggerable capabilities for Claude Code, the Claude Agent SDK, and
-   similar agent runtimes.
+   file or runs a test. Three **AI-agent Skills** (`skills/sbom-generate/`,
+   `skills/sbom-enrich/`, `skills/sbom-validate/`) package Pitloom's CLI
+   (and, for validation, the third-party `spdx3-validate` CLI) as
+   explicit, independently triggerable capabilities for Claude Code, the
+   Claude Agent SDK, and similar agent runtimes.
 
 ## The Skills are more than a CLI wrapper: agent-driven enrichment
 
-The `enrich` skill is deliberately framed as an **enrichment surface**,
-not just a thin CLI wrapper, because an AI agent can do things static
-extraction cannot:
+The `sbom-enrich` skill is deliberately framed as an **enrichment
+surface**, not just a thin CLI wrapper, because an AI agent can do things
+static extraction cannot:
 
 - Read a model card or README in prose and infer an unstated license.
 - Classify what a dependency is *for*, not just that it exists.
@@ -85,7 +86,7 @@ the line between "extracted fact" and "AI guess":
   are merged into the final SBOM via `[tool.pitloom.fragments]` and
   `merge_fragments()` (see [sbom-fragments.md](sbom-fragments.md)).
 
-The `enrich` skill's guidance has an agent contribute enrichment as a
+The `sbom-enrich` skill's guidance has an agent contribute enrichment as a
 fragment, with every inferred field marked `Source: AI agent | Method:
 inference`, so the result stays transparent and auditable. See
 [sbom-enrichment.md](sbom-enrichment.md) for the full data-source model
@@ -127,5 +128,5 @@ implementation on issue #122.
 - New enrichment *code* inside Pitloom core (README/model-card parsers,
   OpenSSF Scorecard, Hugging Face/PyPI enrichers) -- tracked separately in
   [sbom-enrichment.md](sbom-enrichment.md) and [roadmap.md](roadmap.md); the
-  `enrich` skill enables agent-driven enrichment today without waiting for
-  that code.
+  `sbom-enrich` skill enables agent-driven enrichment today without
+  waiting for that code.

--- a/working-docs/design/roadmap.md
+++ b/working-docs/design/roadmap.md
@@ -65,17 +65,19 @@ wired into a build backend. These two extend reach beyond that. See
   backend. Dogfooded on Pitloom itself in
   `.github/workflows/action-selftest.yml`.
   See [github-action.md](../implementation/github-action.md).
-- [x] **AI-agent Skills** (`skills/sbom/`, `skills/enrich/`) -- lets
-  Claude Code, the Claude Agent SDK, or similar runtimes generate an SBOM
-  on request, and optionally enrich it (README/model-card inference
-  contributed back as a provenance-marked fragment). Independently
-  triggerable by natural language or explicit invocation.
+- [x] **AI-agent Skills** (`skills/sbom-generate/`, `skills/sbom-enrich/`,
+  `skills/sbom-validate/`) -- lets Claude Code, the Claude Agent SDK, or
+  similar runtimes generate an SBOM on request, optionally enrich it
+  (README/model-card inference contributed back as a provenance-marked
+  fragment), and validate any SPDX 3 document's schema/shape conformance.
+  Independently triggerable by natural language or explicit invocation.
   See [agent-skill.md](../implementation/agent-skill.md) and
   [sbom-enrichment.md](sbom-enrichment.md).
-- [x] **Claude Code plugin** (`.claude-plugin/`) -- bundles both Skills
-  under the `pitloom` plugin namespace so they install with
+- [x] **Claude Code plugin** (`.claude-plugin/`) -- bundles all three
+  Skills under the `pitloom` plugin namespace so they install with
   `/plugin install` directly from this repository, with namespaced
-  explicit invocation (`/pitloom:sbom`, `/pitloom:enrich`). See
+  explicit invocation (`/pitloom:sbom-generate`, `/pitloom:sbom-enrich`,
+  `/pitloom:sbom-validate`). See
   [claude-code-plugin.md](../implementation/claude-code-plugin.md).
 - [ ] **Docker container action** (future) -- a `Dockerfile` +
   `action.yml` `using: docker` variant of the GitHub Action for hermetic

--- a/working-docs/design/sbom-enrichment.md
+++ b/working-docs/design/sbom-enrichment.md
@@ -116,7 +116,7 @@ extractor can reach -- a plausible license from ambiguous wording, what a
 dependency is actually *for*, or a `trainedOn`/`testedOn` dataset
 relationship implied by a paragraph rather than a machine-readable field.
 
-This is documented and enabled today via the `skills/enrich/` Skill
+This is documented and enabled today via the `skills/sbom-enrich/` Skill
 (see [adoption-surfaces.md](adoption-surfaces.md) and
 [agent-skill.md](../implementation/agent-skill.md) for the surfaces this
 builds on); it does not require new code inside Pitloom core.
@@ -158,9 +158,10 @@ sources. This keeps the result auditable: a reviewer can grep for `AI
 agent` or `Method: inference` in the SBOM to see exactly what was
 inferred rather than extracted.
 
-See `skills/enrich/SKILL.md` and
-`skills/enrich/references/examples.md` for the full agent-facing
-instructions and a worked fragment example.
+See `skills/sbom-enrich/SKILL.md` and
+`skills/sbom-enrich/references/examples.md` for the full agent-facing
+instructions and a worked fragment example. Validate the merged result
+with the `skills/sbom-validate/` Skill.
 
 ### Enricher implementation approach
 

--- a/working-docs/design/sbom-fragments.md
+++ b/working-docs/design/sbom-fragments.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-04-13
-Last-Modified: 2026-08-08
+Last-Modified: 2026-08-10
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -281,7 +281,9 @@ A backward-compatible loader will accept both the old `list[str]` form
      log warning and skip.
    - If `sha256` is set, verify the file hash matches.
    - Parse the JSON-LD and validate it is a valid SPDX 3 document (using
-     `spdx3-validate` or the built-in `JSONLDDeserializer` + schema check).
+     `spdx3-validate`'s library API -- `spdx3_validate.validate()`,
+     available since `spdx3-validate` v0.0.7 -- or the built-in
+     `JSONLDDeserializer` + schema check).
    - Log a structured merge summary entry (path, element count, validation
      result).
 
@@ -605,7 +607,7 @@ pitloom fragment sign   fragments/model.spdx3.json   # compute SHA-256 + write t
 | Command | Purpose |
 | :---- | :---- |
 | `fragment init` | Generate a skeleton fragment JSON-LD for the given role. Prompts for name, version, author. |
-| `fragment validate` | Run `spdx3-validate` against a fragment file; report errors and warnings. |
+| `fragment validate` | Validate a fragment file via `spdx3-validate`'s library API (`spdx3_validate.validate()`); report errors and warnings. |
 | `fragment merge --dry-run` | Simulate the full build-time merge without writing wheel output. Print the merge report. |
 | `fragment list` | Read `pyproject.toml`, list each configured fragment with: path, role, exists?, last-modified, element count (if parseable), sha256 match. |
 | `fragment sign` | Compute SHA-256 of a fragment file and write it back to the matching entry in `[tool.pitloom.fragments]`. |
@@ -700,8 +702,16 @@ all earlier items; each can be delivered independently.
 1. **CycloneDX BOM-Link emission** -- when the CycloneDX assembler is
    implemented, emit `bom-link` references for fragments instead of
    inlining all elements.
-2. **`fragment validate` CLI command** -- wraps `spdx3-validate`; clear
-   error messages with line numbers.
+2. **`fragment validate` CLI command** -- calls `spdx3-validate`'s
+   library API (`spdx3_validate.validate()`, `spdx3-validate>=0.0.7`)
+   directly rather than shelling out to its CLI and parsing stdout --
+   simpler, testable without spawning a subprocess, and gives access to
+   the structured `ValidationResult`/`.errors` list instead of printed
+   text. This makes `spdx3-validate` an actual runtime dependency of
+   Pitloom (today it's only ever agent/user-installed separately, per
+   `skills/sbom-validate/`); add it as a base dependency, or gate it
+   behind an optional-dependency group if kept opt-in. Clear error
+   messages with line numbers.
 3. **Fragment completeness declaration** -- add a `completeness` field to
    `FragmentConfig` (values: `complete`, `incomplete`, `unknown`) that
    maps to CycloneDX `compositions` and is emitted as an SPDX `Annotation`
@@ -733,7 +743,7 @@ fragment work and should be monitored for alignment opportunities.
 | [MLProvLab](https://github.com/fusion-jena/MLProvCodeGen) | JupyterLab ML provenance extension; inspiration for `%%pitloom_record` magic |
 | [AIMMX](https://github.com/IBM/AIMMX) | AI model metadata extraction at repository level; comparable to Pitloom's AI extractor |
 | [Parlay](https://github.com/snyk/parlay) | SBOM enrichment from third-party sources; inspiration for Pitloom's enrichment layer |
-| [spdx3-validate](https://pypi.org/project/spdx3-validate/) | Used in `fragment validate` and pre-merge validation |
+| [spdx3-validate](https://pypi.org/project/spdx3-validate/) | Used in `fragment validate` and pre-merge validation, via its library API (`spdx3_validate.validate()`, added in v0.0.7) rather than shelling out to its CLI |
 | [STAV](https://github.com/bact/stav) | Shared vocabulary for AI SBOM tags; already used in MLflow extractor |
 
 ---

--- a/working-docs/implementation/agent-skill.md
+++ b/working-docs/implementation/agent-skill.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-07-05
-Last-Modified: 2026-08-09
+Last-Modified: 2026-08-10
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -8,83 +8,99 @@ SPDX-License-Identifier: CC0-1.0
 
 # Using Pitloom as an AI-agent Skill
 
-Pitloom ships two Anthropic Agent-Skills, `skills/sbom/` and
-`skills/enrich/`, so an AI coding agent can generate -- and, optionally,
-help enrich -- an SBOM on request, driving the same `loom` CLI a person
-would use from a terminal.
+Pitloom ships three Anthropic Agent-Skills -- `skills/sbom-generate/`,
+`skills/sbom-enrich/`, and `skills/sbom-validate/` -- so an AI coding
+agent can generate, optionally enrich, and validate an SBOM on request,
+driving the same `loom` CLI a person would use from a terminal (plus,
+for validation, the third-party `spdx3-validate` CLI).
 
 See [adoption-surfaces.md](../design/adoption-surfaces.md) for how this
 fits alongside Pitloom's other surfaces, and
 [sbom-enrichment.md](../design/sbom-enrichment.md) for the enrichment model
-the `enrich` skill builds on.
+the `sbom-enrich` skill builds on.
 
 ## What is in the Skills
 
 ```text
 skills/
-|- sbom/
+|- sbom-generate/
 |  |- SKILL.md                  Generate a base SBOM/AIBOM.
 |  `- references/
 |     `- examples.md            Copy-paste generate recipes.
-`- enrich/
-   |- SKILL.md                  Enrich an existing SBOM as a fragment.
+|- sbom-enrich/
+|  |- SKILL.md                  Enrich an existing SBOM as a fragment.
+|  `- references/
+|     `- examples.md            A full worked fragment example.
+`- sbom-validate/
+   |- SKILL.md                  Validate an SPDX 3 document (schema + SHACL).
    `- references/
-      `- examples.md            A full worked fragment example.
+      `- examples.md            Copy-paste validate recipes.
 ```
 
-Each `SKILL.md`'s YAML front matter declares a `name` (`sbom`, `enrich`),
-a `description` written as an explicit trigger sentence -- the string an
-agent runtime matches against a user's request to decide whether to load
-that skill -- and an `argument-hint` (`[target]`, `[sbom-file]`) shown by
-Claude Code's command palette when invoking the skill explicitly (e.g.
-`/sbom <target>`). They are independent and independently triggerable:
-`sbom` always runs first (there is nothing to enrich yet otherwise);
-`enrich` is optional and only fires when asked for, or when a user
-explicitly wants to add detail Pitloom's static extraction cannot see.
+Each `SKILL.md`'s YAML front matter declares a `name`
+(`sbom-generate`/`sbom-enrich`/`sbom-validate`), a `description` written
+as an explicit trigger sentence -- the string an agent runtime matches
+against a user's request to decide whether to load that skill -- and an
+`argument-hint` (`[target]`, `[sbom-file]`) shown by Claude Code's
+command palette when invoking the skill explicitly (e.g.
+`/sbom-generate <target>`). All three are independent and independently
+triggerable: `sbom-generate` always runs first (there is nothing to
+enrich or validate yet otherwise); `sbom-enrich` is optional and only
+fires when asked for, or when a user explicitly wants to add detail
+Pitloom's static extraction cannot see; `sbom-validate` runs on any SPDX
+3 JSON document, Pitloom-generated or not.
 
 ## Installing the Skills in Claude Code
 
-Copy (or symlink) `skills/sbom/` and/or `skills/enrich/` into a skills
-directory Claude Code reads from. Copy both if you want the full
-generate-and-enrich workflow; `sbom` alone is enough for generation only.
+Copy (or symlink) any of `skills/sbom-generate/`, `skills/sbom-enrich/`,
+and `skills/sbom-validate/` into a skills directory Claude Code reads
+from. Copy all three for the full generate-enrich-validate workflow;
+`sbom-generate` alone is enough for generation only.
 
 ```bash
 # Project-scoped (checked into the repository, shared with the team):
 mkdir -p .claude/skills
-cp -r /path/to/pitloom/skills/sbom .claude/skills/
-cp -r /path/to/pitloom/skills/enrich .claude/skills/
+cp -r /path/to/pitloom/skills/sbom-generate .claude/skills/
+cp -r /path/to/pitloom/skills/sbom-enrich .claude/skills/
+cp -r /path/to/pitloom/skills/sbom-validate .claude/skills/
 
 # User-scoped (available in every project on this machine):
 mkdir -p ~/.claude/skills
-cp -r /path/to/pitloom/skills/sbom ~/.claude/skills/
-cp -r /path/to/pitloom/skills/enrich ~/.claude/skills/
+cp -r /path/to/pitloom/skills/sbom-generate ~/.claude/skills/
+cp -r /path/to/pitloom/skills/sbom-enrich ~/.claude/skills/
+cp -r /path/to/pitloom/skills/sbom-validate ~/.claude/skills/
 ```
 
 Once installed, asking Claude Code to "generate an SBOM for this project"
-(or any of the trigger phrasings in `sbom/SKILL.md`'s `description`) should
-load that skill automatically; similarly for enrichment requests and
-`enrich/SKILL.md`.
+(or any of the trigger phrasings in `sbom-generate/SKILL.md`'s
+`description`) should load that skill automatically; similarly for
+enrichment requests and `sbom-enrich/SKILL.md`, and validation requests
+and `sbom-validate/SKILL.md`.
 
-### If a skill name already exists (`sbom` or `enrich` collides)
+### If a skill name already exists (collides)
 
 A skill's invocable name comes from its **directory name**, not its
 `SKILL.md` frontmatter -- so if you already have an unrelated skill at
-`~/.claude/skills/sbom/` (or `enrich/`), copying Pitloom's version to the
-same path will simply overwrite it. Claude Code does not detect or
-resolve this for you.
+`~/.claude/skills/sbom-generate/` (or `sbom-enrich/`, `sbom-validate/`),
+copying Pitloom's version to the same path will simply overwrite it.
+Claude Code does not detect or resolve this for you. (The `sbom-`
+prefix on all three names already makes a collision unlikely -- see
+[claude-code-plugin.md](claude-code-plugin.md)'s design notes for why
+that prefix was chosen even though the Claude Code plugin surface itself
+doesn't need it.)
 
-To avoid the collision, copy under a different destination name instead,
+To avoid a collision, copy under a different destination name instead,
 e.g.:
 
 ```bash
-cp -r /path/to/pitloom/skills/sbom ~/.claude/skills/pitloom-sbom
+cp -r /path/to/pitloom/skills/sbom-generate ~/.claude/skills/pitloom-sbom-generate
 ```
 
 Renaming the destination folder is a pure filesystem operation and always
 safe:
 
-- It **does** change the explicit invocation (`/sbom` becomes
-  `/pitloom-sbom`).
+- It **does** change the explicit invocation (`/sbom-generate` becomes
+  `/pitloom-sbom-generate`).
 - It has **no effect** on natural-language auto-triggering -- that is
   driven entirely by the `description` field, not the folder name.
 - **No edits to `SKILL.md` are required.** The frontmatter `name:` field
@@ -94,56 +110,70 @@ safe:
 ## Using the Skills with the Claude Agent SDK
 
 The Agent SDK reads skills from a filesystem path in the same format. Point
-your agent's skill directory at (or copy into it) `skills/sbom/` and/or
-`skills/enrich/`; consult your SDK version's skill-loading documentation
-for the exact configuration option (typically a `skills` or `skill_dirs`
-setting on the agent/client configuration). Because each `SKILL.md` is
-self-contained -- it does not assume any Pitloom-specific tool wiring
-beyond a shell -- it works the same way regardless of which agent runtime
-loads it.
+your agent's skill directory at (or copy into it) any of
+`skills/sbom-generate/`, `skills/sbom-enrich/`, and `skills/sbom-validate/`;
+consult your SDK version's skill-loading documentation for the exact
+configuration option (typically a `skills` or `skill_dirs` setting on the
+agent/client configuration). Because each `SKILL.md` is self-contained --
+it does not assume any Pitloom-specific tool wiring beyond a shell -- it
+works the same way regardless of which agent runtime loads it.
 
 ## What the Skills actually do
 
-Neither skill contains Pitloom code of its own.
+None of the three skills contains Pitloom code of its own.
 
-1. **`sbom` -- generate.** Run `loom`/`pitloom` (via `uvx`, `pipx run`, or a
+1. **`sbom-generate`.** Run `loom`/`pitloom` (via `uvx`, `pipx run`, or a
    regular `pip install` fallback) against a project directory or an AI
    model file, producing an SPDX 3.0.1 JSON-LD SBOM.
-2. **`enrich` -- optional, after a base SBOM exists.** Read the project's
-   README or a model card, infer information static extraction cannot see
-   (a license, a dependency's purpose, a `trainedOn`/`testedOn` dataset
-   relationship), and contribute it back as a pitloom **fragment** -- a
-   small standalone SPDX 3 JSON-LD file merged in via
-   `[tool.pitloom.fragments]`. Every inferred field is provenance-marked
-   `Source: AI agent | Method: inference`, so it is never confused with
-   Pitloom's own extraction.
+2. **`sbom-enrich` -- optional, after a base SBOM exists.** Read the
+   project's README or a model card, infer information static extraction
+   cannot see (a license, a dependency's purpose, a
+   `trainedOn`/`testedOn` dataset relationship), and contribute it back
+   as a pitloom **fragment** -- a small standalone SPDX 3 JSON-LD file
+   merged in via `[tool.pitloom.fragments]`. Every inferred field is
+   provenance-marked `Source: AI agent | Method: inference`, so it is
+   never confused with Pitloom's own extraction.
+3. **`sbom-validate`.** Run the third-party
+   [`spdx3-validate`](https://github.com/JPEWdev/spdx3-validate) CLI
+   against any SPDX 3 JSON document -- schema (JSON Schema) plus shape
+   (SHACL) validation, catching a missing required property or a wrong
+   relationship type that a bare `@graph`-presence check cannot. Works on
+   Pitloom's own output, a hand-authored fragment, or a third-party SPDX
+   3 file.
 
-See `skills/sbom/references/examples.md` and
-`skills/enrich/references/examples.md` for the exact commands and a full
-worked fragment example.
+See `skills/sbom-generate/references/examples.md`,
+`skills/sbom-enrich/references/examples.md`, and
+`skills/sbom-validate/references/examples.md` for the exact commands and
+a full worked fragment example.
 
 ## Verifying the Skills work
 
 ```bash
-# sbom, project mode:
+# sbom-generate, project mode:
 loom project . -o /tmp/sbom.spdx3.json
 
-# sbom, model mode (adjust the path to a real model file):
+# sbom-generate, model mode (adjust the path to a real model file):
 loom model tests/fixtures/aimodels/onnx/squeezenet1.1-7.onnx -o /tmp/model.spdx3.json
 
 # Both should exit 0 and produce a file containing an "@graph" array.
+
+# sbom-validate, against either output above:
+pip install spdx3-validate  # if not already installed
+spdx3-validate --json /tmp/sbom.spdx3.json
 ```
 
-For the `enrich` recipe, follow `skills/enrich/references/examples.md` end
-to end: write the fragment, add a `[tool.pitloom.fragments]` entry pointing
-at it, re-run `loom`, and confirm the inferred element appears in the
-output with its `Source: AI agent | Method: inference` provenance.
+For the `sbom-enrich` recipe, follow
+`skills/sbom-enrich/references/examples.md` end to end: write the
+fragment, add a `[tool.pitloom.fragments]` entry pointing at it, re-run
+`loom`, and confirm the inferred element appears in the output with its
+`Source: AI agent | Method: inference` provenance.
 
 ## Also available as a Claude Code plugin
 
-Both Skills were written to be plugin-ready, and now are one:
+All three Skills were written to be plugin-ready, and now are one:
 `.claude-plugin/plugin.json` bundles them under the `pitloom` plugin name,
 installable with `/plugin install` directly from this repository --
-namespaced explicit invocation is `/pitloom:sbom` and `/pitloom:enrich`, no
-changes were needed to either `SKILL.md`. See
+namespaced explicit invocation is `/pitloom:sbom-generate`,
+`/pitloom:sbom-enrich`, and `/pitloom:sbom-validate`, no changes were
+needed to any `SKILL.md`. See
 [claude-code-plugin.md](claude-code-plugin.md).

--- a/working-docs/implementation/annotation-provenance.md
+++ b/working-docs/implementation/annotation-provenance.md
@@ -876,7 +876,7 @@ any of these):
   self-reported* identity: `"Source: <agent name> (<vendor>) | Method:
   inference | Date: <ISO 8601 date>"`, e.g. `"Source: Claude Code
   (Anthropic) | Method: inference | Date: 2026-08-10"`. Pitloom cannot
-  verify this at merge time — same trust model the `enrich` skill's
+  verify this at merge time — same trust model the `sbom-enrich` skill's
   existing generic `"Source: AI agent | Method: inference"` marker
   already has, just more specific when the agent knows its own identity.
 

--- a/working-docs/implementation/claude-code-plugin.md
+++ b/working-docs/implementation/claude-code-plugin.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-07-05
-Last-Modified: 2026-08-09
+Last-Modified: 2026-08-10
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -9,10 +9,10 @@ SPDX-License-Identifier: CC0-1.0
 # Using Pitloom as a Claude Code plugin
 
 Pitloom ships a Claude Code plugin, self-hosted from this repository, that
-bundles the `sbom` and `enrich` Skills (see
-[agent-skill.md](agent-skill.md)) under the `pitloom` plugin namespace.
-It is the same Skills either way -- the plugin only adds an install path
-and namespaced explicit invocation.
+bundles the `sbom-generate`, `sbom-enrich`, and `sbom-validate` Skills
+(see [agent-skill.md](agent-skill.md)) under the `pitloom` plugin
+namespace. It is the same Skills either way -- the plugin only adds an
+install path and namespaced explicit invocation.
 
 See [adoption-surfaces.md](../design/adoption-surfaces.md) for how this
 fits alongside Pitloom's other surfaces.
@@ -27,53 +27,67 @@ From a Claude Code session:
 ```
 
 This registers Pitloom's repository as a marketplace (named `pitloom`) and
-installs the `pitloom` plugin from it. Once installed, both Skills are
-available in every session, either by natural-language trigger or by
-explicit invocation (`/pitloom:sbom`, `/pitloom:enrich`).
+installs the `pitloom` plugin from it. Once installed, all three Skills
+are available in every session, either by natural-language trigger or by
+explicit invocation (`/pitloom:sbom-generate`, `/pitloom:sbom-enrich`,
+`/pitloom:sbom-validate`).
 
 ## What is in the plugin
 
 ```text
 .claude-plugin/
-|- plugin.json          Plugin manifest (name, description, author, license).
+|- plugin.json           Plugin manifest (name, description, author, license).
 `- marketplace.json      Self-hosted marketplace entry (source: "./").
 skills/
-|- sbom/                 Generate skill (see agent-skill.md) -- bundled
-|                         as-is; drives 'loom generate' / 'loom project' / 'loom wheel' / 'loom model'.
-`- enrich/               Enrich skill -- same.
+|- sbom-generate/        Generate skill (see agent-skill.md) -- bundled
+|                        as-is; drives 'loom generate' / 'loom project' / 'loom wheel' / 'loom model'.
+|- sbom-enrich/          Enrich skill -- same.
+`- sbom-validate/        Validate skill -- thin wrapper around the
+                         third-party `spdx3-validate` CLI.
 ```
 
 `plugin.json` declares no `skills` field: because `skills/` already sits
-at the repository root (the plugin root), Claude Code auto-discovers both
-`sbom/` and `enrich/`. A skill's invocable name is its **directory name**,
-namespaced by the plugin's own name -- `skills/sbom/` under plugin
-`pitloom` becomes `/pitloom:sbom`, and likewise `/pitloom:enrich`.
+at the repository root (the plugin root), Claude Code auto-discovers all
+three directories. A skill's invocable name is its **directory name**,
+namespaced by the plugin's own name -- `skills/sbom-generate/` under
+plugin `pitloom` becomes `/pitloom:sbom-generate`, and likewise for the
+other two.
 
 ## Using the Skills
 
 ```text
-/pitloom:sbom
-/pitloom:sbom models/my-model.safetensors
-/pitloom:enrich
+/pitloom:sbom-generate
+/pitloom:sbom-generate models/my-model.safetensors
+/pitloom:sbom-enrich
+/pitloom:sbom-validate
 ```
 
-Both remain triggerable by natural language too (e.g. "generate an SBOM
-for this project"), the same as when installed standalone -- the plugin
-only adds the namespaced explicit path, useful when you want to be certain
-a skill runs, or want to pass a target path or model directly as an
-argument.
+All three remain triggerable by natural language too (e.g. "generate an
+SBOM for this project"), the same as when installed standalone -- the
+plugin only adds the namespaced explicit path, useful when you want to be
+certain a skill runs, or want to pass a target path or file directly as
+an argument.
 
 ## Design notes
 
 - Skills are namespaced by the plugin's own name (`pitloom`), not by
   individual command files -- this is why the plugin is named plainly
-  `pitloom` rather than `pitloom-sbom`: the namespace prefix already
-  identifies it, so a per-skill name suffix would be redundant
-  (`/pitloom:pitloom-sbom` instead of the clean `/pitloom:sbom`).
-  Namespacing also means only the plugin's own name (`pitloom`) needs to
-  be globally unique -- not every individual skill name underneath it,
-  which is what actually protects `sbom`/`enrich` from colliding with
-  skills any other plugin might define.
+  `pitloom` rather than, say, `pitloom-sbom`: the namespace prefix
+  already identifies it, so a per-skill name suffix would be redundant
+  under this surface specifically (`/pitloom:pitloom-sbom-generate`
+  instead of `/pitloom:sbom-generate`). Namespacing also means only the
+  plugin's own name (`pitloom`) needs to be globally unique on *this*
+  surface -- not every individual skill name underneath it.
+- Skill directory names still carry an `sbom-` prefix
+  (`sbom-generate`/`sbom-enrich`/`sbom-validate`, not bare
+  `generate`/`enrich`/`validate`) even though the plugin namespace above
+  already prevents collisions here. That prefix is for the *other*
+  adoption surface: standalone/Agent-SDK skill installs (see
+  [agent-skill.md](agent-skill.md)) have no namespace at all, and bare
+  `enrich` or `validate` are exactly the kind of generic verb an
+  unrelated skill from another vendor would also claim. `sbom-` costs
+  nothing on the plugin surface (namespacing already disambiguates) and
+  buys real safety on the un-namespaced one.
 - The plugin declares an explicit `version` (semver) in `plugin.json` --
   this is a publicly installable, marketplace-listed plugin (not an
   internal/dev one), so a real version lets `claude plugin list`/`details`
@@ -87,19 +101,35 @@ argument.
   entry deliberately does **not** repeat `plugin.json`'s `description`,
   `author`, `homepage`, `repository`, `license`, `keywords`, or
   `version` -- Claude Code resolves those from `plugin.json` at
-  install/list/details time when the marketplace entry omits them
-  (verified with `claude plugin install`/`details` against a minimal
-  entry), so duplicating them here would just be two copies to keep in
-  sync for no benefit. The entry keeps only what a marketplace listing
-  needs that `plugin.json` doesn't carry: `category: "security"`, used
-  for browsing/filtering marketplace listings.
-- Both manifests declare `$schema` (SchemaStore's
-  `claude-code-plugin.json` / `claude-code-marketplace.json`) purely for
-  editor autocomplete/validation; it is ignored at load time.
+  install/list time when the marketplace entry omits them, so
+  duplicating them here would just be two copies to keep in sync for no
+  benefit. The entry keeps only what a marketplace listing needs that
+  `plugin.json` doesn't carry: `category: "security"`, used for
+  browsing/filtering marketplace listings.
+- `marketplace.json`'s own top-level description lives under
+  `metadata.description`, not a bare top-level `description` key --
+  `claude plugin validate` (CLI 2.1.114) rejects the latter as an
+  unrecognized key and, if omitted entirely, warns
+  `"No marketplace description provided"`. This is the marketplace's own
+  description (shown when browsing/listing the marketplace itself), a
+  different thing from the per-plugin entry's deliberately-omitted
+  `description` in the bullet above.
+- Neither manifest declares `$schema` -- `claude plugin validate` (CLI
+  2.1.114) rejects it as an unrecognized key at the schema root, contrary
+  to an earlier version of this note claiming it was "ignored at load
+  time" (it validated fine against an older CLI build; the strict-schema
+  behavior changed). `plugin.json` likewise has no `displayName` field in
+  the currently-validated schema -- `name` + `description` already cover
+  that. Re-verify against the installed `claude` CLI version with
+  `claude plugin validate .claude-plugin/plugin.json` /
+  `.../marketplace.json` before assuming either key is safe to add back;
+  don't rely on the SchemaStore schema URL as the source of truth --
+  it's aspirational/editor-hint only, not what the CLI actually enforces.
 - Each `SKILL.md`'s frontmatter declares `argument-hint` (`[target]` for
-  `sbom`, `[sbom-file]` for `enrich`) so the Claude Code command palette
-  shows what an explicit invocation (`/pitloom:sbom <target>`) expects,
-  even though both arguments remain optional.
+  `sbom-generate`, `[sbom-file]` for `sbom-enrich` and `sbom-validate`) so
+  the Claude Code command palette shows what an explicit invocation
+  (`/pitloom:sbom-generate <target>`) expects, even though the argument
+  remains optional in all three.
 - `.claude-plugin/` (pure manifest, no value outside `/plugin install`)
   is excluded from the sdist, like `.github`. `skills/` stays in the
   sdist as user-facing plugin content; it was never part of the wheel


### PR DESCRIPTION
## Summary

Splits validation into its own skill (dedupes drifted copies across sbom/enrich), prefixes all three with sbom- for standalone-install safety, and fixes plugin manifests failing claude plugin validate.

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
