### PR TITLE
Fix missing SBOM info

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -30,7 +30,7 @@ jobs:
           pip install build
 
       - name: Install Pitloom from checkout
-        run: pip install -e .
+        run: pip install -e .[ai]
 
       - name: Build sdist and wheel
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ and this project adheres to
 - Full release notes: <https://github.com/bact/pitloom/releases>
 - Commit history: <https://github.com/bact/pitloom/compare/v0.13.0...v0.13.1>
 
+## [Unreleased]
+
+### Added
+
+- Package URL fallback (name-only) for unresolved versions
+- Copyright extraction from installed License-File
+- Supplier information from installed Author/Maintainer metadata
+- PyPI API fallback for supplier/license/integrity-hash when local install
+  doesn't have them
+- NOASSERTION fallback for copyright and license when genuinely nothing is
+  found anywhere
+- `--offline` CLI flag and `[tool.pitloom]` offline config
+
+### Fixed
+
+- Dependency name and version parsing (multi-clause specifiers)
+- Silently-discarded `hasConcludedLicense` relationship
+- parseaddr dropping multi-address Maintainer-email fields
+
 ## [0.13.1] - 2026-08-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,20 +23,21 @@ and this project adheres to
 
 ### Added
 
-- Package URL fallback (name-only) for unresolved versions
-- Copyright extraction from installed License-File
-- Supplier information from installed Author/Maintainer metadata
+- Package URL fallback (name-only) for unresolved versions ([#131])
+- Copyright extraction from installed License-File ([#131])
+- Supplier information from installed Author/Maintainer metadata ([#131])
 - PyPI API fallback for supplier/license/integrity-hash when local install
-  doesn't have them
+  doesn't have them ([#131])
 - NOASSERTION fallback for copyright and license when genuinely nothing is
-  found anywhere
-- `--offline` CLI flag and `[tool.pitloom]` offline config
+  found anywhere ([#131])
 
 ### Fixed
 
-- Dependency name and version parsing (multi-clause specifiers)
-- Silently-discarded `hasConcludedLicense` relationship
-- parseaddr dropping multi-address Maintainer-email fields
+- Dependency name and version parsing (multi-clause specifiers) ([#131])
+- Silently-discarded `hasConcludedLicense` relationship ([#131])
+- Dropping multi-address Maintainer-email fields ([#131])
+- Merkle root/`doc_uuid` platform-dependent on Windows (backslash
+  `distribution_path` from Hatchling's `os.path.join`) ([#131])
 
 ## [0.13.1] - 2026-08-11
 
@@ -47,6 +48,7 @@ and this project adheres to
 
 [sbom-naming]: https://sbom-catalog.openssf.org/sbom-naming.html
 [#130]: https://github.com/bact/pitloom/pull/130
+[#131]: https://github.com/bact/pitloom/pull/131
 
 ## [0.13.0] - 2026-08-11
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,6 +236,9 @@ max-line-length = 88
 addopts = ["--import-mode=importlib"]
 pythonpath = ["src"]
 testpaths = ["tests"]
+markers = [
+    "pypi_network: exercises the real PyPI JSON API fallback path (opts out of conftest's default network block)",
+]
 
 [tool.pylint.messages_control]
 disable = [

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -278,7 +278,13 @@ def _build_parser() -> argparse.ArgumentParser:
     gen_parser.add_argument(
         "--offline",
         action="store_true",
-        help="Forbid external network requests.",
+        help=(
+            "Forbid network access; effect depends on the resolved target -- "
+            "HF URL/ID: error, no fetch attempted (no local fallback exists). "
+            "project dir / .whl: skip PyPI lookup, no error (local metadata "
+            "already covers what it can). "
+            "local model file: no-op (no network path exists)."
+        ),
     )
 
     # 2. Project Source & Sdist: loom project [PATH]
@@ -294,6 +300,14 @@ def _build_parser() -> argparse.ArgumentParser:
         default=Path.cwd(),
         help="Path to project directory or sdist archive (.tar.gz, .zip).",
     )
+    proj_parser.add_argument(
+        "--offline",
+        action="store_true",
+        help=(
+            "Forbid network access -- skip PyPI lookup, no error "
+            "(local metadata already covers what it can)."
+        ),
+    )
 
     # 3. Built Wheel: loom wheel <WHEEL_FILE>
     wheel_parser = subparsers.add_parser(
@@ -305,6 +319,14 @@ def _build_parser() -> argparse.ArgumentParser:
         "target",
         type=str,
         help="Path to the built .whl file.",
+    )
+    wheel_parser.add_argument(
+        "--offline",
+        action="store_true",
+        help=(
+            "Forbid network access -- skip PyPI lookup, no error "
+            "(local metadata already covers what it can)."
+        ),
     )
 
     # 4. AI Model Asset: loom model <SOURCE> [--offline]
@@ -321,7 +343,11 @@ def _build_parser() -> argparse.ArgumentParser:
     model_parser.add_argument(
         "--offline",
         action="store_true",
-        help="Forbid external network requests.",
+        help=(
+            "Forbid network access; effect depends on the resolved target -- "
+            "HF URL/ID: error, no fetch attempted (no local fallback exists). "
+            "local model file: no-op (no network path exists)."
+        ),
     )
 
     # 4b. Enrichment only: loom enrich <SOURCE>
@@ -354,10 +380,18 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     # 5. Deployed Environment: loom env
-    subparsers.add_parser(
+    env_parser = subparsers.add_parser(
         "env",
         parents=[parent_parser],
         help="Generate a Deployed SBOM for the active installed environment.",
+    )
+    env_parser.add_argument(
+        "--offline",
+        action="store_true",
+        help=(
+            "Forbid network access -- skip PyPI lookup, no error "
+            "(local metadata already covers what it can)."
+        ),
     )
 
     # 6. Fragment Merger: loom merge <FRAGMENTS_DIR>
@@ -802,6 +836,7 @@ def _run_project_mode(args: argparse.Namespace) -> int:
             pitloom_config=pitloom_config,
             registry=args.registry,
             enrich=args.enrich,
+            offline=args.offline or None,
         )
         return 0
 
@@ -846,6 +881,7 @@ def _run_wheel_mode(args: argparse.Namespace) -> int:
             pretty=effective_pretty,
             describe_relationship=effective_describe,
             registry=args.registry,
+            offline=args.offline,
         )
         return 0
 
@@ -988,6 +1024,7 @@ def _run_env_mode(args: argparse.Namespace) -> int:
             pretty=effective_pretty,
             describe_relationship=effective_describe,
             registry=args.registry,
+            offline=args.offline,
         )
         return 0
 

--- a/src/pitloom/assemble/__init__.py
+++ b/src/pitloom/assemble/__init__.py
@@ -105,12 +105,18 @@ def generate_project_sbom(
     registry: str | Path | IdRegistry | None = None,
     provenance: ProvenanceConfig | None = None,
     enrich: bool | None = None,
+    offline: bool | None = None,
 ) -> str:
     """Generate a Source SPDX 3 SBOM for a Python project or sdist archive.
 
     ``enrich``: ``None`` (default) defers to ``[tool.pitloom.enrich]``
     (off by default); ``True``/``False`` overrides it for this run, applied
     to every AI model discovered in the project.
+
+    ``offline``: ``None`` (default) defers to ``[tool.pitloom] offline``
+    (network attempted, best-effort, by default); ``True``/``False``
+    overrides it for this run -- see :func:`~pitloom.assemble.spdx3.
+    document.build`.
     """
     target_path = Path(project_target)
     if project_metadata is None or pitloom_config is None:
@@ -128,6 +134,7 @@ def generate_project_sbom(
         if enrich is not None
         else pitloom_config.enrich
     )
+    effective_offline: bool = pitloom_config.offline if offline is None else offline
 
     if target_path.is_file():
         merkle_root = None
@@ -170,6 +177,7 @@ def generate_project_sbom(
         registry=resolved_registry,
         provenance=effective_provenance,
         enrichment_results_by_model=enrichment_results_by_model,
+        offline=effective_offline,
     )
 
     if target_path.is_dir():
@@ -194,6 +202,7 @@ def generate_wheel_sbom(
     describe_relationship: bool | None = None,
     registry: str | Path | IdRegistry | None = None,
     provenance: ProvenanceConfig | None = None,
+    offline: bool = False,
 ) -> str:
     """Generate an Analyzed SPDX 3 SBOM for a built Python wheel."""
     effective_pretty = False if pretty is None else pretty
@@ -225,6 +234,7 @@ def generate_wheel_sbom(
         sbom_type=spdx3_bindings.software_SbomType.analyzed,
         registry=resolved_registry,
         provenance=provenance,
+        offline=offline,
     )
 
     sbom_json = exporter.to_json(
@@ -255,6 +265,15 @@ def generate_model_sbom(
     (off by default); ``True``/``False`` overrides it for this run. Has no
     effect on a Hugging Face source -- local enrichers never run there
     (HF model cards are already parsed natively).
+
+    ``offline``: for a Hugging Face *source*, a hard requirement -- raises
+    ``ValueError`` rather than fetching it, since there's no local
+    fallback for a remote-only source. For a local model file, a no-op --
+    there's no network path in that case either way. This is a narrower
+    contract than ``generate_project_sbom``/``generate_wheel_sbom``'s
+    ``offline`` (a soft, always-silent skip of a best-effort PyPI lookup
+    that local metadata can already partly cover); the two aren't
+    interchangeable despite sharing a name.
     """
     effective_pretty = False if pretty is None else pretty
     effective_describe = (
@@ -430,6 +449,7 @@ def generate_env_sbom(
     describe_relationship: bool | None = None,
     registry: str | Path | IdRegistry | None = None,
     provenance: ProvenanceConfig | None = None,
+    offline: bool = False,
 ) -> str:
     """Generate a Deployed SPDX 3 SBOM for the current installed environment."""
     effective_pretty = False if pretty is None else pretty
@@ -457,6 +477,7 @@ def generate_env_sbom(
         env_tree=env_tree,
         registry=resolved_registry,
         provenance=provenance,
+        offline=offline,
     )
 
     sbom_json = exporter.to_json(
@@ -496,6 +517,7 @@ def generate(
             describe_relationship=describe_relationship,
             registry=registry,
             provenance=provenance,
+            offline=offline,
         )
 
     if target_str.lower().endswith(".whl"):
@@ -507,6 +529,7 @@ def generate(
             describe_relationship=describe_relationship,
             registry=registry,
             provenance=provenance,
+            offline=offline,
         )
 
     if is_huggingface_source(target_str):
@@ -563,6 +586,7 @@ def generate(
         registry=registry,
         provenance=provenance,
         enrich=enrich,
+        offline=offline,
     )
 
 

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -7,10 +7,18 @@
 
 from __future__ import annotations
 
+import re
+from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor
+from email.utils import getaddresses
 from importlib.metadata import PackageMetadata, PackageNotFoundError
+from importlib.metadata import distribution as get_pkg_distribution
 from importlib.metadata import metadata as get_pkg_metadata
 from importlib.metadata import version as get_package_version
+from typing import Any
+from urllib.parse import quote as url_quote
 
+from packaging.requirements import InvalidRequirement, Requirement
 from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.assemble.spdx3.provenance import (
@@ -25,6 +33,7 @@ from pitloom.core.models import build_pypi_purl, generate_spdx_id
 from pitloom.core.project import PhantomDependency
 from pitloom.core.provenance import ProvenanceConfig
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
+from pitloom.extract._extract_utils import fetch_json
 from pitloom.extract._license import (
     normalize_license_expression,
     tag_license_normalization,
@@ -34,14 +43,52 @@ from pitloom.extract._license import (
 # avoid splitting on a prefix of a multi-character operator (e.g. "==" before "=").
 _VERSION_OPERATORS = ("===", "~=", "!=", "==", ">=", "<=", ">", "<")
 
-# Well-known Project-URL labels that map to homePage / downloadLocation.
-# Matched case-insensitively against the label part of "Label, URL" entries.
-_HOMEPAGE_LABELS = frozenset(["homepage", "home page", "home"])
-_DOWNLOAD_LABELS = frozenset(["download"])
+# Well-known Project-URL labels that map to homePage / downloadLocation, in
+# priority order. Matched case-insensitively against the label part of
+# "Label, URL" entries. A tuple, not a set/frozenset: when a package
+# declares more than one matching label, iteration order decides which URL
+# wins, and a set's order is str-hash-dependent (PYTHONHASHSEED, randomized
+# per process by default) -- a plain tuple keeps that choice deterministic
+# across builds instead of varying by which process happened to generate
+# the SBOM.
+_HOMEPAGE_LABELS = ("homepage", "home page", "home")
+_DOWNLOAD_LABELS = ("download",)
+
+# A permissive (MIT/BSD-style) LICENSE file's copyright line, e.g.
+# "Copyright (c) 2021 Taneli Hukkinen" or "Copyright © 2019 Filipe Laíns".
+_COPYRIGHT_LINE_RE = re.compile(
+    r"^\s*Copyright\s+(?:\(c\)|©)?\s*\S.*$", re.IGNORECASE | re.MULTILINE
+)
+# Only the file's head is searched -- see _find_license_copyright.
+_COPYRIGHT_SEARCH_HEAD_CHARS = 500
+
+# Best-effort PyPI JSON API fetch timeout -- short enough that a blocked or
+# slow network doesn't meaningfully stall a build; see _fetch_pypi_release_info.
+_PYPI_TIMEOUT_SECONDS = 5.0
+
+# A `license` field this long is almost certainly a project pasting its
+# entire LICENSE file into PyPI's free-text `license` metadata (a known,
+# common anti-pattern) rather than a short identifier/expression -- treated
+# as absent rather than polluting the license/copyright fields with it.
+_PYPI_LICENSE_FIELD_MAX_LEN = 200
 
 
 def _parse_dep_name(dep: str) -> str:
-    """Return the bare package name from a PEP 508 dependency specifier."""
+    """Return the bare package name from a PEP 508 dependency specifier.
+
+    Parses *dep* as a :class:`packaging.requirements.Requirement` first, so
+    environment markers (``; sys_platform == '...'``) and multi-clause
+    specifier sets (``>=1,<2``) are handled correctly -- a naive
+    operator-substring split misidentifies the split point when a marker's
+    own ``==`` comparison is checked before the specifier's real operator,
+    or when a later clause's operator appears before an earlier one's in
+    the fixed *_VERSION_OPERATORS* priority order. Falls back to the naive
+    split only for specifiers ``Requirement`` itself can't parse.
+    """
+    try:
+        return Requirement(dep).name
+    except InvalidRequirement:
+        pass
     for op in _VERSION_OPERATORS:
         if op in dep:
             return dep.split(op)[0].strip()
@@ -52,8 +99,15 @@ def _resolve_version(dep_name: str, dep: str) -> tuple[str, str | None]:
     """Return ``(version_string, resolved_from)`` for a dependency.
 
     Tries to read the installed version via ``importlib.metadata`` first.
-    Falls back to extracting the pinned version from an ``==`` constraint,
-    or ``"unknown"`` if neither is available.
+    Falls back to extracting a pinned version (PEP 440 ``==``/``===``) from
+    the specifier set via :class:`packaging.requirements.Requirement` (so a
+    marker's own ``==`` comparison, e.g. ``sys_platform == 'linux'``, is
+    never mistaken for a version pin). If *dep* isn't valid PEP 508 at all
+    (``Requirement`` raises), falls back further to a naive ``"==" in dep``
+    substring split -- a best-effort recovery for a malformed-but-pinned
+    string, matching what a plain PEP 508 parse failure used to still
+    recover before ``Requirement``-based parsing was introduced. Returns
+    ``"unknown"`` only when none of these find a pin.
 
     Returns:
         A tuple of the version string and an optional provenance note.
@@ -67,10 +121,256 @@ def _resolve_version(dep_name: str, dep: str) -> tuple[str, str | None]:
     except PackageNotFoundError:
         pass
 
-    if "==" in dep:
-        return dep.split("==")[1].strip(), None
+    try:
+        pinned = [
+            spec.version
+            for spec in Requirement(dep).specifier
+            if spec.operator in ("==", "===")
+        ]
+    except InvalidRequirement:
+        if "==" in dep:
+            return dep.split("==")[1].strip(), None
+        return "unknown", None
+    if pinned:
+        return pinned[0], None
 
     return "unknown", None
+
+
+def _pick_supplier(name: str, email_raw: str) -> tuple[str | None, str | None] | None:
+    """Return ``(name, email)`` from one name/email metadata pair, or ``None``.
+
+    *email_raw* may carry an RFC 5322 ``"Name <email>"`` form (how PEP 621
+    ``[project.authors]`` round-trips through core metadata / PyPI's JSON
+    API), a bare address, or -- commonly for a maintainer field -- a
+    comma-separated list of several such entries; :func:`email.utils.
+    getaddresses` handles all three (unlike :func:`email.utils.parseaddr`,
+    which mis-parses a multi-entry list as one malformed address and
+    silently returns nothing). Only the first entry is used. *name* alone
+    (no email) is still a usable result.
+    """
+    name = name.strip()
+    email_raw = email_raw.strip()
+    if email_raw:
+        addresses = getaddresses([email_raw])
+        if addresses:
+            parsed_name, parsed_email = addresses[0]
+            resolved_name = parsed_name.strip() or name or None
+            resolved_email = parsed_email.strip() or None
+            if resolved_name or resolved_email:
+                return resolved_name, resolved_email
+    if name:
+        return name, None
+    return None
+
+
+def _resolve_supplier(pkg_meta: PackageMetadata) -> tuple[str | None, str | None]:
+    """Return ``(name, email)`` for a dependency's supplier from installed
+    metadata, or ``(None, None)``. Tries ``Author``/``Author-email`` first,
+    then falls back to ``Maintainer``/``Maintainer-email``."""
+    for name_field, email_field in (
+        ("Author", "Author-email"),
+        ("Maintainer", "Maintainer-email"),
+    ):
+        result = _pick_supplier(pkg_meta[name_field] or "", pkg_meta[email_field] or "")
+        if result:
+            return result
+    return None, None
+
+
+def _extract_pypi_supplier(info: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Return ``(name, email)`` for a dependency's supplier from a PyPI JSON
+    API ``info`` object, or ``(None, None)``. Same author-then-maintainer
+    precedence as :func:`_resolve_supplier`."""
+    for name_key, email_key in (
+        ("author", "author_email"),
+        ("maintainer", "maintainer_email"),
+    ):
+        result = _pick_supplier(info.get(name_key) or "", info.get(email_key) or "")
+        if result:
+            return result
+    return None, None
+
+
+def _extract_pypi_license(info: dict[str, Any]) -> str | None:
+    """Return a license expression/identifier from a PyPI JSON API ``info``
+    object, or ``None``. Prefers PEP 639 ``license_expression``, then the
+    legacy free-text ``license`` field (skipped if implausibly long -- see
+    :data:`_PYPI_LICENSE_FIELD_MAX_LEN`), then an OSI/other ``License ::``
+    trove classifier.
+    """
+    license_expression = (info.get("license_expression") or "").strip()
+    if license_expression and license_expression.upper() != "UNKNOWN":
+        return license_expression
+
+    license_field = (info.get("license") or "").strip()
+    if (
+        license_field
+        and license_field.upper() != "UNKNOWN"
+        and len(license_field) <= _PYPI_LICENSE_FIELD_MAX_LEN
+    ):
+        return license_field
+
+    classifiers: list[str] = info.get("classifiers") or []
+    for classifier in classifiers:
+        if classifier.startswith("License ::"):
+            return classifier.rsplit("::", maxsplit=1)[-1].strip()
+    return None
+
+
+def _fetch_pypi_release_info(name: str, version: str | None) -> dict[str, Any] | None:
+    """Best-effort fetch of PyPI JSON API release info for *name*, optionally
+    pinned to *version* (the unversioned endpoint returns the latest
+    release). Returns ``None`` on any failure -- no network, DNS blocked,
+    timeout, non-200, or a malformed response -- so this is always a
+    silent, non-blocking enrichment layer, never a hard requirement.
+
+    Delegates the actual fetch to :func:`~pitloom.extract._extract_utils.
+    fetch_json` (also used for Croissant metadata) rather than a second
+    urlopen/json.loads implementation, so the scheme-restriction and
+    HTTP-exception handling only need to be reviewed and gotten right once.
+    """
+    path = (
+        f"{url_quote(name)}/{url_quote(version)}/json"
+        if version
+        else f"{url_quote(name)}/json"
+    )
+    url = f"https://pypi.org/pypi/{path}"
+    try:
+        return fetch_json(url, timeout=_PYPI_TIMEOUT_SECONDS)
+    except ValueError:
+        return None
+
+
+def _extract_release_hash(release_info: dict[str, Any]) -> str | None:
+    """Return the hex SHA-256 digest of the release's wheel (preferred) or
+    sdist artifact from a PyPI JSON API response, or ``None``."""
+    urls = release_info.get("urls") or []
+    by_type = {u.get("packagetype"): u for u in urls if isinstance(u, dict)}
+    entry = by_type.get("bdist_wheel") or by_type.get("sdist")
+    if entry is None and urls:
+        entry = urls[0]
+    if entry is None:
+        return None
+    digest = (entry.get("digests") or {}).get("sha256")
+    return digest or None
+
+
+# Cap on concurrent PyPI JSON API requests, so a project with hundreds of
+# dependencies doesn't open hundreds of sockets at once.
+_PYPI_MAX_CONCURRENT_FETCHES = 8
+
+
+def _prefetch_pypi_release_infos(
+    name_versions: Iterable[tuple[str, str]],
+) -> dict[tuple[str, str | None], dict[str, Any] | None]:
+    """Concurrently fetch PyPI JSON API release info for each distinct
+    ``(name, version)`` pair, so N dependencies cost roughly one network
+    round-trip's worth of wall time instead of N sequential ones (each
+    with its own TCP+TLS handshake and up to a
+    :data:`_PYPI_TIMEOUT_SECONDS` timeout on failure).
+
+    ``version == "unknown"`` is normalized to ``None`` here, matching
+    :func:`_fetch_pypi_release_info`'s own "no pin -> latest release"
+    semantics -- so two dependencies that both have an unresolved version
+    share a single fetch instead of one per occurrence.
+    """
+    keys = {
+        (name, version if version != "unknown" else None)
+        for name, version in name_versions
+    }
+    if not keys:
+        return {}
+    results: dict[tuple[str, str | None], dict[str, Any] | None] = {}
+    with ThreadPoolExecutor(
+        max_workers=min(_PYPI_MAX_CONCURRENT_FETCHES, len(keys))
+    ) as pool:
+        futures = {
+            pool.submit(_fetch_pypi_release_info, name, version): (name, version)
+            for name, version in keys
+        }
+        for future, key in futures.items():
+            results[key] = future.result()
+    return results
+
+
+def _get_or_create_supplier_agent(
+    name: str | None,
+    email: str | None,
+    creation_info: spdx3.CreationInfo,
+    doc_name: str,
+    doc_uuid: str,
+    exporter: Spdx3JsonExporter,
+) -> str:
+    """Get or create a ``Person`` Agent for a dependency's supplier, deduped
+    by ``name``/``email`` so packages sharing an author reuse one Agent."""
+    key = f"{name or ''}|{email or ''}"
+    existing = exporter.find_agent(key)
+    if existing:
+        return existing
+
+    agent = spdx3.Person(
+        spdxId=generate_spdx_id("Person", doc_name=doc_name, doc_uuid=doc_uuid),
+        name=name or email,
+        creationInfo=creation_info,
+    )
+    if email:
+        agent.externalIdentifier = [
+            spdx3.ExternalIdentifier(
+                externalIdentifierType=spdx3.ExternalIdentifierType.email,
+                identifier=email,
+            )
+        ]
+    exporter.add_agent(agent, key=key)
+    return require_spdx_id(agent)
+
+
+def _find_license_copyright(dist_name: str, pkg_meta: PackageMetadata) -> str | None:
+    """Return a copyright statement from the dependency's installed
+    ``License-File``, or ``None`` if not found.
+
+    Only the first :data:`_COPYRIGHT_SEARCH_HEAD_CHARS` of the file are
+    searched: a permissive (MIT/BSD-style) license puts its copyright line
+    right at the top, while a copyleft/Apache-style license's boilerplate
+    body can contain the word "copyright" in an unrelated sentence deep in
+    the file (e.g. Apache-2.0 SS4's "You must retain... all copyright...
+    notices") -- restricting to the head avoids that false positive, at the
+    cost of correctly finding nothing for those license families (which
+    don't embed a per-project copyright line in ``LICENSE`` anyway; that
+    text lives in an optional, non-standardized ``NOTICE`` file instead).
+    """
+    license_files = pkg_meta.get_all("License-File") or []
+    if not license_files:
+        return None
+    try:
+        dist = get_pkg_distribution(dist_name)
+    except PackageNotFoundError:
+        return None
+
+    package_files = dist.files or []
+    for license_file in license_files:
+        for candidate in package_files:
+            if candidate.name != license_file:
+                continue
+            # License-File-declared files live under the package's own
+            # .dist-info directory (PEP 639, either directly or under its
+            # licenses/ subdirectory) -- restricting to that prevents a
+            # same-named LICENSE file elsewhere in the installed package
+            # tree (e.g. a vendored third-party library at
+            # mypkg/vendor/otherlib/LICENSE) from being matched instead of
+            # the real one, misattributing that library's copyright.
+            if not str(candidate).split("/", 1)[0].endswith(".dist-info"):
+                continue
+            try:
+                text = candidate.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            if not text:
+                continue
+            match = _COPYRIGHT_LINE_RE.search(text[:_COPYRIGHT_SEARCH_HEAD_CHARS])
+            if match:
+                return match.group(0).strip()
+    return None
 
 
 def _parse_project_urls(pkg_meta: PackageMetadata) -> dict[str, str]:
@@ -84,6 +384,76 @@ def _parse_project_urls(pkg_meta: PackageMetadata) -> dict[str, str]:
     return result
 
 
+def _resolve_metadata_url(
+    core_value: str, project_urls: dict[str, str], labels: tuple[str, ...]
+) -> str | None:
+    """Return *core_value* if set and not ``"UNKNOWN"``, else the first
+    *project_urls* entry matching one of *labels* (checked in order --
+    *labels* must be an ordered sequence, not a set, so which one wins
+    when several match is deterministic), else ``None``."""
+    value = core_value
+    if not value or value == "UNKNOWN":
+        for label in labels:
+            if label in project_urls:
+                value = project_urls[label]
+                break
+    return value if value and value != "UNKNOWN" else None
+
+
+def _apply_supplier(
+    name: str | None,
+    email: str | None,
+    dep_package: spdx3.software_Package,
+    creation_info: spdx3.CreationInfo,
+    doc_name: str,
+    doc_uuid: str,
+    exporter: Spdx3JsonExporter,
+) -> bool:
+    """Set ``suppliedBy`` to a (deduped) Agent built from *name*/*email*, if
+    either is given. Returns whether it was set."""
+    if not (name or email):
+        return False
+    dep_package.suppliedBy = _get_or_create_supplier_agent(
+        name, email, creation_info, doc_name, doc_uuid, exporter
+    )
+    return True
+
+
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+def _apply_license(
+    license_id: str | None,
+    license_provenance: str,
+    dep_package: spdx3.software_Package,
+    creation_info: spdx3.CreationInfo,
+    doc_name: str,
+    doc_uuid: str,
+    exporter: Spdx3JsonExporter,
+    *,
+    provenance_config: ProvenanceConfig | None = None,
+    encoder: ProvenanceEncoder | None = None,
+) -> bool:
+    """Build and add whichever declared/concluded license relationship(s)
+    *license_id* resolves to (see :func:`build_license_elements`). Returns
+    whether anything was added."""
+    if not license_id or license_id == "UNKNOWN":
+        return False
+    rel_declared, rel_concluded = build_license_elements(
+        license_id=license_id,
+        package_spdx_id=require_spdx_id(dep_package),
+        license_provenance=license_provenance,
+        creation_info=creation_info,
+        doc_name=doc_name,
+        doc_uuid=doc_uuid,
+        exporter=exporter,
+        provenance_config=provenance_config,
+        encoder=encoder,
+    )
+    for rel in (rel_declared, rel_concluded):
+        if rel:
+            exporter.add_relationship(rel)
+    return True
+
+
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 def _enrich_from_installed(
     dep_name: str,
@@ -95,39 +465,37 @@ def _enrich_from_installed(
     *,
     provenance_config: ProvenanceConfig | None = None,
     encoder: ProvenanceEncoder | None = None,
-) -> None:
-    """Populate optional fields on a dependency package from installed metadata."""
+) -> set[str]:
+    """Populate optional fields on a dependency package from installed metadata.
+
+    Returns which of ``{"supplier", "copyright", "license"}`` were actually
+    filled in, so :func:`add_dependencies` knows what still needs a PyPI
+    JSON API fallback or a ``NOASSERTION`` placeholder.
+    """
     try:
         pkg_meta: PackageMetadata = get_pkg_metadata(dep_name)
     except PackageNotFoundError:
-        return
+        return set()
 
+    filled: set[str] = set()
     project_urls = _parse_project_urls(pkg_meta)
-    provenance_source = f"Source: installed metadata | Package: {dep_name}"
 
     # description
     summary = pkg_meta["Summary"] or ""
     if summary and summary != "UNKNOWN":
         dep_package.description = summary
 
-    # homePage -- core field first, then well-known Project-URL labels
-    home_page = pkg_meta["Home-page"] or ""
-    if not home_page or home_page == "UNKNOWN":
-        for label in _HOMEPAGE_LABELS:
-            if label in project_urls:
-                home_page = project_urls[label]
-                break
-    if home_page and home_page != "UNKNOWN":
+    # homePage / downloadLocation -- core field first, then well-known
+    # Project-URL labels
+    home_page = _resolve_metadata_url(
+        pkg_meta["Home-page"] or "", project_urls, _HOMEPAGE_LABELS
+    )
+    if home_page:
         dep_package.software_homePage = home_page
-
-    # downloadLocation -- core field first, then well-known Project-URL labels
-    download_url = pkg_meta["Download-URL"] or ""
-    if not download_url or download_url == "UNKNOWN":
-        for label in _DOWNLOAD_LABELS:
-            if label in project_urls:
-                download_url = project_urls[label]
-                break
-    if download_url and download_url != "UNKNOWN":
+    download_url = _resolve_metadata_url(
+        pkg_meta["Download-URL"] or "", project_urls, _DOWNLOAD_LABELS
+    )
+    if download_url:
         dep_package.software_downloadLocation = download_url
 
     # packageUrl -- PyPI PURL (pkg:pypi/<name>@<version>)
@@ -135,22 +503,170 @@ def _enrich_from_installed(
     if version and version != "unknown":
         dep_package.software_packageUrl = build_pypi_purl(dep_name, version)
 
-    # hasDeclaredLicense -- prefer PEP 639 License-Expression over legacy License
+    # suppliedBy -- Person built from Author/Maintainer metadata, when known
+    supplier_name, supplier_email = _resolve_supplier(pkg_meta)
+    if _apply_supplier(
+        supplier_name,
+        supplier_email,
+        dep_package,
+        creation_info,
+        doc_name,
+        doc_uuid,
+        exporter,
+    ):
+        filled.add("supplier")
+
+    # copyrightText -- first copyright line found in a declared License-File
+    copyright_text = _find_license_copyright(dep_name, pkg_meta)
+    if copyright_text:
+        dep_package.software_copyrightText = copyright_text
+        filled.add("copyright")
+
+    # hasDeclaredLicense / hasConcludedLicense -- prefer PEP 639
+    # License-Expression over legacy License. Single-candidate mode returns
+    # exactly one of the two relationships (never both) depending on whether
+    # `_is_license_concluded` treats "installed metadata" as transparent --
+    # it doesn't, so this is always the concluded slot in practice; see
+    # _apply_license for why both are checked.
     license_id = pkg_meta["License-Expression"] or pkg_meta["License"] or ""
-    if license_id and license_id != "UNKNOWN":
-        rel_declared, _ = build_license_elements(
-            license_id=license_id,
-            package_spdx_id=require_spdx_id(dep_package),
-            license_provenance=provenance_source,
-            creation_info=creation_info,
-            doc_name=doc_name,
-            doc_uuid=doc_uuid,
-            exporter=exporter,
+    if _apply_license(
+        license_id,
+        f"Source: installed metadata | Package: {dep_name}",
+        dep_package,
+        creation_info,
+        doc_name,
+        doc_uuid,
+        exporter,
+        provenance_config=provenance_config,
+        encoder=encoder,
+    ):
+        filled.add("license")
+
+    return filled
+
+
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+def _enrich_from_pypi(
+    dep_name: str,
+    dep_version: str,
+    dep_package: spdx3.software_Package,
+    creation_info: spdx3.CreationInfo,
+    doc_name: str,
+    doc_uuid: str,
+    exporter: Spdx3JsonExporter,
+    *,
+    already_filled: set[str],
+    release_info_cache: dict[tuple[str, str | None], dict[str, Any] | None]
+    | None = None,
+    provenance_config: ProvenanceConfig | None = None,
+    encoder: ProvenanceEncoder | None = None,
+) -> set[str]:
+    """Best-effort PyPI JSON API fallback for whatever *already_filled*
+    doesn't already cover (supplier, license), plus the published
+    artifact's integrity hash -- never available from local install state
+    alone, since an installed package's unpacked files aren't the original
+    distributed wheel/sdist bytes. Silently does nothing if the network is
+    unavailable; see :func:`_fetch_pypi_release_info`.
+
+    *release_info_cache*, when given, must already contain an entry for
+    this dependency's ``(name, version)`` key -- see
+    :func:`_prefetch_pypi_release_infos`, which every current caller uses
+    to fetch all of a document's dependencies concurrently before this
+    function runs for any of them. Falls back to fetching individually
+    when omitted (e.g. a direct unit-test call).
+    """
+    version = dep_version if dep_version != "unknown" else None
+    release_info = (
+        release_info_cache.get((dep_name, version))
+        if release_info_cache is not None
+        else _fetch_pypi_release_info(dep_name, version)
+    )
+    if release_info is None:
+        return set()
+
+    filled: set[str] = set()
+    info = release_info.get("info") or {}
+
+    if "supplier" not in already_filled:
+        supplier_name, supplier_email = _extract_pypi_supplier(info)
+        if _apply_supplier(
+            supplier_name,
+            supplier_email,
+            dep_package,
+            creation_info,
+            doc_name,
+            doc_uuid,
+            exporter,
+        ):
+            filled.add("supplier")
+
+    if "license" not in already_filled:
+        license_id = _extract_pypi_license(info)
+        if _apply_license(
+            license_id,
+            f"Source: PyPI JSON API | Package: {dep_name}",
+            dep_package,
+            creation_info,
+            doc_name,
+            doc_uuid,
+            exporter,
             provenance_config=provenance_config,
             encoder=encoder,
+        ):
+            filled.add("license")
+
+    # verifiedUsing -- the published artifact's real sha256, only when a
+    # definite version is known: an unpinned/unresolved dependency has no
+    # single "the" artifact to assert an integrity hash against.
+    if version is not None:
+        digest = _extract_release_hash(release_info)
+        if digest:
+            dep_package.verifiedUsing = [
+                spdx3.Hash(algorithm=spdx3.HashAlgorithm.sha256, hashValue=digest)
+            ]
+            filled.add("hash")
+
+    return filled
+
+
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+def _add_license_noassertion(
+    dep_package: spdx3.software_Package,
+    creation_info: spdx3.CreationInfo,
+    doc_name: str,
+    doc_uuid: str,
+    exporter: Spdx3JsonExporter,
+    *,
+    provenance_config: ProvenanceConfig | None = None,
+    encoder: ProvenanceEncoder | None = None,
+) -> None:
+    """Assert ``hasDeclaredLicense: NOASSERTION`` for a package whose license
+    couldn't be determined locally or via PyPI -- an explicit "we checked
+    and don't know" is more useful to a consumer than a silently absent
+    field, and is the standard SPDX placeholder for exactly this case.
+    Deduped like any other license value, so every such package shares one
+    NOASSERTION element.
+    """
+    license_spdx_id = _get_or_create_license_element(
+        "NOASSERTION",
+        "Source: NOASSERTION (no license information found locally or via PyPI)",
+        creation_info,
+        doc_name,
+        doc_uuid,
+        exporter,
+        provenance_config=provenance_config,
+        encoder=encoder,
+    )
+    exporter.add_relationship(
+        _build_license_relationship(
+            require_spdx_id(dep_package),
+            license_spdx_id,
+            spdx3.RelationshipType.hasDeclaredLicense,
+            creation_info,
+            doc_name,
+            doc_uuid,
         )
-        if rel_declared:
-            exporter.add_relationship(rel_declared)
+    )
 
 
 def _is_license_concluded(parsed_prov: dict[str, str]) -> bool:
@@ -387,6 +903,81 @@ def build_license_elements(
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
+def _finish_dependency_enrichment(
+    dep_name: str,
+    dep_version: str,
+    dep_package: spdx3.software_Package,
+    creation_info: spdx3.CreationInfo,
+    doc_name: str,
+    doc_uuid: str,
+    exporter: Spdx3JsonExporter,
+    *,
+    offline: bool,
+    release_info_cache: dict[tuple[str, str | None], dict[str, Any] | None]
+    | None = None,
+    provenance_config: ProvenanceConfig | None = None,
+    encoder: ProvenanceEncoder | None = None,
+) -> None:
+    """Apply the shared dependency-package completeness policy to an
+    already-created *dep_package*: PURL (name-only when *dep_version* is
+    unresolved), local-install enrichment, then -- unless *offline* -- a
+    PyPI JSON API fallback for whatever's still missing, then an explicit
+    ``NOASSERTION`` for copyright/license if neither source determined
+    them. Shared by :func:`add_dependencies` (``loom project``/``loom
+    wheel``/the Hatchling hook) and :func:`~pitloom.assemble.spdx3.
+    document.build_deployed` (``loom env``) so every dependency-package
+    path gets the same NTIA-completeness treatment instead of each one
+    needing this policy re-applied by hand.
+
+    *release_info_cache*: see :func:`_enrich_from_pypi` -- pass the result
+    of a prior :func:`_prefetch_pypi_release_infos` call covering this
+    dependency to avoid a per-dependency blocking network round-trip.
+    """
+    dep_package.software_packageUrl = build_pypi_purl(
+        dep_name, dep_version if dep_version != "unknown" else None
+    )
+
+    filled = _enrich_from_installed(
+        dep_name,
+        dep_package,
+        creation_info,
+        doc_name,
+        doc_uuid,
+        exporter,
+        provenance_config=provenance_config,
+        encoder=encoder,
+    )
+
+    if not offline:
+        filled |= _enrich_from_pypi(
+            dep_name,
+            dep_version,
+            dep_package,
+            creation_info,
+            doc_name,
+            doc_uuid,
+            exporter,
+            already_filled=filled,
+            release_info_cache=release_info_cache,
+            provenance_config=provenance_config,
+            encoder=encoder,
+        )
+
+    if "copyright" not in filled:
+        dep_package.software_copyrightText = "NOASSERTION"
+    if "license" not in filled:
+        _add_license_noassertion(
+            dep_package,
+            creation_info,
+            doc_name,
+            doc_uuid,
+            exporter,
+            provenance_config=provenance_config,
+            encoder=encoder,
+        )
+
+
+# pylint: disable=too-many-arguments,too-many-positional-arguments
 def add_dependencies(
     dependencies: list[str],
     dep_provenance: str,
@@ -396,15 +987,42 @@ def add_dependencies(
     doc_uuid: str,
     exporter: Spdx3JsonExporter,
     *,
+    offline: bool = False,
     provenance_config: ProvenanceConfig | None = None,
     encoder: ProvenanceEncoder | None = None,
 ) -> None:
     """Build SPDX ``software_Package`` and ``Relationship`` elements for each
-    declared dependency."""
+    declared dependency.
+
+    Each dependency is enriched from installed metadata first (fast,
+    deterministic, no network), then -- unless *offline* -- from the PyPI
+    JSON API for whatever installed metadata didn't cover (supplier,
+    license, and the published artifact's integrity hash, which is never
+    available locally). A package whose license or copyright remains
+    unknown after both gets an explicit ``NOASSERTION`` rather than a
+    silently absent field.
+
+    The PyPI lookups for every dependency are fetched concurrently before
+    any ``software_Package``/``Relationship`` element is built -- element
+    construction itself (and the deterministic id-counters it uses) stays
+    single-threaded and in declaration order, only the network round-trips
+    overlap -- so N dependencies cost roughly one request's wall time
+    instead of N sequential ones.
+    """
+    resolved = []
     for dep in dependencies:
         dep_name = _parse_dep_name(dep)
         dep_version, version_note = _resolve_version(dep_name, dep)
+        resolved.append((dep, dep_name, dep_version, version_note))
+    release_info_cache = (
+        None
+        if offline
+        else _prefetch_pypi_release_infos(
+            (dep_name, dep_version) for _dep, dep_name, dep_version, _note in resolved
+        )
+    )
 
+    for dep, dep_name, dep_version, version_note in resolved:
         dep_provenance_fields: dict[str, str] = {
             "dependencies": dep_provenance,
             "declared_constraint": dep,
@@ -420,13 +1038,16 @@ def add_dependencies(
         dep_package.software_packageVersion = dep_version
         dep_package.software_primaryPurpose = spdx3.software_SoftwarePurpose.library
 
-        _enrich_from_installed(
+        _finish_dependency_enrichment(
             dep_name,
+            dep_version,
             dep_package,
             creation_info,
             doc_name,
             doc_uuid,
             exporter,
+            offline=offline,
+            release_info_cache=release_info_cache,
             provenance_config=provenance_config,
             encoder=encoder,
         )
@@ -468,7 +1089,18 @@ def add_phantom_dependencies(
     provenance_config: ProvenanceConfig | None = None,
     encoder: ProvenanceEncoder | None = None,
 ) -> None:
-    """Build SPDX elements for bundled phantom binary dependencies."""
+    """Build SPDX elements for bundled phantom binary dependencies.
+
+    Unlike :func:`add_dependencies`, there's no PyPI (or any registry)
+    lookup here -- a phantom dependency is a bundled shared library (e.g.
+    ``.so``/``.dll``/``.dylib``) discovered by binary inspection, not a
+    named package release, so there's no ecosystem identifier to query.
+    But the same "always assert something concrete" completeness policy
+    still applies: license/copyright get an explicit ``NOASSERTION``
+    rather than a silently absent field (see :func:`add_dependencies`),
+    and the bundled binary's own SHA-256 -- already computed locally with
+    no network needed -- becomes its ``verifiedUsing`` integrity hash.
+    """
     for dep in phantom_deps:
         dep_package = spdx3.software_Package(
             spdxId=generate_spdx_id("Package", doc_name=doc_name, doc_uuid=doc_uuid),
@@ -481,6 +1113,22 @@ def add_phantom_dependencies(
             dep_package.software_packageVersion = "unknown"
 
         dep_package.software_primaryPurpose = spdx3.software_SoftwarePurpose.library
+        dep_package.software_copyrightText = "NOASSERTION"
+        if dep.digest_sha256:
+            dep_package.verifiedUsing = [
+                spdx3.Hash(
+                    algorithm=spdx3.HashAlgorithm.sha256, hashValue=dep.digest_sha256
+                )
+            ]
+        _add_license_noassertion(
+            dep_package,
+            creation_info,
+            doc_name,
+            doc_uuid,
+            exporter,
+            provenance_config=provenance_config,
+            encoder=encoder,
+        )
 
         exporter.add_package(dep_package)
         emit_provenance(

--- a/src/pitloom/assemble/spdx3/document.py
+++ b/src/pitloom/assemble/spdx3/document.py
@@ -26,7 +26,9 @@ from pitloom.assemble.spdx3.creation_info import (
 )
 from pitloom.assemble.spdx3.dataset import add_datasets_for_model
 from pitloom.assemble.spdx3.deps import (
-    _enrich_from_installed,
+    _add_license_noassertion,
+    _finish_dependency_enrichment,
+    _prefetch_pypi_release_infos,
     add_dependencies,
     add_phantom_dependencies,
     build_license_elements,
@@ -219,12 +221,18 @@ def build(
     registry: IdRegistry | None = None,
     provenance: ProvenanceConfig | None = None,
     enrichment_results_by_model: list[list[EnrichmentResult]] | None = None,
+    offline: bool = False,
 ) -> Spdx3JsonExporter:
     """Assemble SPDX 3 elements from a :class:`~pitloom.core.document.DocumentModel`.
 
     ``enrichment_results_by_model``, when given, is one
     ``list[EnrichmentResult]`` per ``doc.ai_models`` element, same order --
     see :func:`~pitloom.assemble.spdx3.ai.add_ai_models`.
+
+    ``offline``: when ``False`` (the default), each dependency package's
+    supplier/license/copyright gaps left by installed metadata are given a
+    best-effort PyPI JSON API lookup before falling back to ``NOASSERTION``
+    -- see :func:`~pitloom.assemble.spdx3.deps.add_dependencies`.
     """
     metadata = doc.project
     prov_cfg = provenance or ProvenanceConfig()
@@ -310,7 +318,20 @@ def build(
             exporter.add_relationship(rel_declared)
         if rel_concluded:
             exporter.add_relationship(rel_concluded)
-        spdx_doc.profileConformance.append(spdx3.ProfileIdentifierType.simpleLicensing)
+    else:
+        # No license declared anywhere pitloom looked -- assert that
+        # explicitly rather than silently omitting the field; see
+        # add_dependencies' identical NOASSERTION policy for dependencies.
+        _add_license_noassertion(
+            main_package,
+            spdx_ci,
+            metadata.name,
+            doc_uuid,
+            exporter,
+            provenance_config=prov_cfg,
+            encoder=encoder,
+        )
+    spdx_doc.profileConformance.append(spdx3.ProfileIdentifierType.simpleLicensing)
 
     # --- Dependencies ---
     add_dependencies(
@@ -321,6 +342,7 @@ def build(
         doc_name=metadata.name,
         doc_uuid=doc_uuid,
         exporter=exporter,
+        offline=offline,
         provenance_config=prov_cfg,
         encoder=encoder,
     )
@@ -699,8 +721,15 @@ def build_deployed(
     *,
     registry: IdRegistry | None = None,
     provenance: ProvenanceConfig | None = None,
+    offline: bool = False,
 ) -> Spdx3JsonExporter:
-    """Assemble SPDX 3 elements for a deployed environment."""
+    """Assemble SPDX 3 elements for a deployed environment.
+
+    ``offline``: forwarded to :func:`~pitloom.assemble.spdx3.deps.
+    _finish_dependency_enrichment` for each installed package -- see
+    :func:`~pitloom.assemble.spdx3.deps.add_dependencies` for what it
+    controls.
+    """
     metadata = doc.project
     prov_cfg = provenance or ProvenanceConfig()
     encoder: ProvenanceEncoder = resolve_encoder(prov_cfg.schema)
@@ -735,6 +764,23 @@ def build_deployed(
         encoder=encoder,
     )
 
+    # PyPI lookups for every installed package are fetched concurrently up
+    # front -- see add_dependencies' identical rationale -- rather than
+    # one-by-one inside the loop below, which would otherwise cost roughly
+    # one blocking network round-trip per package in the environment.
+    release_info_cache = (
+        None
+        if offline
+        else _prefetch_pypi_release_infos(
+            (
+                node.get("package", {}).get("package_name")
+                or node.get("package", {}).get("key", "unknown"),
+                node.get("package", {}).get("installed_version", "unknown"),
+            )
+            for node in env_tree
+        )
+    )
+
     # --- First pass: Create software_Package elements ---
     package_spdx_ids: dict[str, str] = {}
     for node in env_tree:
@@ -761,13 +807,16 @@ def build_deployed(
         dep_package.software_packageVersion = dep_version
         dep_package.software_primaryPurpose = spdx3.software_SoftwarePurpose.library
 
-        _enrich_from_installed(
+        _finish_dependency_enrichment(
             dep_name,
+            dep_version,
             dep_package,
             spdx_ci,
             metadata.name,
             doc_uuid,
             exporter,
+            offline=offline,
+            release_info_cache=release_info_cache,
             provenance_config=prov_cfg,
             encoder=encoder,
         )

--- a/src/pitloom/core/config.py
+++ b/src/pitloom/core/config.py
@@ -131,6 +131,13 @@ class PitloomConfig:
             (README/model-card YAML frontmatter), from
             ``[tool.pitloom.enrich] local``. Defaults to ``False`` --
             enrichment is opt-in until more sources ship.
+        offline: Whether to skip the PyPI JSON API fallback used to fill
+            dependency-package supplier/license/integrity-hash gaps that
+            installed metadata didn't cover, from ``[tool.pitloom] offline``.
+            Defaults to ``False`` (network attempted, best-effort -- any
+            failure, including no network at all, silently falls back to
+            local-only data); set ``true`` for fully offline/hermetic/
+            air-gapped builds.
     """
 
     fragments: list[str] = field(default_factory=list)
@@ -147,6 +154,7 @@ class PitloomConfig:
     provenance_detail: str = "minimal"
     provenance_preserve_source_metadata: str = "auto"
     enrich_local: bool = False
+    offline: bool = False
 
     @property
     def provenance(self) -> ProvenanceConfig:
@@ -388,6 +396,65 @@ def _read_enrich_settings(pitloom_data: dict[str, Any]) -> bool:
     return local
 
 
+def _read_offline_setting(pitloom_data: dict[str, Any]) -> bool:
+    """Read ``[tool.pitloom] offline``.
+
+    Raises:
+        ValueError: If ``offline`` is present but not a boolean.
+    """
+    offline = pitloom_data.get("offline", False)
+    if not isinstance(offline, bool):
+        raise ValueError(
+            f"[tool.pitloom] 'offline' must be a boolean, got "
+            f"{type(offline).__name__}: {offline!r}"
+        )
+    return offline
+
+
+def _read_fragments(pitloom_data: dict[str, Any]) -> list[str]:
+    """Read ``[tool.pitloom.fragments] files``."""
+    raw = pitloom_data.get("fragments", {}).get("files", [])
+    return [str(f) for f in raw] if isinstance(raw, list) else []
+
+
+def _apply_no_creation_tool(
+    creation_data: dict[str, Any], tools: list[Tool] | None
+) -> list[Tool] | None:
+    """Apply ``[tool.pitloom.creation] no-creation-tool`` -- clear *tools*
+    (from ``[[tool.pitloom.creation-tool]]``) when set, otherwise pass
+    *tools* through unchanged.
+
+    Raises:
+        ValueError: If ``no-creation-tool`` is present but not a boolean
+            (e.g. the string ``"false"``, which is truthy in Python).
+    """
+    no_creation_tool = creation_data.get("no-creation-tool")
+    if no_creation_tool is None:
+        no_creation_tool = creation_data.get("no_creation_tool")
+    if no_creation_tool is not None and not isinstance(no_creation_tool, bool):
+        raise ValueError(
+            "[tool.pitloom.creation] 'no-creation-tool' must be a boolean, "
+            f"got {type(no_creation_tool).__name__}: {no_creation_tool!r}"
+        )
+    return [] if no_creation_tool else tools
+
+
+def _pick_str(*sources: tuple[dict[str, Any], tuple[str, ...]]) -> str | None:
+    """Return the first string found by key, scanning *sources* in order.
+
+    Each source is checked fully (all its keys) before moving to the next,
+    so an explicit empty string in a higher-priority source is returned
+    as-is -- it does not fall through to a lower-priority source the way
+    ``a or b`` would.
+    """
+    for source, keys in sources:
+        for key in keys:
+            value = source.get(key)
+            if isinstance(value, str):
+                return value
+    return None
+
+
 def _read_pitloom_config(data: dict[str, Any]) -> PitloomConfig:
     """Read ``[tool.pitloom]`` settings and return a :class:`PitloomConfig`.
 
@@ -411,25 +478,7 @@ def _read_pitloom_config(data: dict[str, Any]) -> PitloomConfig:
 
     _check_moved_creation_keys(pitloom_data, creation_data)
 
-    def _pick_str(*sources: tuple[dict[str, Any], tuple[str, ...]]) -> str | None:
-        """Return the first string found by key, scanning *sources* in order.
-
-        Each source is checked fully (all its keys) before moving to the
-        next, so an explicit empty string in a higher-priority source is
-        returned as-is -- it does not fall through to a lower-priority
-        source the way ``a or b`` would.
-        """
-        for source, keys in sources:
-            for key in keys:
-                value = source.get(key)
-                if isinstance(value, str):
-                    return value
-        return None
-
-    raw_fragments = pitloom_data.get("fragments", {}).get("files", [])
-    fragments = (
-        [str(f) for f in raw_fragments] if isinstance(raw_fragments, list) else []
-    )
+    fragments = _read_fragments(pitloom_data)
     ids_file = _read_ids_file(pitloom_data)
     (
         provenance_format,
@@ -445,19 +494,10 @@ def _read_pitloom_config(data: dict[str, Any]) -> PitloomConfig:
     if desc_rel is not None:
         desc_rel = bool(desc_rel)
     sbom_basename: str | None = pitloom_data.get("sbom-basename") or None
+    offline = _read_offline_setting(pitloom_data)
 
     creators = _read_creators(pitloom_data)
-    tools = _read_tools(pitloom_data)
-    no_creation_tool = creation_data.get("no-creation-tool")
-    if no_creation_tool is None:
-        no_creation_tool = creation_data.get("no_creation_tool")
-    if no_creation_tool is not None and not isinstance(no_creation_tool, bool):
-        raise ValueError(
-            "[tool.pitloom.creation] 'no-creation-tool' must be a boolean, "
-            f"got {type(no_creation_tool).__name__}: {no_creation_tool!r}"
-        )
-    if no_creation_tool:
-        tools = []
+    tools = _apply_no_creation_tool(creation_data, _read_tools(pitloom_data))
 
     creation_datetime = _pick_str(
         (creation_data, ("creation-datetime", "creation_datetime", "datetime")),
@@ -483,6 +523,7 @@ def _read_pitloom_config(data: dict[str, Any]) -> PitloomConfig:
         provenance_detail=provenance_detail,
         provenance_preserve_source_metadata=provenance_preserve,
         enrich_local=enrich_local,
+        offline=offline,
     )
 
 

--- a/src/pitloom/core/models.py
+++ b/src/pitloom/core/models.py
@@ -54,8 +54,8 @@ def normalize_dependency_specifier(dep: str) -> str:
     return str(req)
 
 
-def build_pypi_purl(name: str, version: str) -> str:
-    """Return a canonical ``pkg:pypi/<name>@<version>`` Package URL.
+def build_pypi_purl(name: str, version: str | None) -> str:
+    """Return a canonical ``pkg:pypi/<name>[@<version>]`` Package URL.
 
     Uses :func:`packaging.utils.canonicalize_name` for PEP 503
     canonicalization (lowercase; runs of ``-``/``_``/``.`` collapsed to a
@@ -63,8 +63,16 @@ def build_pypi_purl(name: str, version: str) -> str:
     ``pkg:pypi/zope-interface@...`` rather than the non-canonical
     ``pkg:pypi/zope.interface@...`` that a naive ``.replace("_", "-")``
     would produce (dots are left untouched by that substitution alone).
+
+    *version* is optional -- the ``@<version>`` component is a purl-spec
+    qualifier, not a requirement. Omitting it (``version=None``) still
+    yields a valid, matchable identifier for a dependency whose exact
+    version can't be resolved (e.g. an unpinned, platform-gated requirement
+    that isn't installed in the current environment) -- preferable to
+    leaving the package with no identifier at all.
     """
-    return f"pkg:pypi/{canonicalize_name(name)}@{version}"
+    base = f"pkg:pypi/{canonicalize_name(name)}"
+    return f"{base}@{version}" if version else base
 
 
 def _clear_doc_counters(doc_uuid: str) -> None:
@@ -133,8 +141,20 @@ def get_wheel_files(project_dir: Path) -> tuple[str | None, list[ProjectFile]]:
         for included_file in builder.recurse_included_files():
             source = Path(included_file.path)
             if source.is_file():
+                # Hatchling builds distribution_path with os.path.join, so
+                # it carries backslashes on Windows -- unlike a wheel's
+                # actual internal zip-entry paths, which the ZIP format
+                # itself requires to be forward-slash-separated regardless
+                # of host OS. Left un-normalized, this file's distribution
+                # path (and thus this sort key, and thus the Merkle root
+                # and doc_uuid built from it) would differ by build
+                # platform for byte-identical source content. Normalizing
+                # here matches physical_path's own .as_posix() a few lines
+                # below, and is safe on every OS: pathlib accepts forward
+                # slashes on Windows too.
+                distribution_path = included_file.distribution_path.replace("\\", "/")
                 digest_bytes = hashlib.sha256(source.read_bytes()).digest()
-                file_entries.append((included_file.distribution_path, digest_bytes))
+                file_entries.append((distribution_path, digest_bytes))
                 try:
                     rel_path = source.relative_to(project_dir).as_posix()
                 except ValueError:
@@ -142,7 +162,7 @@ def get_wheel_files(project_dir: Path) -> tuple[str | None, list[ProjectFile]]:
                 project_files.append(
                     ProjectFile(
                         physical_path=rel_path,
-                        distribution_path=included_file.distribution_path,
+                        distribution_path=distribution_path,
                         digest_sha256=digest_bytes.hex(),
                     )
                 )

--- a/src/pitloom/export/spdx3_json.py
+++ b/src/pitloom/export/spdx3_json.py
@@ -217,6 +217,10 @@ class Spdx3JsonExporter:
         self.object_set = spdx3.SHACLObjectSet()
         # Maps simplelicensing_licenseText -> spdxId for deduplication.
         self._license_index: dict[str, str] = {}
+        # Maps an arbitrary caller-chosen key (e.g. "name|email") -> spdxId,
+        # for deduplicating Agents built from external metadata (e.g. two
+        # dependencies sharing the same author).
+        self._agent_index: dict[str, str] = {}
 
     def add_creation_info(self, creation_info: spdx3.CreationInfo) -> None:
         """Add creation info to the document.
@@ -234,14 +238,26 @@ class Spdx3JsonExporter:
         """
         self.object_set.add(person)
 
-    def add_agent(self, agent: spdx3.Agent) -> None:
+    def add_agent(self, agent: spdx3.Agent, *, key: str | None = None) -> None:
         """Add a creator Agent (Person, Organization, SoftwareAgent, or the
         generic Agent).
 
         Args:
-            agent: Any ``Agent`` subclass used in ``CreationInfo.createdBy``.
+            agent: Any ``Agent`` subclass used in ``CreationInfo.createdBy``
+                or elsewhere (e.g. a dependency's ``suppliedBy``).
+            key: Optional dedup key (e.g. ``"name|email"``). When given,
+                updates the internal agent index so a subsequent
+                :meth:`find_agent` call with the same key returns this
+                agent's spdxId instead of a caller minting a duplicate.
         """
         self.object_set.add(agent)
+        if key:
+            self._agent_index[key] = require_spdx_id(agent)
+
+    def find_agent(self, key: str) -> str | None:
+        """Return the spdxId of an existing Agent registered under *key* via
+        :meth:`add_agent`, or ``None`` if not yet added."""
+        return self._agent_index.get(key)
 
     def add_package(self, package: spdx3.software_Package) -> None:
         """Add a software package to the document.

--- a/src/pitloom/extract/_extract_utils.py
+++ b/src/pitloom/extract/_extract_utils.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import http.client
 import json
 import urllib.request
 from collections.abc import Iterable
@@ -103,12 +104,14 @@ def to_str_list(value: Any) -> list[str]:
     return [s] if s else []
 
 
-def fetch_json(source: str | Path) -> dict[str, Any]:
+def fetch_json(source: str | Path, *, timeout: float = 30) -> dict[str, Any]:
     """Load and parse JSON from an HTTP/HTTPS URL or a local ``Path``.
 
     Args:
         source: A URL string (``http://`` or ``https://``) or a
             :class:`~pathlib.Path` to a local file.
+        timeout: Socket timeout in seconds for a URL *source* (ignored for a
+            local file). Default matches the historical hardcoded value.
 
     Returns:
         Parsed JSON as a ``dict``.
@@ -119,11 +122,15 @@ def fetch_json(source: str | Path) -> dict[str, Any]:
     """
     try:
         if isinstance(source, str) and source.startswith(("http://", "https://")):
-            with urllib.request.urlopen(source, timeout=30) as resp:  # nosec B310
+            with urllib.request.urlopen(source, timeout=timeout) as resp:  # nosec B310
                 raw = resp.read()
         else:
             raw = Path(source).read_bytes()
-    except OSError as exc:
+    except (OSError, http.client.HTTPException) as exc:
+        # http.client.HTTPException (e.g. IncompleteRead on a connection that
+        # closes mid-response) is not an OSError subclass, so it needs its
+        # own arm here -- without it, a transient network glitch would raise
+        # out of what every caller treats as a "fetch failed" ValueError path.
         raise ValueError(f"Cannot read source {source!r}: {exc}") from exc
 
     try:

--- a/src/pitloom/plugins/hatch.py
+++ b/src/pitloom/plugins/hatch.py
@@ -241,6 +241,7 @@ class PitloomBuildHook(BuildHookInterface[BuilderConfig]):
             registry=registry,
             provenance=pitloom_config.provenance,
             enrichment_results_by_model=enrichment_results_by_model,
+            offline=pitloom_config.offline,
         )
         merge_fragments(project_dir, pitloom_config.fragments, exporter)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,3 +16,26 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures"
 def fixtures_dir() -> Path:
     """Return the path to the test fixtures directory."""
     return FIXTURES_DIR
+
+
+@pytest.fixture(autouse=True)
+def _block_pypi_network_lookups(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Make PyPI JSON API dependency enrichment act as if offline, by default.
+
+    ``add_dependencies`` (``pitloom.assemble.spdx3.deps``) makes a real
+    network request per dependency unless ``offline=True`` is threaded all
+    the way from the caller -- which most existing SBOM-generation tests
+    don't do, since that plumbing didn't exist when they were written.
+    Without this, the whole suite would silently start making live network
+    calls, become slow, flaky, and fail offline/CI-sandboxed runs. Tests
+    that specifically exercise the PyPI fallback path opt out via the
+    ``pypi_network`` marker.
+    """
+    if "pypi_network" in request.keywords:
+        return
+    monkeypatch.setattr(
+        "pitloom.assemble.spdx3.deps._fetch_pypi_release_info",
+        lambda name, version: None,
+    )

--- a/tests/test_deps_enrichment.py
+++ b/tests/test_deps_enrichment.py
@@ -1,0 +1,991 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for dependency-package enrichment in SPDX 3 SBOMs.
+
+Covers four bugs found while reviewing a real published wheel's embedded
+SBOM against an NTIA-minimum-elements checker: two independent causes of
+"Package identifiers missing" (a name-parsing bug and a missing
+no-version PURL fallback), a silently-discarded license relationship, and
+a multi-address ``Maintainer-email`` field that a naive parser dropped
+entirely. Also covers the PyPI JSON API fallback (used when installed
+metadata doesn't cover a field) and the NOASSERTION policy for whatever
+neither source can determine.
+"""
+
+# pylint: disable=missing-function-docstring
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError
+from typing import Any
+
+import pytest
+from spdx_python_model.bindings import v3_0_1 as spdx3
+
+from pitloom.assemble.spdx3 import deps as deps_mod
+from pitloom.assemble.spdx3.deps import (
+    _add_license_noassertion,
+    _enrich_from_installed,
+    _extract_pypi_license,
+    _extract_pypi_supplier,
+    _extract_release_hash,
+    _fetch_pypi_release_info,
+    _find_license_copyright,
+    _parse_dep_name,
+    _prefetch_pypi_release_infos,
+    _resolve_metadata_url,
+    _resolve_supplier,
+    _resolve_version,
+    add_dependencies,
+)
+from pitloom.core.models import (
+    _clear_doc_counters,
+    build_pypi_purl,
+    compute_doc_uuid,
+    generate_spdx_id,
+)
+from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
+
+_DOC_NAME = "testproject"
+_DOC_UUID = compute_doc_uuid("testproject", "1.0", [])
+
+
+def _make_ci() -> spdx3.CreationInfo:
+    ci = spdx3.CreationInfo(
+        specVersion="3.0.1",
+        created=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    person = spdx3.Person(
+        spdxId=generate_spdx_id("Person", doc_name=_DOC_NAME, doc_uuid=_DOC_UUID),
+        name="Test",
+        creationInfo=ci,
+    )
+    ci.createdBy = [require_spdx_id(person)]
+    return ci
+
+
+class _FakeMetadata:
+    """Minimal stand-in satisfying the ``importlib.metadata.PackageMetadata``
+    protocol. ``__getitem__`` returns ``None`` for a missing key at runtime
+    (matching the real, ``email.message.Message``-backed implementation,
+    which the ``-> str`` protocol signature doesn't accurately capture
+    either) -- callers here always guard with ``pkg_meta[field] or ""``,
+    same as production code.
+    """
+
+    def __init__(
+        self,
+        fields: dict[str, str],
+        project_urls: list[str] | None = None,
+        license_files: list[str] | None = None,
+    ):
+        self._fields = fields
+        self._project_urls = project_urls or []
+        self._license_files = license_files or []
+
+    def __len__(self) -> int:
+        return len(self._fields)
+
+    def __contains__(self, item: str) -> bool:
+        return item in self._fields
+
+    def __getitem__(self, key: str) -> str:
+        return self._fields.get(key)  # type: ignore[return-value]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._fields)
+
+    def get_all(self, name: str, failobj: Any = None) -> Any:
+        if name == "Project-URL":
+            return self._project_urls
+        if name == "License-File":
+            return self._license_files
+        return failobj
+
+    @property
+    def json(self) -> dict[str, Any]:
+        return dict(self._fields)
+
+
+# ---------------------------------------------------------------------------
+# _parse_dep_name -- environment markers and multi-clause specifiers
+# ---------------------------------------------------------------------------
+
+
+def test_parse_dep_name_strips_environment_marker() -> None:
+    """A marker's own ``==`` comparison must not be mistaken for the
+    specifier's version operator.
+
+    Regression for the real ``auditwheel>=6.7.0; sys_platform == 'linux'``
+    dependency in Pitloom's own ``pyproject.toml``: the old naive split
+    checked ``==`` (present in the marker) before ``>=`` in a fixed
+    priority order, producing the garbled name
+    ``"auditwheel>=6.7.0; sys_platform"``.
+    """
+    assert _parse_dep_name("auditwheel>=6.7.0; sys_platform == 'linux'") == "auditwheel"
+
+
+def test_parse_dep_name_strips_python_version_marker() -> None:
+    assert _parse_dep_name("tomli>=2.4.1; python_version<'3.11'") == "tomli"
+
+
+def test_parse_dep_name_handles_multi_clause_specifier() -> None:
+    """A later clause's operator must not be matched ahead of an earlier one.
+
+    Regression for the real ``py-spdx-license>=0.0.1,<1`` dependency: after
+    ``packaging.Requirement`` normalizes/reorders the specifier set, the old
+    fixed-priority substring search matched ``>=`` (checked before ``<``)
+    wherever it appeared in the string -- even after the actual first
+    operator -- producing the garbled name ``"py-spdx-license<1,"``.
+    """
+    assert _parse_dep_name("py-spdx-license>=0.0.1,<1") == "py-spdx-license"
+    assert _parse_dep_name("pyyaml>=6.0.3,<7") == "pyyaml"
+
+
+def test_parse_dep_name_plain_specifier_still_works() -> None:
+    assert _parse_dep_name("hatchling>=1.31.0") == "hatchling"
+    assert _parse_dep_name("numpy==1.24.0") == "numpy"
+    assert _parse_dep_name("click") == "click"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_version -- a marker's "==" must not be mistaken for a version pin
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_version_ignores_marker_equality() -> None:
+    """Regression: the old ``"==" in dep`` check matched the marker's
+    ``sys_platform == 'linux'`` comparison, returning ``"'linux'"`` as the
+    "pinned version" for an uninstalled, unpinned dependency."""
+    version, note = _resolve_version(
+        "not-installed-xyz", "not-installed-xyz>=1.0; sys_platform == 'linux'"
+    )
+    assert version == "unknown"
+    assert note is None
+
+
+def test_resolve_version_extracts_real_pin() -> None:
+    version, note = _resolve_version("not-installed-xyz", "not-installed-xyz==2.5.0")
+    assert version == "2.5.0"
+    assert note is None
+
+
+def test_resolve_version_multi_clause_no_pin_is_unknown() -> None:
+    version, _ = _resolve_version("not-installed-xyz", "not-installed-xyz>=0.1,<1")
+    assert version == "unknown"
+
+
+def test_resolve_version_extracts_arbitrary_equality_pin() -> None:
+    """Regression: the pin-extraction filter only matched operator '==',
+    silently excluding PEP 440 arbitrary-equality '===' pins -- a valid,
+    parseable specifier that used to resolve to 'unknown' instead of the
+    real version."""
+    version, note = _resolve_version("not-installed-xyz", "not-installed-xyz===1.0")
+    assert version == "1.0"
+    assert note is None
+
+
+def test_resolve_version_falls_back_to_naive_split_for_unparseable_dep() -> None:
+    """Regression: a dependency string packaging.Requirement can't parse at
+    all used to still recover a best-effort pinned version via a naive
+    '==' substring split (pre-Requirement-based parsing); that fallback
+    must survive for the genuinely-unparseable case, distinct from the
+    marker-false-positive case the Requirement-based path already
+    handles correctly on its own."""
+    # A stray space makes this invalid PEP 508, but packaging.Requirement
+    # not being able to parse it doesn't mean a version can't be recovered.
+    version, note = _resolve_version("not installed", "not installed==2.0")
+    assert version == "2.0"
+    assert note is None
+
+
+# ---------------------------------------------------------------------------
+# build_pypi_purl / add_dependencies -- PURL even without a resolved version
+# ---------------------------------------------------------------------------
+
+
+def test_build_pypi_purl_omits_version_when_none() -> None:
+    assert build_pypi_purl("auditwheel", None) == "pkg:pypi/auditwheel"
+
+
+def test_build_pypi_purl_includes_version_when_known() -> None:
+    assert build_pypi_purl("auditwheel", "6.7.0") == "pkg:pypi/auditwheel@6.7.0"
+
+
+def test_add_dependencies_sets_name_only_purl_for_unresolved_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every dependency must get a PURL, even an unpinned one that isn't
+    installed -- a name-only ``pkg:pypi/<name>`` is still a valid,
+    matchable identifier, and is strictly better than no identifier at
+    all (the reviewer-flagged "Package identifiers missing" gap)."""
+
+    def _raise_not_found(_name: str) -> str:
+        raise PackageNotFoundError
+
+    monkeypatch.setattr(deps_mod, "get_package_version", _raise_not_found)
+    monkeypatch.setattr(deps_mod, "get_pkg_metadata", _raise_not_found)
+
+    doc_uuid = compute_doc_uuid("purltest", "1.0", [])
+    _clear_doc_counters(doc_uuid)
+    exporter = Spdx3JsonExporter()
+    ci = _make_ci()
+    main_pkg = spdx3.software_Package(
+        spdxId=generate_spdx_id("Package", doc_name="purltest", doc_uuid=doc_uuid),
+        name="purltest",
+        creationInfo=ci,
+    )
+    exporter.add_package(main_pkg)
+
+    add_dependencies(
+        ["auditwheel>=6.7.0; sys_platform == 'linux'"],
+        "Source: pyproject.toml | Field: project.dependencies",
+        require_spdx_id(main_pkg),
+        ci,
+        "purltest",
+        doc_uuid,
+        exporter,
+    )
+
+    packages = [
+        o for o in exporter.object_set.objects if isinstance(o, spdx3.software_Package)
+    ]
+    dep = next(p for p in packages if p.name == "auditwheel")
+    assert dep.software_packageUrl == "pkg:pypi/auditwheel"
+    assert dep.software_packageVersion == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# _enrich_from_installed -- the discarded-concluded-license-relationship bug
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_from_installed_adds_concluded_license_relationship(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: ``build_license_elements`` in single-candidate mode
+    returns exactly one of (declared, concluded) depending on whether the
+    source is "transparent" -- "installed metadata" isn't, so it always
+    returns the *concluded* slot. The caller used to do
+    ``rel_declared, _ = build_license_elements(...)``, silently discarding
+    that concluded relationship every time -- so no dependency enriched
+    from installed metadata ever got a license relationship at all, even
+    when ``License-Expression`` was present.
+    """
+    monkeypatch.setattr(
+        deps_mod,
+        "get_pkg_metadata",
+        lambda name: _FakeMetadata({"License-Expression": "MIT"}),
+    )
+
+    doc_uuid = compute_doc_uuid("lictest", "1.0", [])
+    _clear_doc_counters(doc_uuid)
+    exporter = Spdx3JsonExporter()
+    ci = _make_ci()
+    dep_package = spdx3.software_Package(
+        spdxId=generate_spdx_id("Package", doc_name="lictest", doc_uuid=doc_uuid),
+        name="tomli",
+        creationInfo=ci,
+    )
+    dep_package.software_packageVersion = "2.4.1"
+    exporter.add_package(dep_package)
+
+    _enrich_from_installed("tomli", dep_package, ci, "lictest", doc_uuid, exporter)
+
+    relationships = [
+        o for o in exporter.object_set.objects if isinstance(o, spdx3.Relationship)
+    ]
+    license_rels = [
+        r
+        for r in relationships
+        if r.from_ == require_spdx_id(dep_package)
+        and r.relationshipType
+        in (
+            spdx3.RelationshipType.hasDeclaredLicense,
+            spdx3.RelationshipType.hasConcludedLicense,
+        )
+    ]
+    assert len(license_rels) == 1
+    assert (
+        license_rels[0].relationshipType == spdx3.RelationshipType.hasConcludedLicense
+    )
+
+
+def test_enrich_from_installed_skips_license_when_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(deps_mod, "get_pkg_metadata", lambda name: _FakeMetadata({}))
+
+    doc_uuid = compute_doc_uuid("nolictest", "1.0", [])
+    _clear_doc_counters(doc_uuid)
+    exporter = Spdx3JsonExporter()
+    ci = _make_ci()
+    dep_package = spdx3.software_Package(
+        spdxId=generate_spdx_id("Package", doc_name="nolictest", doc_uuid=doc_uuid),
+        name="rfc8785",
+        creationInfo=ci,
+    )
+    dep_package.software_packageVersion = "0.1.4"
+    exporter.add_package(dep_package)
+
+    _enrich_from_installed("rfc8785", dep_package, ci, "nolictest", doc_uuid, exporter)
+
+    relationships = [
+        o for o in exporter.object_set.objects if isinstance(o, spdx3.Relationship)
+    ]
+    assert relationships == []
+
+
+# ---------------------------------------------------------------------------
+# _resolve_supplier -- single address, Maintainer fallback, multi-address list
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_supplier_from_author_email() -> None:
+    meta = _FakeMetadata({"Author-email": "Trail of Bits <opensource@trailofbits.com>"})
+    assert _resolve_supplier(meta) == ("Trail of Bits", "opensource@trailofbits.com")
+
+
+def test_resolve_supplier_falls_back_to_maintainer() -> None:
+    meta = _FakeMetadata(
+        {"Maintainer-email": "Taneli Hukkinen <hukkin@users.noreply.github.com>"}
+    )
+    assert _resolve_supplier(meta) == (
+        "Taneli Hukkinen",
+        "hukkin@users.noreply.github.com",
+    )
+
+
+def test_resolve_supplier_handles_multiple_maintainer_addresses() -> None:
+    """Regression: a comma-separated multi-maintainer ``Maintainer-email``
+    (common in real PyPI metadata, e.g. pipdeptree's three maintainers)
+    made ``email.utils.parseaddr`` -- which expects a single address --
+    return ``('', '')`` for the whole field, silently dropping a real,
+    usable supplier. ``email.utils.getaddresses`` parses the list
+    correctly; only the first entry is used.
+    """
+    meta = _FakeMetadata(
+        {
+            "Maintainer-email": (
+                "Bernát Gábor <gaborjbernat@gmail.com>, "
+                "Kemal Zebari <kemalzebra@gmail.com>, "
+                "Vineet Naik <naikvin@gmail.com>"
+            )
+        }
+    )
+    assert _resolve_supplier(meta) == ("Bernát Gábor", "gaborjbernat@gmail.com")
+
+
+def test_resolve_supplier_plain_name_no_email() -> None:
+    meta = _FakeMetadata({"Author": "Some Org"})
+    assert _resolve_supplier(meta) == ("Some Org", None)
+
+
+def test_resolve_supplier_absent_returns_none() -> None:
+    assert _resolve_supplier(_FakeMetadata({})) == (None, None)
+
+
+def test_enrich_from_installed_sets_supplied_by(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        deps_mod,
+        "get_pkg_metadata",
+        lambda name: _FakeMetadata(
+            {"Author-email": "Taneli Hukkinen <hukkin@users.noreply.github.com>"}
+        ),
+    )
+
+    doc_uuid = compute_doc_uuid("supptest", "1.0", [])
+    _clear_doc_counters(doc_uuid)
+    exporter = Spdx3JsonExporter()
+    ci = _make_ci()
+    dep_package = spdx3.software_Package(
+        spdxId=generate_spdx_id("Package", doc_name="supptest", doc_uuid=doc_uuid),
+        name="tomli",
+        creationInfo=ci,
+    )
+    dep_package.software_packageVersion = "2.4.1"
+    exporter.add_package(dep_package)
+
+    _enrich_from_installed("tomli", dep_package, ci, "supptest", doc_uuid, exporter)
+
+    assert dep_package.suppliedBy is not None
+    agents = [o for o in exporter.object_set.objects if isinstance(o, spdx3.Person)]
+    assert len(agents) == 1
+    assert agents[0].name == "Taneli Hukkinen"
+    assert dep_package.suppliedBy == require_spdx_id(agents[0])
+
+
+def test_enrich_from_installed_dedupes_shared_supplier_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two dependencies with the same author must share one Agent element,
+    not mint a duplicate for each."""
+    monkeypatch.setattr(
+        deps_mod,
+        "get_pkg_metadata",
+        lambda name: _FakeMetadata({"Author-email": "Same Author <same@example.com>"}),
+    )
+
+    doc_uuid = compute_doc_uuid("deduptest", "1.0", [])
+    _clear_doc_counters(doc_uuid)
+    exporter = Spdx3JsonExporter()
+    ci = _make_ci()
+
+    for dep_name in ("pkg-a", "pkg-b"):
+        dep_package = spdx3.software_Package(
+            spdxId=generate_spdx_id("Package", doc_name="deduptest", doc_uuid=doc_uuid),
+            name=dep_name,
+            creationInfo=ci,
+        )
+        dep_package.software_packageVersion = "1.0.0"
+        exporter.add_package(dep_package)
+        _enrich_from_installed(
+            dep_name, dep_package, ci, "deduptest", doc_uuid, exporter
+        )
+
+    agents = [o for o in exporter.object_set.objects if isinstance(o, spdx3.Person)]
+    assert len(agents) == 1
+
+
+# ---------------------------------------------------------------------------
+# _find_license_copyright -- License-File must be matched under .dist-info
+# ---------------------------------------------------------------------------
+
+
+class _FakePackagePath:
+    """Minimal stand-in for ``importlib.metadata.PackagePath``."""
+
+    def __init__(self, path: str, content: str):
+        self._path = path
+        self._content = content
+
+    @property
+    def name(self) -> str:
+        return self._path.rsplit("/", maxsplit=1)[-1]
+
+    def __str__(self) -> str:
+        return self._path
+
+    def read_text(self, encoding: str = "utf-8") -> str:
+        _ = encoding
+        return self._content
+
+
+# pylint: disable-next=too-few-public-methods
+class _FakeDistribution:
+    def __init__(self, files: list[_FakePackagePath]):
+        self.files = files
+
+
+def test_find_license_copyright_ignores_same_named_file_outside_dist_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: License-File was matched by basename only
+    (candidate.name != license_file), so a same-named LICENSE file
+    bundled elsewhere in the installed package tree -- e.g. vendored
+    third-party code at mypkg/vendor/otherlib/LICENSE -- could be matched
+    instead of the real dist-info one, misattributing that library's
+    copyright to the dependency. Listed first here specifically to prove
+    basename-only matching would have picked it.
+    """
+    vendored_license = _FakePackagePath(
+        "mypkg/vendor/otherlib/LICENSE",
+        "Copyright (c) 2015 Vendored Author\n",
+    )
+    real_license = _FakePackagePath(
+        "mypkg-1.0.dist-info/licenses/LICENSE",
+        "Copyright (c) 2026 Real Author\n",
+    )
+    fake_dist = _FakeDistribution([vendored_license, real_license])
+    monkeypatch.setattr(deps_mod, "get_pkg_distribution", lambda name: fake_dist)
+
+    meta = _FakeMetadata({}, license_files=["LICENSE"])
+    assert _find_license_copyright("mypkg", meta) == "Copyright (c) 2026 Real Author"
+
+
+def test_find_license_copyright_matches_dist_info_root_not_only_licenses_subdir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    license_file = _FakePackagePath(
+        "mypkg-1.0.dist-info/LICENSE.txt",
+        "Copyright (c) 2026 Root Dist-Info Author\n",
+    )
+    fake_dist = _FakeDistribution([license_file])
+    monkeypatch.setattr(deps_mod, "get_pkg_distribution", lambda name: fake_dist)
+
+    meta = _FakeMetadata({}, license_files=["LICENSE.txt"])
+    assert (
+        _find_license_copyright("mypkg", meta)
+        == "Copyright (c) 2026 Root Dist-Info Author"
+    )
+
+
+# ---------------------------------------------------------------------------
+# PyPI JSON API extraction helpers (pure functions, no network)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_pypi_supplier_from_author() -> None:
+    info = {"author": "Trail of Bits", "author_email": "opensource@trailofbits.com"}
+    assert _extract_pypi_supplier(info) == (
+        "Trail of Bits",
+        "opensource@trailofbits.com",
+    )
+
+
+def test_extract_pypi_supplier_falls_back_to_maintainer() -> None:
+    info = {"maintainer": "Someone", "maintainer_email": "someone@example.com"}
+    assert _extract_pypi_supplier(info) == ("Someone", "someone@example.com")
+
+
+def test_extract_pypi_supplier_absent_returns_none() -> None:
+    assert _extract_pypi_supplier({}) == (None, None)
+
+
+def test_extract_pypi_license_prefers_license_expression() -> None:
+    info = {"license_expression": "MIT", "license": "some legacy free text"}
+    assert _extract_pypi_license(info) == "MIT"
+
+
+def test_extract_pypi_license_falls_back_to_legacy_field() -> None:
+    assert _extract_pypi_license({"license": "Apache-2.0"}) == "Apache-2.0"
+
+
+def test_extract_pypi_license_ignores_implausibly_long_legacy_field() -> None:
+    """Regression guard: some PyPI projects paste their entire LICENSE file
+    into the free-text ``license`` metadata field -- that must not be
+    treated as a short license identifier/expression."""
+    info = {"license": "A" * 500}
+    assert _extract_pypi_license(info) is None
+
+
+def test_extract_pypi_license_falls_back_to_classifier() -> None:
+    info = {
+        "classifiers": [
+            "Programming Language :: Python :: 3",
+            "License :: OSI Approved :: MIT License",
+        ]
+    }
+    assert _extract_pypi_license(info) == "MIT License"
+
+
+def test_extract_pypi_license_absent_returns_none() -> None:
+    assert _extract_pypi_license({}) is None
+
+
+def test_extract_release_hash_prefers_wheel() -> None:
+    release_info = {
+        "urls": [
+            {"packagetype": "sdist", "digests": {"sha256": "sdist-hash"}},
+            {"packagetype": "bdist_wheel", "digests": {"sha256": "wheel-hash"}},
+        ]
+    }
+    assert _extract_release_hash(release_info) == "wheel-hash"
+
+
+def test_extract_release_hash_falls_back_to_sdist() -> None:
+    release_info = {
+        "urls": [{"packagetype": "sdist", "digests": {"sha256": "sdist-hash"}}]
+    }
+    assert _extract_release_hash(release_info) == "sdist-hash"
+
+
+def test_extract_release_hash_no_urls_returns_none() -> None:
+    assert _extract_release_hash({"urls": []}) is None
+    assert _extract_release_hash({}) is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_metadata_url -- deterministic label priority, not hash-order
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_metadata_url_prefers_core_field() -> None:
+    assert (
+        _resolve_metadata_url("https://core.example", {"home": "https://x"}, ("home",))
+        == "https://core.example"
+    )
+
+
+def test_resolve_metadata_url_falls_back_to_first_matching_label_in_order() -> None:
+    """Regression: labels used to be a frozenset, so which of several
+    matching Project-URL labels won was dependent on Python's per-process
+    string-hash randomization (PYTHONHASHSEED) rather than a fixed
+    priority -- breaking build-to-build SBOM reproducibility. Verified
+    empirically that a frozenset of these exact three strings iterates in
+    different orders across different hash seeds; a tuple does not."""
+    project_urls = {"home": "https://a.example", "homepage": "https://b.example"}
+    assert (
+        _resolve_metadata_url("", project_urls, ("homepage", "home page", "home"))
+        == "https://b.example"
+    )
+    assert (
+        _resolve_metadata_url("", project_urls, ("home", "home page", "homepage"))
+        == "https://a.example"
+    )
+
+
+def test_resolve_metadata_url_none_when_nothing_matches() -> None:
+    assert _resolve_metadata_url("", {}, ("homepage", "home")) is None
+    assert _resolve_metadata_url("UNKNOWN", {}, ("homepage", "home")) is None
+
+
+# ---------------------------------------------------------------------------
+# add_dependencies -- PyPI fallback integration, NOASSERTION policy, offline
+# ---------------------------------------------------------------------------
+
+
+def _uninstalled(*_args: object, **_kwargs: object) -> None:
+    raise PackageNotFoundError
+
+
+def test_add_dependencies_pypi_fallback_fills_gaps_and_hash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When a dependency isn't installed locally, offline=False must reach
+    the PyPI JSON API for supplier/license/hash, and never assert
+    NOASSERTION for fields that lookup actually filled."""
+    monkeypatch.setattr(deps_mod, "get_package_version", _uninstalled)
+    monkeypatch.setattr(deps_mod, "get_pkg_metadata", _uninstalled)
+    monkeypatch.setattr(
+        deps_mod,
+        "_fetch_pypi_release_info",
+        lambda name, version: {
+            "info": {
+                "author": "Some Author",
+                "author_email": "author@example.com",
+                "license_expression": "MIT",
+            },
+            "urls": [
+                {"packagetype": "bdist_wheel", "digests": {"sha256": "deadbeef" * 8}},
+            ],
+        },
+    )
+
+    doc_uuid = compute_doc_uuid("pypitest", "1.0", [])
+    _clear_doc_counters(doc_uuid)
+    exporter = Spdx3JsonExporter()
+    ci = _make_ci()
+    main_pkg = spdx3.software_Package(
+        spdxId=generate_spdx_id("Package", doc_name="pypitest", doc_uuid=doc_uuid),
+        name="pypitest",
+        creationInfo=ci,
+    )
+    exporter.add_package(main_pkg)
+
+    add_dependencies(
+        ["somepkg==2.0.0"],
+        "Source: pyproject.toml | Field: project.dependencies",
+        require_spdx_id(main_pkg),
+        ci,
+        "pypitest",
+        doc_uuid,
+        exporter,
+        offline=False,
+    )
+
+    packages = [
+        o for o in exporter.object_set.objects if isinstance(o, spdx3.software_Package)
+    ]
+    dep = next(p for p in packages if p.name == "somepkg")
+
+    # PyPI's JSON API has no "copyright" field at all, so this correctly
+    # still falls back to NOASSERTION even though supplier/license/hash
+    # were all filled from the network.
+    assert dep.software_copyrightText == "NOASSERTION"
+    verified = dep.verifiedUsing[0]
+    assert isinstance(verified, spdx3.Hash)
+    assert verified.hashValue == "deadbeef" * 8
+
+    agents = [o for o in exporter.object_set.objects if isinstance(o, spdx3.Person)]
+    assert agents[0].name == "Some Author"
+
+    relationships = [
+        o for o in exporter.object_set.objects if isinstance(o, spdx3.Relationship)
+    ]
+    license_rels = [
+        r
+        for r in relationships
+        if r.from_ == require_spdx_id(dep)
+        and r.relationshipType
+        in (
+            spdx3.RelationshipType.hasDeclaredLicense,
+            spdx3.RelationshipType.hasConcludedLicense,
+        )
+    ]
+    assert len(license_rels) == 1
+    licenses = [
+        o
+        for o in exporter.object_set.objects
+        if isinstance(o, spdx3.simplelicensing_SimpleLicensingText)
+    ]
+    assert any(lic.simplelicensing_licenseText == "MIT" for lic in licenses)
+
+
+def test_add_dependencies_noassertion_when_nothing_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dependency with no local metadata and no PyPI hit must still get
+    an explicit NOASSERTION copyright and license, not silently absent
+    fields."""
+    monkeypatch.setattr(deps_mod, "get_package_version", _uninstalled)
+    monkeypatch.setattr(deps_mod, "get_pkg_metadata", _uninstalled)
+    monkeypatch.setattr(
+        deps_mod, "_fetch_pypi_release_info", lambda name, version: None
+    )
+
+    doc_uuid = compute_doc_uuid("noassertion", "1.0", [])
+    _clear_doc_counters(doc_uuid)
+    exporter = Spdx3JsonExporter()
+    ci = _make_ci()
+    main_pkg = spdx3.software_Package(
+        spdxId=generate_spdx_id("Package", doc_name="noassertion", doc_uuid=doc_uuid),
+        name="noassertion",
+        creationInfo=ci,
+    )
+    exporter.add_package(main_pkg)
+
+    add_dependencies(
+        ["totallyunknownpkg>=1.0"],
+        "Source: pyproject.toml | Field: project.dependencies",
+        require_spdx_id(main_pkg),
+        ci,
+        "noassertion",
+        doc_uuid,
+        exporter,
+        offline=False,
+    )
+
+    packages = [
+        o for o in exporter.object_set.objects if isinstance(o, spdx3.software_Package)
+    ]
+    dep = next(p for p in packages if p.name == "totallyunknownpkg")
+    assert dep.software_copyrightText == "NOASSERTION"
+    assert not dep.verifiedUsing
+
+    relationships = [
+        o for o in exporter.object_set.objects if isinstance(o, spdx3.Relationship)
+    ]
+    license_rels = [
+        r
+        for r in relationships
+        if r.from_ == require_spdx_id(dep)
+        and r.relationshipType == spdx3.RelationshipType.hasDeclaredLicense
+    ]
+    assert len(license_rels) == 1
+    licenses = [
+        o
+        for o in exporter.object_set.objects
+        if isinstance(o, spdx3.simplelicensing_SimpleLicensingText)
+    ]
+    noassertion_licenses = [
+        lic for lic in licenses if lic.simplelicensing_licenseText == "NOASSERTION"
+    ]
+    assert len(noassertion_licenses) == 1
+    assert license_rels[0].to == [require_spdx_id(noassertion_licenses[0])]
+
+
+def test_add_dependencies_offline_skips_pypi_entirely(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(deps_mod, "get_package_version", _uninstalled)
+    monkeypatch.setattr(deps_mod, "get_pkg_metadata", _uninstalled)
+
+    called = False
+
+    def _fail_if_called(*_args: object, **_kwargs: object) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(deps_mod, "_fetch_pypi_release_info", _fail_if_called)
+
+    doc_uuid = compute_doc_uuid("offlinetest", "1.0", [])
+    _clear_doc_counters(doc_uuid)
+    exporter = Spdx3JsonExporter()
+    ci = _make_ci()
+    main_pkg = spdx3.software_Package(
+        spdxId=generate_spdx_id("Package", doc_name="offlinetest", doc_uuid=doc_uuid),
+        name="offlinetest",
+        creationInfo=ci,
+    )
+    exporter.add_package(main_pkg)
+
+    add_dependencies(
+        ["somepkg>=1.0"],
+        "Source: pyproject.toml | Field: project.dependencies",
+        require_spdx_id(main_pkg),
+        ci,
+        "offlinetest",
+        doc_uuid,
+        exporter,
+        offline=True,
+    )
+
+    assert called is False
+    packages = [
+        o for o in exporter.object_set.objects if isinstance(o, spdx3.software_Package)
+    ]
+    dep = next(p for p in packages if p.name == "somepkg")
+    assert dep.software_copyrightText == "NOASSERTION"
+
+
+def test_add_license_noassertion_is_deduped() -> None:
+    """Two packages that both fall back to NOASSERTION must share one
+    license element, not mint a duplicate for each."""
+    doc_uuid = compute_doc_uuid("noassertiondedup", "1.0", [])
+    _clear_doc_counters(doc_uuid)
+    exporter = Spdx3JsonExporter()
+    ci = _make_ci()
+
+    for name in ("pkg-a", "pkg-b"):
+        dep_package = spdx3.software_Package(
+            spdxId=generate_spdx_id(
+                "Package", doc_name="noassertiondedup", doc_uuid=doc_uuid
+            ),
+            name=name,
+            creationInfo=ci,
+        )
+        exporter.add_package(dep_package)
+        _add_license_noassertion(
+            dep_package, ci, "noassertiondedup", doc_uuid, exporter
+        )
+
+    licenses = [
+        o
+        for o in exporter.object_set.objects
+        if isinstance(o, spdx3.simplelicensing_SimpleLicensingText)
+    ]
+    noassertion_licenses = [
+        lic for lic in licenses if lic.simplelicensing_licenseText == "NOASSERTION"
+    ]
+    assert len(noassertion_licenses) == 1
+
+
+# ---------------------------------------------------------------------------
+# _prefetch_pypi_release_infos -- concurrency, dedup, offline integration
+# ---------------------------------------------------------------------------
+
+
+def test_prefetch_pypi_release_infos_runs_concurrently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: add_dependencies used to fetch each dependency from
+    PyPI sequentially -- N dependencies cost N blocking round-trips (each
+    up to _PYPI_TIMEOUT_SECONDS on failure) instead of roughly one."""
+
+    def _slow_fetch(_name: str, _version: str | None) -> None:
+        time.sleep(0.2)
+
+    monkeypatch.setattr(deps_mod, "_fetch_pypi_release_info", _slow_fetch)
+
+    start = time.monotonic()
+    _prefetch_pypi_release_infos([(f"pkg{i}", "unknown") for i in range(6)])
+    elapsed = time.monotonic() - start
+
+    # Sequential would be >= 1.2s (6 * 0.2s); concurrent should be close to
+    # the single-fetch latency. Generous bound to absorb CI/scheduler noise.
+    assert elapsed < 0.8
+
+
+def test_prefetch_pypi_release_infos_dedupes_same_name_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    call_count = 0
+
+    def _counting_fetch(_name: str, _version: str | None) -> dict[str, Any]:
+        nonlocal call_count
+        call_count += 1
+        return {"info": {}}
+
+    monkeypatch.setattr(deps_mod, "_fetch_pypi_release_info", _counting_fetch)
+
+    _prefetch_pypi_release_infos(
+        [("samepkg", "1.0.0"), ("samepkg", "1.0.0"), ("samepkg", "1.0.0")]
+    )
+    assert call_count == 1
+
+
+def test_prefetch_pypi_release_infos_normalizes_unknown_to_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen_versions: list[str | None] = []
+
+    def _record_fetch(_name: str, version: str | None) -> None:
+        seen_versions.append(version)
+
+    monkeypatch.setattr(deps_mod, "_fetch_pypi_release_info", _record_fetch)
+
+    _prefetch_pypi_release_infos([("pkg", "unknown")])
+    assert seen_versions == [None]
+
+
+def test_prefetch_pypi_release_infos_empty_input() -> None:
+    assert not _prefetch_pypi_release_infos([])
+
+
+def test_add_dependencies_uses_prefetch_cache_not_individual_fetches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """add_dependencies must fetch each distinct dependency's PyPI data
+    exactly once via the concurrent prefetch, not once per call inside
+    the per-dependency enrichment loop."""
+    monkeypatch.setattr(deps_mod, "get_package_version", _uninstalled)
+    monkeypatch.setattr(deps_mod, "get_pkg_metadata", _uninstalled)
+
+    call_count = 0
+
+    def _counting_fetch(_name: str, _version: str | None) -> dict[str, Any]:
+        nonlocal call_count
+        call_count += 1
+        return {"info": {"license_expression": "MIT"}}
+
+    monkeypatch.setattr(deps_mod, "_fetch_pypi_release_info", _counting_fetch)
+
+    doc_uuid = compute_doc_uuid("prefetchtest", "1.0", [])
+    _clear_doc_counters(doc_uuid)
+    exporter = Spdx3JsonExporter()
+    ci = _make_ci()
+    main_pkg = spdx3.software_Package(
+        spdxId=generate_spdx_id("Package", doc_name="prefetchtest", doc_uuid=doc_uuid),
+        name="prefetchtest",
+        creationInfo=ci,
+    )
+    exporter.add_package(main_pkg)
+
+    add_dependencies(
+        ["pkg-a==1.0", "pkg-b==1.0", "pkg-c==1.0"],
+        "Source: pyproject.toml | Field: project.dependencies",
+        require_spdx_id(main_pkg),
+        ci,
+        "prefetchtest",
+        doc_uuid,
+        exporter,
+        offline=False,
+    )
+
+    assert call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Live PyPI JSON API sanity check -- real network, opts out of conftest's
+# default block. "packaging" is a long-established, guaranteed-published
+# PyPI project, chosen to keep this stable over time.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.pypi_network
+def test_fetch_pypi_release_info_live_network() -> None:
+    release_info = _fetch_pypi_release_info("packaging", None)
+    assert release_info is not None
+    assert release_info["info"]["name"].lower() == "packaging"
+    digest = _extract_release_hash(release_info)
+    assert digest is not None
+    assert len(digest) == 64  # hex sha256

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -658,6 +658,103 @@ Source = "https://github.com/bact/sentimentdemo"
         assert len(relationships) >= 3  # At least 3 dependencies
 
 
+def test_generate_project_sbom_dependency_names_with_markers_and_specifiers() -> None:
+    """Dependency names must be clean even with markers and multi-clause specifiers.
+
+    Regression guard: a naive operator-substring split on a fixed priority
+    order (``===``, ``~=``, ``!=``, ``==``, ``>=``, ``<=``, ``>``, ``<``)
+    mis-parses two real-world shapes -- an environment marker's own ``==``
+    comparison being matched before the specifier's real operator (e.g.
+    ``pkg>=1.0; sys_platform == 'linux'``), and a later clause's operator
+    appearing earlier in the string than an earlier clause's (e.g.
+    ``pkg>=0.1,<1``, which -- after ``packaging.Requirement`` reorders
+    clauses -- puts ``<1`` before ``>=0.1``). Both previously produced a
+    garbled package name (with leftover operators/markers) and no PURL.
+    """
+    pyproject_content = """
+[project]
+name = "markerdemo"
+version = "0.1.0"
+description = "Dependency-parsing regression fixture"
+dependencies = [
+    "auditwheel>=6.7.0; sys_platform == 'linux'",
+    "py-spdx-license>=0.0.1,<1",
+    "pyyaml>=6.0.3,<7",
+]
+"""
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        (tmppath / "pyproject.toml").write_text(pyproject_content)
+
+        sbom_json = generate_project_sbom(tmppath)
+        sbom_data = json.loads(sbom_json)
+
+        graph = sbom_data["@graph"]
+        packages = {
+            p["name"]: p
+            for p in graph
+            if p["type"] == "software_Package" and p["name"] != "markerdemo"
+        }
+
+        assert set(packages) == {"auditwheel", "py-spdx-license", "pyyaml"}
+        for name, pkg in packages.items():
+            assert ";" not in name
+            assert not any(op in name for op in (">=", "<=", "==", "<", ">"))
+            version = pkg.get("software_packageVersion")
+            assert version is not None
+            assert ";" not in version and "'" not in version
+            # Every dependency gets a PURL, even with an unresolved version
+            # (e.g. an unpinned, platform-gated requirement not installed
+            # in the current environment) -- name-only is still a valid,
+            # matchable purl-spec identifier, preferable to none at all.
+            purl = pkg["software_packageUrl"]
+            expected = f"pkg:pypi/{name}" + (
+                "" if version == "unknown" else f"@{version}"
+            )
+            assert purl == expected
+
+
+def test_build_main_package_noassertion_license_when_undeclared() -> None:
+    """The main project package must assert ``hasDeclaredLicense:
+    NOASSERTION`` when no license is declared anywhere, rather than
+    silently having no license relationship at all -- same policy as
+    dependency packages (see add_dependencies)."""
+    project = ProjectMetadata(name="nolicenseproject", version="1.0.0")
+    doc = DocumentModel(project=project, creation_metadata=CreationMetadata())
+
+    exporter = build(doc)
+    data = json.loads(exporter.to_json(pretty=True))
+    graph = data["@graph"]
+
+    main_pkg = next(
+        p
+        for p in graph
+        if p.get("type") == "software_Package" and p["name"] == "nolicenseproject"
+    )
+    licenses = [
+        e for e in graph if e.get("type") == "simplelicensing_SimpleLicensingText"
+    ]
+    noassertion = next(
+        lic
+        for lic in licenses
+        if lic.get("simplelicensing_licenseText") == "NOASSERTION"
+    )
+
+    rels = [e for e in graph if e.get("type") == "Relationship"]
+    license_rels = [
+        r
+        for r in rels
+        if r.get("from") == main_pkg["spdxId"]
+        and r.get("relationshipType") == "hasDeclaredLicense"
+    ]
+    assert len(license_rels) == 1
+    assert license_rels[0]["to"] == [noassertion["spdxId"]]
+
+    spdx_docs = [e for e in graph if e.get("type") == "SpdxDocument"]
+    assert "simpleLicensing" in spdx_docs[0]["profileConformance"]
+
+
 def test_generate_project_sbom_with_fragments() -> None:
     """Test SBOM generation with external generic SBOM fragments."""
     pyproject_content = """
@@ -853,13 +950,17 @@ def test_assembler_ai_model_with_inputs_outputs() -> None:
     assert len(contains_rels) == 1
     assert any(pkg["spdxId"] in r["to"] for r in contains_rels)
 
-    # no license relationships when ai_model.license is not set
-    license_rels = [
+    # no license relationship *from the AI package* when ai_model.license is
+    # not set (the main project package gets its own NOASSERTION fallback
+    # when it has no declared license either -- see build()'s license block
+    # -- which is a separate, expected relationship, not this one).
+    ai_pkg_license_rels = [
         r
         for r in rels
         if r.get("relationshipType") in ("hasDeclaredLicense", "hasConcludedLicense")
+        and r.get("from") == pkg["spdxId"]
     ]
-    assert not license_rels
+    assert not ai_pkg_license_rels
 
 
 def test_assembler_usage_file_hasdatafile_is_lifecycle_scoped_runtime() -> None:
@@ -1095,6 +1196,31 @@ def test_phantom_dependency_creates_package_and_dependency_relationship() -> Non
         and phantom_pkg["spdxId"] in r["to"]
     ]
     assert len(depends_on) == 1
+
+    # Same completeness policy as regular dependencies (add_dependencies):
+    # NOASSERTION for copyright/license rather than a silently absent
+    # field, and the bundled binary's own hash -- already computed
+    # locally -- as its integrity hash.
+    assert phantom_pkg["software_copyrightText"] == "NOASSERTION"
+    assert phantom_pkg["verifiedUsing"] == [
+        {"type": "Hash", "algorithm": "sha256", "hashValue": "c" * 64}
+    ]
+    license_rels = [
+        r
+        for r in relationships
+        if r["relationshipType"] == "hasDeclaredLicense"
+        and r["from"] == phantom_pkg["spdxId"]
+    ]
+    assert len(license_rels) == 1
+    licenses = {
+        e["spdxId"]: e
+        for e in graph
+        if e.get("type") == "simplelicensing_SimpleLicensingText"
+    }
+    assert (
+        licenses[license_rels[0]["to"][0]]["simplelicensing_licenseText"]
+        == "NOASSERTION"
+    )
 
 
 def test_phantom_dependency_without_version_is_unknown() -> None:

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -1441,8 +1441,9 @@ def test_analyze_wheel_dispatches_to_wheel_path(
         pretty: bool = False,
         describe_relationship: bool = False,
         registry: object = None,
+        offline: bool = False,
     ) -> str:
-        _ = (creation_metadata, pretty, describe_relationship, registry)
+        _ = (creation_metadata, pretty, describe_relationship, registry, offline)
         captured["wheel_path"] = wheel_path_arg
         captured["output_path"] = output_path
         return "{}"
@@ -1467,8 +1468,9 @@ def test_deployed_dispatches_to_generate_env_sbom(
         pretty: bool = False,
         describe_relationship: bool = False,
         registry: object = None,
+        offline: bool = False,
     ) -> str:
-        _ = (creation_metadata, pretty, describe_relationship, registry)
+        _ = (creation_metadata, pretty, describe_relationship, registry, offline)
         captured["output_path"] = output_path
         return "{}"
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,11 +5,18 @@
 
 """Tests for SPDX 3 core models."""
 
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import pytest
+from hatchling.builders.wheel import WheelBuilder
+
 from pitloom.core.models import (
     _clear_doc_counters,
     _normalize_dep,
     compute_doc_uuid,
     generate_spdx_id,
+    get_wheel_files,
 )
 
 
@@ -94,3 +101,74 @@ def test_generate_spdx_id() -> None:
     doc_id = generate_spdx_id("SpdxDocument")
     assert doc_id.startswith("https://spdx.org/spdxdocs/pitloom-")
     assert "#" not in doc_id
+
+
+# pylint: disable-next=too-few-public-methods
+class _FakeIncludedFile:
+    """Minimal stand-in for ``hatchling.builders.plugin.interface.IncludedFile``."""
+
+    def __init__(self, path: str, distribution_path: str):
+        self.path = path
+        self.relative_path = distribution_path
+        self.distribution_path = distribution_path
+
+
+def test_get_wheel_files_normalizes_windows_style_distribution_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: Hatchling builds ``distribution_path`` with
+    ``os.path.join``, which uses backslashes on Windows -- unlike a
+    wheel's actual internal zip-entry paths, which the ZIP format itself
+    requires to be forward-slash-separated regardless of host OS. Left
+    un-normalized, the Merkle root (and the ``doc_uuid`` built from it)
+    would differ by build platform for byte-identical source content,
+    since both the sort key and the tree-combination input are exactly
+    this string.
+
+    Uses two files, ``pkg/zoo.py`` and ``pkg0/a.py``, deliberately chosen
+    so their relative sort order flips depending on the separator: ``/``
+    (0x2F) sorts before ``0`` (0x30), so ``pkg/zoo.py`` sorts first in
+    POSIX form -- but ``\\`` (0x5C) sorts *after* ``0``, so
+    ``pkg\\zoo.py`` would sort *second* in un-normalized Windows form.
+    With only one file (or a pair whose order doesn't happen to flip),
+    the Merkle root would trivially match either way and this test
+    wouldn't actually prove anything.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        '[build-system]\nrequires = ["hatchling"]\n'
+        'build-backend = "hatchling.build"\n\n'
+        '[project]\nname = "pkg"\nversion = "1.0.0"\n',
+        encoding="utf-8",
+    )
+    pkg_dir = tmp_path / "pkg"
+    pkg_dir.mkdir()
+    zoo_file = pkg_dir / "zoo.py"
+    zoo_file.write_text("zoo = 1\n", encoding="utf-8")
+    pkg0_dir = tmp_path / "pkg0"
+    pkg0_dir.mkdir()
+    a_file = pkg0_dir / "a.py"
+    a_file.write_text("a = 1\n", encoding="utf-8")
+
+    def _make_fake_recurse(
+        sep: str,
+    ) -> Callable[[WheelBuilder], Iterator[_FakeIncludedFile]]:
+        def _fake_recurse(_self: WheelBuilder) -> Iterator[_FakeIncludedFile]:
+            yield _FakeIncludedFile(str(zoo_file), f"pkg{sep}zoo.py")
+            yield _FakeIncludedFile(str(a_file), f"pkg0{sep}a.py")
+
+        return _fake_recurse
+
+    monkeypatch.setattr(WheelBuilder, "recurse_included_files", _make_fake_recurse("/"))
+    posix_root, posix_files = get_wheel_files(tmp_path)
+
+    monkeypatch.setattr(
+        WheelBuilder, "recurse_included_files", _make_fake_recurse("\\")
+    )
+    windows_root, windows_files = get_wheel_files(tmp_path)
+
+    assert posix_root is not None
+    assert posix_root == windows_root, (
+        "Merkle root must not depend on the build platform's path separator"
+    )
+    assert [f.distribution_path for f in posix_files] == ["pkg/zoo.py", "pkg0/a.py"]
+    assert [f.distribution_path for f in windows_files] == ["pkg/zoo.py", "pkg0/a.py"]


### PR DESCRIPTION
## Summary

Some info were already extracted but discarded. Some info extraction have a bug. Fix them all.

Add PyPI API fallback to get more info if no package installed.

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
