### PR TITLE
Update default SBOM filename

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pitloom",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Generate, enrich, and validate SPDX 3 SBOMs/AIBOMs for Python projects and AI models using Pitloom.",
   "author": {
     "name": "Arthit Suriyawongkul",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,15 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Full release notes: <https://github.com/bact/pitloom/releases>
-- Commit history: <https://github.com/bact/pitloom/compare/v0.12.0...v0.13.0>
+- Commit history: <https://github.com/bact/pitloom/compare/v0.13.0...v0.13.1>
+
+## [0.13.1] - 2026-08-11
+
+### Changed
+
+- Use default SBOM filename as suggested by [SBOM Everywhere][sbom-naming]
+
+[sbom-naming]: https://sbom-catalog.openssf.org/sbom-naming.html
 
 ## [0.13.0] - 2026-08-11
 
@@ -415,6 +423,7 @@ release because "Loom" and "Pyloom" were unavailable on PyPI.
 
 ---
 
+[0.13.1]: https://github.com/bact/pitloom/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/bact/pitloom/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/bact/pitloom/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/bact/pitloom/compare/v0.10.0...v0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,10 @@ and this project adheres to
 ### Changed
 
 - Use default SBOM filename as suggested by [SBOM Everywhere][sbom-naming]
+  ([#130])
 
 [sbom-naming]: https://sbom-catalog.openssf.org/sbom-naming.html
+[#130]: https://github.com/bact/pitloom/pull/130
 
 ## [0.13.0] - 2026-08-11
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ abstract: Generate SPDX 3 SBOMs for Python projects and AI models with native Ha
 repository-code: "https://github.com/bact/pitloom"
 type: software
 doi: 10.5281/zenodo.19246283
-version: 0.13.0
+version: 0.13.1
 license-url: "https://spdx.org/licenses/Apache-2.0"
 keywords:
   - sbom

--- a/README.md
+++ b/README.md
@@ -150,14 +150,16 @@ full surface list (Python API, Hatchling hook, GitHub Action, Skill).
 ### Hatchling build hook
 
 Pitloom can embed an SBOM automatically into every wheel you build, at
-`.dist-info/sboms/sbom.spdx3.json`, per
-[PEP 770](https://peps.python.org/pep-0770/) (wheels only). Add `pitloom`
-as a build requirement (Hatchling **1.28.0+** required) and register the
-hook:
+`.dist-info/sboms/<name>-<version>.spdx3.json` by default (e.g.
+`.dist-info/sboms/mypackage-1.0.0.spdx3.json`), per
+[PEP 770](https://peps.python.org/pep-0770/) (wheels only).
+
+Add `pitloom` as a build requirement (Hatchling **1.28.0+** required) and
+register the hook:
 
 ```toml
 [build-system]
-requires = ["hatchling>=1.31.0", "pitloom>=0.13.0"]
+requires = ["hatchling>=1.28.0", "pitloom>=0.13.1"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.hooks.pitloom]
@@ -173,7 +175,7 @@ as compact canonical JSON. Basename and fragments are configured under
 
 ```toml
 [tool.pitloom]
-sbom-basename = "sbom"   # -> "sbom.spdx3.json"
+sbom-basename = "custom-bom"       # -> "custom-bom.spdx3.json" (default: "<name>-<version>")
 
 [tool.pitloom.fragments]
 files = ["fragments/model.json"]   # merge externally tracked fragments
@@ -240,7 +242,7 @@ Add SBOM generation to any repository's CI with a single step, for any
 Python build backend, not just Hatchling:
 
 ```yaml
-- uses: bact/pitloom@v0.13.0
+- uses: bact/pitloom@v0.13.1
 ```
 
 See [working-docs/implementation/github-action.md](working-docs/implementation/github-action.md)

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ inputs:
     default: ""
   pitloom-version:
     description: >-
-      Pitloom version or version specifier to install, e.g. "0.13.0" or
+      Pitloom version or version specifier to install, e.g. "0.13.1" or
       ">=0.13,<1.0". Empty installs the latest release from PyPI.
     required: false
     default: ""
@@ -103,7 +103,7 @@ runs:
           spec="${spec}[${PL_EXTRAS}]"
         fi
         if [ -n "${PL_VERSION}" ]; then
-          # pitloom-version accepts either a bare version ("0.13.0") or a
+          # pitloom-version accepts either a bare version ("0.13.1") or a
           # full specifier (">=0.13,<1.0"). A leading comparison operator
           # means it is already a specifier; only bare versions need "=="
           # inserted, otherwise "pitloom==>=0.13,<1.0" is invalid.

--- a/codemeta.json
+++ b/codemeta.json
@@ -60,5 +60,5 @@
     "programmingLanguage": "Python 3",
     "readme": "https://github.com/bact/pitloom/blob/main/README.md",
     "url": "https://github.com/bact/pitloom",
-    "version": "0.13.0"
+    "version": "0.13.1"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,7 +80,7 @@ loom generate .
 ### GitHub Action
 
 ```yaml
-- uses: bact/pitloom@v0.13.0
+- uses: bact/pitloom@v0.13.1
 ```
 
 This creates a standalone SBOM file on the runner.
@@ -96,7 +96,7 @@ Create SBOM during Hatchling build:
 
 ```toml
 [build-system]
-requires = ["hatchling>=1.31.0", "pitloom>=0.13.0"]
+requires = ["hatchling>=1.28.0", "pitloom>=0.13.1"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.hooks.pitloom]

--- a/examples/sentimentdemo-aibom/README.md
+++ b/examples/sentimentdemo-aibom/README.md
@@ -37,7 +37,7 @@ of the final AI SBOM:
 Each stage writes a self-contained SPDX 3 JSON-LD **fragment**. The
 build hook then weaves all of them - plus dependency information taken
 straight from `pyproject.toml` - into a single composite SBOM that
-ships inside the wheel at `.dist-info/sboms/sentimentdemo.spdx3.json`
+ships inside the wheel at `.dist-info/sboms/sentimentdemo-0.1.0.spdx3.json`
 ([PEP 770](https://peps.python.org/pep-0770/)).
 
 ---
@@ -269,7 +269,7 @@ build-backend = "hatchling.build"
 enabled = true
 
 [tool.pitloom]
-sbom-basename = "sentimentdemo"
+pretty = true
 
 [tool.pitloom.fragments]
 files = [
@@ -293,7 +293,7 @@ fires automatically and does three things:
    is added to the wheel SBOM with its original `spdxId` preserved,
    so the lineage from stages 1-4 survives intact.
 3. **Embeds the composite SBOM** in the wheel at
-   `sentimentdemo-0.1.0.dist-info/sboms/sentimentdemo.spdx3.json`
+   `sentimentdemo-0.1.0.dist-info/sboms/sentimentdemo-0.1.0.spdx3.json`
    per [PEP 770](https://peps.python.org/pep-0770/).
 
 Build it:

--- a/examples/sentimentdemo-aibom/pyproject.toml
+++ b/examples/sentimentdemo-aibom/pyproject.toml
@@ -57,7 +57,6 @@ enabled = true
 
 [tool.pitloom]
 pretty = true
-sbom-basename = "sentimentdemo"
 
 [tool.pitloom.fragments]
 files = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,6 @@ module = "tests.test_extract_huggingface"
 
 [tool.pitloom]
 pretty = true
-sbom-basename = "sbom"
 
 [[tool.pitloom.creator]]
 name = "Arthit Suriyawongkul"

--- a/src/pitloom/__about__.py
+++ b/src/pitloom/__about__.py
@@ -5,4 +5,4 @@
 
 """Package information for Pitloom."""
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -706,7 +706,7 @@ def _resolve_output_path(
 def _resolve_model_output_path(explicit: Path | None, model_path: Path) -> Path:
     if explicit is not None:
         return explicit
-    return Path.cwd() / (model_path.stem + _SPDX3_JSON_EXT)
+    return Path.cwd() / (model_path.name + _SPDX3_JSON_EXT)
 
 
 def _resolve_hf_output_path(explicit: Path | None, model_id: str) -> Path:
@@ -831,7 +831,7 @@ def _run_wheel_mode(args: argparse.Namespace) -> int:
         )
 
         output_path = args.output or (
-            Path.cwd() / f"{wheel_path.stem}{_SPDX3_JSON_EXT}"
+            Path.cwd() / f"{wheel_path.name}{_SPDX3_JSON_EXT}"
         )
 
         if args.verbose:
@@ -929,7 +929,7 @@ def _run_enrich_mode(args: argparse.Namespace) -> int:
         effective_pretty = args.pretty if args.pretty is not None else False
 
         output_path = args.output or (
-            Path.cwd() / f"{model_path.stem}.enrich{_SPDX3_JSON_EXT}"
+            Path.cwd() / f"{model_path.name}.enrich{_SPDX3_JSON_EXT}"
         )
 
         if args.verbose:

--- a/src/pitloom/plugins/hatch.py
+++ b/src/pitloom/plugins/hatch.py
@@ -121,6 +121,19 @@ def _build_document_model(
     return document, merkle_root, enrichment_results_by_model
 
 
+def _default_sbom_basename(hatch_metadata: Any) -> str:
+    """Derive the default embedded-SBOM basename from package name/version.
+
+    The final wheel filename's platform/ABI/Python tags aren't resolved
+    yet at hook ``initialize()`` time, so this can't reproduce the exact
+    wheel filename -- only ``<name>-<version>``, matching what ``loom
+    project``'s own default (``_resolve_output_path``) uses.
+    """
+    name = hatch_metadata.core.raw_name
+    version = str(hatch_metadata.version) if hatch_metadata.version else None
+    return f"{name}-{version}" if version else name
+
+
 def _stage_sbom_file(
     sbom_json: str, sbom_filename: str
 ) -> tuple[tempfile.TemporaryDirectory[str], Path]:
@@ -211,7 +224,9 @@ class PitloomBuildHook(BuildHookInterface[BuilderConfig]):
         pitloom_config: PitloomConfig = read_pitloom_config(
             project_dir / "pyproject.toml"
         )
-        sbom_basename = pitloom_config.sbom_basename or "sbom"
+        sbom_basename = pitloom_config.sbom_basename or _default_sbom_basename(
+            self.metadata
+        )
         sbom_filename: str = f"{sbom_basename}{_SPDX3_JSON_EXT}"
 
         document, merkle_root, enrichment_results_by_model = _build_document_model(

--- a/tests/test_hatch_hook.py
+++ b/tests/test_hatch_hook.py
@@ -472,7 +472,7 @@ def test_hook_sbom_files_populated() -> None:
         assert len(build_data["sbom_files"]) == 1
         staged = Path(build_data["sbom_files"][0])
         assert staged.exists()
-        assert staged.name == "sbom.spdx3.json"
+        assert staged.name == "testpkg-0.1.0.spdx3.json"
 
         hook.finalize("standard", build_data, "")
 

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -448,7 +448,7 @@ def test_model_mode_explicit_output_path(
     assert captured["output_path"] == explicit_out
 
 
-def test_model_mode_default_output_path_uses_stem(
+def test_model_mode_default_output_path_uses_full_filename(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -473,7 +473,7 @@ def test_model_mode_default_output_path_uses_stem(
     assert __main__.main() == 0
     out = captured["output_path"]
     assert isinstance(out, Path)
-    assert out.name == "whisper-tiny-random.spdx3.json"
+    assert out.name == "whisper-tiny-random.safetensors.spdx3.json"
     assert out.parent == Path.cwd()
 
 
@@ -1066,7 +1066,7 @@ def test_enrich_mode_writes_fragment(
     assert ds_pkgs[0]["name"] == "tiny-imagenet"
 
 
-def test_enrich_mode_default_output_path_uses_stem(
+def test_enrich_mode_default_output_path_uses_full_filename(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -1076,7 +1076,7 @@ def test_enrich_mode_default_output_path_uses_stem(
     monkeypatch.setattr(sys, "argv", ["loom", "enrich", str(model_path)])
 
     assert __main__.main() == 0
-    assert (tmp_path / "mymodel.enrich.spdx3.json").exists()
+    assert (tmp_path / "mymodel.safetensors.enrich.spdx3.json").exists()
 
 
 def test_enrich_mode_missing_model_file_errors(

--- a/working-docs/design/architecture-overview.md
+++ b/working-docs/design/architecture-overview.md
@@ -238,8 +238,8 @@ See `working-docs/design/hatchling-build-hook.md`.
 
 #### 2. PEP 770 wheel embedding
 
-The SBOM is placed at `{name}-{version}.dist-info/sboms/sbom.spdx3.json`
-inside the wheel archive. Downstream tools (Trivy, Grype, pip-audit) can
+The SBOM is placed at `{name}-{version}.dist-info/sboms/{name}-{version}.spdx3.json`
+inside the wheel archive (default basename; overridable via `sbom-basename`). Downstream tools (Trivy, Grype, pip-audit) can
 discover and consume the SBOM without any separate distribution step.
 Implemented as part of the Hatchling build hook.
 
@@ -396,7 +396,7 @@ hatch build  /  python -m build
         ├── compute_wheel_merkle_root() (WheelBuilder file set -> deterministic UUID)
         ├── DocumentModel -> build(merkle_root) -> Spdx3JsonExporter
         ├── merge fragments/run.spdx3.json    (AI provenance)
-        └── -> .dist-info/sboms/sbom.spdx3.json  <- PEP 770
+        └── -> .dist-info/sboms/mypackage-1.0.spdx3.json  <- PEP 770
 
 Downstream consumption
 ───────────────────────

--- a/working-docs/design/hatchling-build-hook.md
+++ b/working-docs/design/hatchling-build-hook.md
@@ -31,7 +31,7 @@ Target placement for Pitloom output:
 ```text
 {name}-{version}.dist-info/
 └── sboms/
-    └── sbom.spdx3.json
+    └── {name}-{version}.spdx3.json
 ```
 
 ## Data sources from the build backend
@@ -152,7 +152,8 @@ files = []                  # List of pre-generated fragment paths to merge
 ```
 
 The full SBOM filename is derived by appending the format extension to the
-basename: `{sbom-basename}.spdx3.json` (e.g., `sbom.spdx3.json` by default).
+basename: `{sbom-basename}.spdx3.json` (e.g., `mypackage-1.0.0.spdx3.json`
+by default, from the resolved project name/version).
 
 Specifying fragments allows the hook to merge `pitloom.loom`-generated AI/ML
 fragments produced during training before the build:
@@ -169,9 +170,11 @@ files = [
 
 ### Inside the wheel (PEP 770)
 
-The default filename is `sbom.spdx3.json`. The user can override the base
-name via `sbom-basename`; the `.spdx3.json` extension is always appended by
-Pitloom to reflect the SPDX 3 JSON-LD format.
+The default filename is `{name}-{version}.spdx3.json`, derived from the
+resolved project name/version (e.g. `mypackage-1.0.0.spdx3.json`). The
+user can override the base name via `sbom-basename`; the `.spdx3.json`
+extension is always appended by Pitloom to reflect the SPDX 3 JSON-LD
+format.
 
 PEP 770 allows a wheel to contain multiple SBOM files (e.g., one per
 format), so the `sbom-basename` option is designed to be forward-compatible
@@ -289,7 +292,7 @@ Output:
   └── mypackage-1.0-py3-none-any.whl
           └── mypackage-1.0.dist-info/
                   └── sboms/
-                          └── sbom.spdx3.json
+                          └── mypackage-1.0.spdx3.json
 ```
 
 ## Source and test layout

--- a/working-docs/design/hatchling-build-hook.md
+++ b/working-docs/design/hatchling-build-hook.md
@@ -118,7 +118,7 @@ The user adds `pitloom` to their build dependencies and enables the hook:
 
 ```toml
 [build-system]
-requires = ["hatchling>=1.31.0", "pitloom>=0.13.0"]
+requires = ["hatchling>=1.31.0", "pitloom>=0.13.1"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.hooks.pitloom]

--- a/working-docs/implementation/github-action.md
+++ b/working-docs/implementation/github-action.md
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: bact/pitloom@v0.13.0
+      - uses: bact/pitloom@v0.13.1
         with:
           project-path: "."
           output: "sbom.spdx3.json"
@@ -63,7 +63,7 @@ change any of it).
 ## Recipe: AI model SBOM
 
 ```yaml
-- uses: bact/pitloom@v0.13.0
+- uses: bact/pitloom@v0.13.1
   with:
     model: "models/my-model.safetensors"
     extras: "aimodel"
@@ -79,7 +79,7 @@ Pass them through `args` (the Action itself has no dedicated multi-creator
 input):
 
 ```yaml
-- uses: bact/pitloom@v0.13.0
+- uses: bact/pitloom@v0.13.1
   with:
     project-path: "."
     output: "sbom.spdx3.json"
@@ -104,7 +104,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
-      - uses: bact/pitloom@v0.13.0
+      - uses: bact/pitloom@v0.13.1
         id: pitloom
         with:
           project-path: "."
@@ -134,7 +134,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
-      - uses: bact/pitloom@v0.13.0
+      - uses: bact/pitloom@v0.13.1
         with:
           project-path: "."
           python-version: ${{ matrix.python-version }}

--- a/working-docs/implementation/release-checklist.md
+++ b/working-docs/implementation/release-checklist.md
@@ -35,7 +35,7 @@ the release-cutting process itself, run once per version bump.
       <last-tag>..HEAD | grep "Merge pull request"` against the
       `[#NNN]:` link refs at the bottom of the file).
 - [ ] `python -m build --wheel` succeeds locally; the built wheel embeds
-      `<name>-<version>.dist-info/sboms/sbom.spdx3.json` (PEP 770).
+      `<name>-<version>.dist-info/sboms/<name>-<version>.spdx3.json` (PEP 770).
 
 ## 2. Tag and publish
 
@@ -51,7 +51,7 @@ wheel directly:
 - [ ] Resolve the wheel URL via `https://pypi.org/pypi/pitloom/<version>/json`
       and download it; verify its SHA-256 against the digest PyPI's own
       API publishes for that file.
-- [ ] Unzip it and inspect `pitloom-<version>.dist-info/sboms/sbom.spdx3.json`
+- [ ] Unzip it and inspect `pitloom-<version>.dist-info/sboms/pitloom-<version>.spdx3.json`
       directly -- the actual bytes a consumer gets, not a regenerated copy.
 - [ ] Confirm PEP 770 location, run schema + SHACL validation
       (`spdx3_validate` or the `sbom-validate` Skill), recompute every


### PR DESCRIPTION
## Summary

Use default SBOM filename as suggested by BOM Everywhere
https://sbom-catalog.openssf.org/sbom-naming.html#consistent-naming-conventions

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
