### PR TITLE
Let sbom-enrich asks info from SBOM author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ and this project adheres to
   Annotation. ([#121])
 - AI-model metadata enrichment is available from every usage surface
   (CLI, API, Hatchling hook, GitHub Action), opt-in via config. ([#124])
+- `sbom-enrich` Skill can ask the SBOM author for missing info in
+  interactive sessions, tracked with a new `sbomAuthorSupplied`
+  provenance role. ([#125])
 
 ### Changed
 
@@ -100,6 +103,7 @@ and this project adheres to
 [#121]: https://github.com/bact/pitloom/pull/121
 [#123]: https://github.com/bact/pitloom/pull/123
 [#124]: https://github.com/bact/pitloom/pull/124
+[#125]: https://github.com/bact/pitloom/pull/125
 
 ## [0.12.0] - 2026-07-10
 

--- a/README.md
+++ b/README.md
@@ -252,8 +252,9 @@ for inputs, outputs, and more recipes.
 are ready-to-install [Agent Skills](https://www.anthropic.com/) for
 Claude Code and the Claude Agent SDK: `sbom-generate` generates an SBOM
 on request; `sbom-enrich` augments an existing one with detail read from
-a README or model card, via Pitloom's fragment system; `sbom-validate`
-checks any SPDX 3 document's schema/shape conformance.
+a README or model card (or, interactively, asked directly of the SBOM
+author), via Pitloom's fragment system; `sbom-validate` checks any
+SPDX 3 document's schema/shape conformance.
 
 ```bash
 mkdir -p ~/.claude/skills   # or .claude/skills for a project-scoped install

--- a/docs/ai-skills-and-plugin.md
+++ b/docs/ai-skills-and-plugin.md
@@ -22,8 +22,9 @@ self-hosted [Claude Code plugin][claude-code-plugins].
   AI/ML model file.
 - `sbom-enrich` -- reads a README or model card and contributes inferred
   detail (a license guess, a `trainedOn` dataset) back into an existing
-  SBOM as a provenance-marked fragment. Requires a base SBOM to already
-  exist; run `sbom-generate` first.
+  SBOM as a provenance-marked fragment; in an interactive session it can
+  also ask the SBOM author directly for gaps no file answers. Requires a
+  base SBOM to already exist; run `sbom-generate` first.
 - `sbom-validate` -- runs the third-party `spdx3-validate` CLI against
   any SPDX 3 JSON document (schema + SHACL), catching a missing required
   property or a wrong relationship type that a bare `@graph`-presence

--- a/skills/sbom-enrich/SKILL.md
+++ b/skills/sbom-enrich/SKILL.md
@@ -67,6 +67,14 @@ generic form rather than guessing:
 Source: AI agent | Method: inference
 ```
 
+**In an interactive session** (a human present to answer), a field the
+SBOM author directly tells you is not an inference -- mark it
+`sbomAuthorSupplied`, not `inference`:
+
+```text
+Source: SBOM author | Method: sbomAuthorSupplied | Date: <ISO 8601 date>
+```
+
 Steps:
 
 1. Generate a base SBOM first, if not already done (use the
@@ -93,7 +101,39 @@ Steps:
    local docs. Only propose fields for gaps step 2 left untouched --
    `loom enrich` already found everything it could from frontmatter, so
    do not re-derive or restate those same fields.
-4. Draft your own fragment (`*.spdx3.json`) containing only the elements
+4. **Interactive session only -- ask the SBOM author about remaining
+   gaps they're plausibly positioned to know:** intended use, training-data
+   provenance/consent, deployment restrictions -- not facts derivable from
+   files (those belong in steps 2-3, not here). Ask targeted questions for
+   *specific* remaining gaps only, not an open-ended interview. **Skip
+   this step entirely in a non-interactive run** (CI, batch, no human to
+   answer) -- do not block waiting for input.
+
+   **The answer decides the role -- is it the fact, or a pointer to the
+   fact?**
+   - The SBOM author states the fact itself ("it's MIT", "yes, trained on
+     our internal support-ticket corpus"): mark it `Source: SBOM author |
+     Method: sbomAuthorSupplied | Date: <ISO 8601 date>` -- never `Method:
+     inference`; you didn't derive it, you relayed what you were told.
+   - The SBOM author points at a source instead ("look at
+     CONTRIBUTING.md", "read the wiki page", "try the HF card", "infer it
+     from the changelog"): go look. The role is *never*
+     `sbomAuthorSupplied` here -- it's whichever of
+     `declared`/`externalReported`/`inferred` matches how you actually got
+     the value from that source once you looked (see the role vocabulary
+     in `working-docs/implementation/annotation-provenance.md`).
+5. **Before using any source outside this project** -- whether the SBOM
+   author pointed you at it (step 4) or you noticed it **on your own
+   initiative**: already in your context window, in another file you have
+   permission to read, or at a known remote location (e.g. PyPI, arXiv,
+   Hugging Face Hub, GitHub, GitLab, Codeberg, or a URL already visible in
+   context) -- stop and ask the SBOM author for permission first. Name
+   exactly what you found and where; an unprompted find needs an *at
+   least as* explicit ask as a prompted one, since nothing invited you to
+   go looking. Never fold such a finding into a fragment silently. That
+   permission check is a consent gate, not a provenance role -- it still
+   never makes the result `sbomAuthorSupplied`.
+6. Draft your own fragment (`*.spdx3.json`) containing only the elements
    or relationships you infer from prose (e.g. a `dataset_DatasetPackage`
    plus a `trainedOn` relationship, or a `comment` refining a license
    guess). Mark every inferred value with the provenance string above.
@@ -114,10 +154,10 @@ Steps:
    Source: <your agent name> (<vendor>) | Method: inference | Overrides: <deterministic value> | Reason: <why>
    ```
 
-   and say so explicitly in your final report (step 9) -- an override
+   and say so explicitly in your final report (step 11) -- an override
    must never be silent.
-5. **Pre-merge check (mandatory):** validate each drafted fragment (the
-   deterministic one from step 2 and your own from step 4) is
+7. **Pre-merge check (mandatory):** validate each drafted fragment (the
+   deterministic one from step 2 and your own from step 6) is
    syntactically valid JSON before registering it -- a fragment with
    broken JSON is silently dropped by `merge_fragments()`'s catch-and-warn
    behaviour, so catch it now rather than after a wasted `loom` run:
@@ -142,7 +182,7 @@ Steps:
    " fragments/agent-enrichment.spdx3.json
    ```
 
-6. Register **both** fragments so Pitloom merges them on the next run:
+8. Register **both** fragments so Pitloom merges them on the next run:
 
    ```toml
    [tool.pitloom.fragments]
@@ -152,17 +192,17 @@ Steps:
    ]
    ```
 
-7. Re-run `loom project <path>` or `loom generate <path>` (generate again) so
+9. Re-run `loom project <path>` or `loom generate <path>` (generate again) so
    the merged, enriched SBOM is written.
-8. **Post-merge check (mandatory):** use the `sbom-validate` skill on
+10. **Post-merge check (mandatory):** use the `sbom-validate` skill on
    `<merged-sbom-file>` -- a syntactically valid fragment can still be
    missing a required property or use the wrong relationship type, which
    only shape/SHACL validation catches.
 
-9. Tell the user what was found deterministically (step 2) versus
-   inferred from prose (step 4), and call out any override from step 4
-   explicitly -- this is provenance-tracked, agent-derived data, not
-   ground truth.
+11. Tell the user what was found deterministically (step 2), what was
+   inferred from prose (step 6), and what the SBOM author supplied
+   directly (step 4) -- and call out any override from step 6 explicitly
+   -- this is provenance-tracked, agent-relayed data, not ground truth.
 
 For the full enrichment data-source table, the `[tool.pitloom.enrich]`
 enable/disable model, and the dataset-relationship field map, see

--- a/skills/sbom-enrich/references/examples.md
+++ b/skills/sbom-enrich/references/examples.md
@@ -105,6 +105,30 @@ The final report to the user (step 7 below) must call this override out
 by name -- never let a silent override look identical to an ordinary
 gap-fill.
 
+### Interactive example: asking the SBOM author
+
+Say neither frontmatter nor prose says what the model was actually
+*trained* on -- only what it was evaluated on. In an interactive session,
+the agent asks the SBOM author directly, and marks the answer
+`sbomAuthorSupplied`, not `inference` -- the agent didn't derive this, it
+was told:
+
+```json
+{
+  "creationInfo": "_:creationinfo-agent",
+  "comment": "Source: SBOM author | Method: sbomAuthorSupplied | Date: 2026-08-10 -- SBOM author confirmed in the enrichment session that this model was fine-tuned on an internal, unpublished dataset not described in any project file.",
+  "dataset_datasetAvailability": "none",
+  "dataset_datasetType": ["other"],
+  "description": "Training dataset per the SBOM author, not documented in any project file.",
+  "name": "internal-finetune-set",
+  "spdxId": "https://spdx.org/spdxdocs/pitloom-agent/DatasetPackage/internal-finetune-set-01",
+  "type": "dataset_DatasetPackage"
+}
+```
+
+Skip this kind of question entirely in a non-interactive run -- there is
+no one to answer it.
+
 Notes:
 
 - `comment` on the inferred element carries the required provenance marker

--- a/src/pitloom/assemble/spdx3/provenance.py
+++ b/src/pitloom/assemble/spdx3/provenance.py
@@ -377,6 +377,18 @@ class ConflictCandidate(_ConflictCandidateRequired, total=False):
       opinion, relayed without Pitloom re-deriving it -- and not the
       subject's own claim either.
     * ``"inferred"`` -- an AI agent's non-deterministic reasoning/judgment.
+    * ``"sbomAuthorSupplied"`` -- asserted directly by the human operating
+      Pitloom (or an agent on their behalf), regardless of channel: typed
+      in answer to an agent's question in an interactive session, passed
+      as a CLI flag, or set in ``[tool.pitloom]`` config. Not
+      ``"declared"`` (that's the *artifact's* author/vendor, not the
+      SBOM's author); not ``"inferred"`` (nothing was derived -- the value
+      was simply relayed, and Pitloom can no more verify it than a
+      ``"declared"`` value). Only applies when the human states the fact
+      itself -- if they instead point at a source ("look at X", "read Y",
+      "infer it from Z"), the role is whichever of the other four
+      actually matches how the agent obtained the value once it looked
+      there; a pointer is never itself ``"sbomAuthorSupplied"``.
 
     ``source`` follows the existing ``"Key: Value | Key: Value"`` provenance
     string convention (:func:`parse_provenance_value`). ``ref`` is the
@@ -462,8 +474,9 @@ def build_enrichment_annotation(
     ``Element.creationInfo`` is singular per element. This Annotation is
     where that case's evidence lives instead: which field changed, its
     before/after value, and the role (``"declared"``/``"detected"``/
-    ``"externalReported"``/``"inferred"`` -- G2's exact vocabulary,
-    reused rather than inventing a separate one for enrichment).
+    ``"externalReported"``/``"inferred"``/``"sbomAuthorSupplied"`` -- G2's
+    exact vocabulary, reused rather than inventing a separate one for
+    enrichment).
 
     Only call this when *changes* is non-empty; a no-op enrichment run has
     nothing extrinsic to assert.

--- a/working-docs/design/adoption-surfaces.md
+++ b/working-docs/design/adoption-surfaces.md
@@ -76,6 +76,9 @@ static extraction cannot:
 - Classify what a dependency is *for*, not just that it exists.
 - Derive `trainedOn` / `testedOn` dataset relationships from documentation
   that no model file format encodes explicitly.
+- In an interactive session, ask the SBOM author directly for gaps no
+  file answers (see [sbom-enrichment.md](sbom-enrichment.md)'s
+  "Interactive mode" section).
 
 Pitloom already has the machinery to accept this safely, without blurring
 the line between "extracted fact" and "AI guess":
@@ -87,10 +90,12 @@ the line between "extracted fact" and "AI guess":
   `merge_fragments()` (see [sbom-fragments.md](sbom-fragments.md)).
 
 The `sbom-enrich` skill's guidance has an agent contribute enrichment as a
-fragment, with every inferred field marked `Source: AI agent | Method:
-inference`, so the result stays transparent and auditable. See
-[sbom-enrichment.md](sbom-enrichment.md) for the full data-source model
-this builds on.
+fragment, with every field marked with the provenance role that matches
+how it was obtained -- `Source: AI agent | Method: inference` for a
+prose-derived guess, `Source: SBOM author | Method: sbomAuthorSupplied`
+for a fact the SBOM author stated directly -- so the result stays
+transparent and auditable. See [sbom-enrichment.md](sbom-enrichment.md)
+for the full data-source model this builds on.
 
 ## Keeping surfaces consistent: product owners (proposed, not yet implemented)
 

--- a/working-docs/design/sbom-enrichment.md
+++ b/working-docs/design/sbom-enrichment.md
@@ -257,6 +257,67 @@ See `skills/sbom-enrich/SKILL.md` and
 instructions and a worked fragment example. Validate the merged result
 with the `skills/sbom-validate/` Skill.
 
+### Interactive mode: asking the SBOM author
+
+When the Skill runs in an interactive session (a human present to answer),
+it can go beyond prose inference for gaps neither the deterministic pass
+nor prose resolves -- by asking. Some fields are things the person running
+the enrichment is plausibly positioned to know even though no file states
+them -- intended use, training-data provenance/consent, deployment
+restrictions. The agent may ask a targeted question for *specific*
+remaining gaps, not run an open-ended interview.
+
+**Decision rule for the role: is the answer the fact, or a pointer to the
+fact?**
+
+1. **The SBOM author states the fact itself** ("it's MIT", "yes, trained
+   on our internal support-ticket corpus"). Role is `sbomAuthorSupplied`,
+   not `inferred` -- the agent didn't derive it, it relayed what it was
+   told, and Pitloom can no more verify it than a `declared` value. See
+   [annotation-provenance.md](../implementation/annotation-provenance.md)'s
+   role vocabulary for the full definition; the same role also covers a
+   value passed via CLI flag or `[tool.pitloom]` config, since both are
+   the SBOM author asserting a value directly, just through a different
+   channel than chat.
+2. **The SBOM author points at a source instead** ("look at
+   CONTRIBUTING.md", "read the internal wiki page", "try the HF model
+   card", "infer it from the changelog"). The role is *never*
+   `sbomAuthorSupplied` here -- the human didn't assert the fact, only
+   named where to look. The agent must actually go look, and the
+   resulting role is whichever mechanism it then used to get the value
+   out of that source: `declared` if reading a field the source states
+   about itself, `externalReported` if relaying another party's own claim
+   found there, `inferred` if the agent had to reason over prose to reach
+   it.
+
+**Consent gate for any source outside the target project** -- applies
+regardless of who initiated the lookup. Two ways this comes up:
+
+- The SBOM author points the agent at an outside source (case 2 above).
+- The agent notices something relevant **on its own initiative**, with no
+  prompting: already sitting in its context window, in another file it
+  has permission to read, or at a known remote location -- e.g. PyPI,
+  arXiv, Hugging Face Hub, GitHub, GitLab, Codeberg, or a URL already
+  visible in context. (Some of these overlap with data sources planned
+  as future *deterministic* enrichers -- see "Enricher implementation
+  approach" below; an agent-initiated lookup here is a distinct,
+  informal, interactive-session-only path, not a substitute for building
+  those.)
+
+Either way, the agent must never fold the finding into a fragment
+silently. It must name exactly what it found and where, and ask the SBOM
+author for permission to use it, before drafting anything -- an
+agent-initiated ask needs to be at least as explicit as one prompted by
+the user, since there was no request inviting the agent to go looking in
+the first place. The resulting role is still whichever of
+`declared`/`externalReported`/`inferred` matches how the value was
+obtained; the permission check is a consent gate, not a provenance role,
+and never makes the result `sbomAuthorSupplied`.
+
+In a non-interactive run (CI, batch, no human present to answer), skip
+both entirely -- do not block waiting for input; fall back to prose-only
+inference (or no enrichment) for anything these would have covered.
+
 ### Enricher implementation approach (shipped, MVP scope)
 
 1. `src/pitloom/enrich/` subpackage, one module per data source. Shipped:

--- a/working-docs/implementation/agent-skill.md
+++ b/working-docs/implementation/agent-skill.md
@@ -128,11 +128,14 @@ None of the three skills contains Pitloom code of its own.
 2. **`sbom-enrich` -- optional, after a base SBOM exists.** Read the
    project's README or a model card, infer information static extraction
    cannot see (a license, a dependency's purpose, a
-   `trainedOn`/`testedOn` dataset relationship), and contribute it back
-   as a pitloom **fragment** -- a small standalone SPDX 3 JSON-LD file
-   merged in via `[tool.pitloom.fragments]`. Every inferred field is
-   provenance-marked `Source: AI agent | Method: inference`, so it is
-   never confused with Pitloom's own extraction.
+   `trainedOn`/`testedOn` dataset relationship) -- or, in an interactive
+   session, ask the SBOM author directly for gaps no file answers -- and
+   contribute it back as a pitloom **fragment** -- a small standalone
+   SPDX 3 JSON-LD file merged in via `[tool.pitloom.fragments]`. Every
+   field is provenance-marked with the role matching how it was obtained
+   (`Source: AI agent | Method: inference` for a prose-derived guess,
+   `Source: SBOM author | Method: sbomAuthorSupplied` for a fact stated
+   directly), so it is never confused with Pitloom's own extraction.
 3. **`sbom-validate`.** Run the third-party
    [`spdx3-validate`](https://github.com/JPEWdev/spdx3-validate) CLI
    against any SPDX 3 JSON document -- schema (JSON Schema) plus shape

--- a/working-docs/implementation/annotation-provenance.md
+++ b/working-docs/implementation/annotation-provenance.md
@@ -851,6 +851,21 @@ method category):
   race against a local `declared` candidate.
 - `inferred` — an AI agent's non-deterministic reasoning/judgment. Same
   word E2 already reserves for this.
+- `sbomAuthorSupplied` — asserted directly by the human operating Pitloom
+  (or an agent on their behalf), through any channel: a CLI flag,
+  `[tool.pitloom]` config, or an answer typed in an interactive
+  `sbom-enrich` session. Not `declared` (that's the *artifact's*
+  author/vendor, not the SBOM's author); not `inferred` (nothing was
+  derived — the value was simply relayed, and Pitloom can no more verify
+  it than a `declared` value). Applies only when the human states the
+  fact itself, not when they merely point the agent at a source ("look at
+  X", "read Y", "infer it from Z") -- in that case the role is whichever
+  of `declared`/`externalReported`/`inferred` matches how the agent
+  actually obtained the value from that source once it looked, never
+  `sbomAuthorSupplied` (the human didn't assert the fact, only named
+  where to find it). Added for the `sbom-enrich` Skill's interactive mode
+  (see [sbom-enrichment.md](../design/sbom-enrichment.md)'s "Interactive
+  mode" section) — not yet exercised by any non-Skill code path.
 
 **Decision rule:** ask "whose determination is this," never "was the
 data local or remote" and never "was a rule-based algorithm involved
@@ -882,6 +897,9 @@ any of these):
   verify this at merge time — same trust model the `sbom-enrich` skill's
   existing generic `"Source: AI agent | Method: inference"` marker
   already has, just more specific when the agent knows its own identity.
+- `sbomAuthorSupplied` (future convention, not built) — `"Source: SBOM
+  author | Method: sbomAuthorSupplied | Date: <ISO 8601 date>"`; same
+  unverifiable trust model as `inferred`, just a different answerer.
 
 **Role → native relationship mapping is today's default policy, not an
 inherent law.** For license: `declared` → `hasDeclaredLicense`,
@@ -896,8 +914,8 @@ pre-existing limitation of the single detector itself, not something G2
 introduces. Once multiple detectors or confidence scoring exist, this
 mapping is where a smarter policy would plug in (e.g. falling back to
 `declared` when `detected` confidence is low) — future work, not built.
-`externalReported` and `inferred` never map to a native relationship for
-license (no 3rd/4th native slot exists).
+`externalReported`, `inferred`, and `sbomAuthorSupplied` never map to a
+native relationship for license (no 3rd/4th/5th native slot exists).
 
 **What's actually built (v1, license only).**
 [`_license.py`](../../src/pitloom/extract/_license.py)


### PR DESCRIPTION
## Summary

Expand capability of sbom-enrich skilk, allows AI agent to ask for information from the SBOM author.

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
