### PR TITLE
Add Pitloom PURL and hash to SBOM

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pitloom",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "Generate, enrich, and validate SPDX 3 SBOMs/AIBOMs for Python projects and AI models using Pitloom.",
   "author": {
     "name": "Arthit Suriyawongkul",

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -30,7 +30,7 @@ jobs:
           pip install build
 
       - name: Install Pitloom from checkout
-        run: pip install -e .[ai]
+        run: pip install -e .
 
       - name: Build sdist and wheel
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -458,6 +458,7 @@ release because "Loom" and "Pyloom" were unavailable on PyPI.
 
 ---
 
+[0.13.3]: https://github.com/bact/pitloom/compare/v0.13.2...v0.13.3
 [0.13.2]: https://github.com/bact/pitloom/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/bact/pitloom/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/bact/pitloom/compare/v0.12.0...v0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,16 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Full release notes: <https://github.com/bact/pitloom/releases>
-- Commit history: <https://github.com/bact/pitloom/compare/v0.13.1...v0.13.2>
+- Commit history: <https://github.com/bact/pitloom/compare/v0.13.2...v0.13.3>
+
+## [0.13.3] - 2026-08-11
+
+### Added
+
+- Pitloom's own hash and Package URL with version number to the generated SBOM
+  ([#132])
+
+[#132]: https://github.com/bact/pitloom/pull/132
 
 ## [0.13.2] - 2026-08-11
 
@@ -41,6 +50,8 @@ This release fixes bugs and offers few fallbacks to improve SBOM completeness.
 - Merkle root/`doc_uuid` platform-dependent on Windows (backslash
   `distribution_path` from Hatchling's `os.path.join`) ([#131])
 
+[#131]: https://github.com/bact/pitloom/pull/131
+
 ## [0.13.1] - 2026-08-11
 
 ### Changed
@@ -50,7 +61,6 @@ This release fixes bugs and offers few fallbacks to improve SBOM completeness.
 
 [sbom-naming]: https://sbom-catalog.openssf.org/sbom-naming.html
 [#130]: https://github.com/bact/pitloom/pull/130
-[#131]: https://github.com/bact/pitloom/pull/131
 
 ## [0.13.0] - 2026-08-11
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ abstract: Generate SPDX 3 SBOMs for Python projects and AI models with native Ha
 repository-code: "https://github.com/bact/pitloom"
 type: software
 doi: 10.5281/zenodo.19246283
-version: 0.13.2
+version: 0.13.3
 license-url: "https://spdx.org/licenses/Apache-2.0"
 keywords:
   - sbom

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ register the hook:
 
 ```toml
 [build-system]
-requires = ["hatchling>=1.28.0", "pitloom>=0.13.2"]
+requires = ["hatchling>=1.28.0", "pitloom>=0.13.3"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.hooks.pitloom]
@@ -242,7 +242,7 @@ Add SBOM generation to any repository's CI with a single step, for any
 Python build backend, not just Hatchling:
 
 ```yaml
-- uses: bact/pitloom@v0.13.2
+- uses: bact/pitloom@v0.13.3
 ```
 
 See [working-docs/implementation/github-action.md](working-docs/implementation/github-action.md)

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ inputs:
     default: ""
   pitloom-version:
     description: >-
-      Pitloom version or version specifier to install, e.g. "0.13.2" or
+      Pitloom version or version specifier to install, e.g. "0.13.3" or
       ">=0.13,<1.0". Empty installs the latest release from PyPI.
     required: false
     default: ""
@@ -103,7 +103,7 @@ runs:
           spec="${spec}[${PL_EXTRAS}]"
         fi
         if [ -n "${PL_VERSION}" ]; then
-          # pitloom-version accepts either a bare version ("0.13.2") or a
+          # pitloom-version accepts either a bare version ("0.13.3") or a
           # full specifier (">=0.13,<1.0"). A leading comparison operator
           # means it is already a specifier; only bare versions need "=="
           # inserted, otherwise "pitloom==>=0.13,<1.0" is invalid.

--- a/codemeta.json
+++ b/codemeta.json
@@ -60,5 +60,5 @@
     "programmingLanguage": "Python 3",
     "readme": "https://github.com/bact/pitloom/blob/main/README.md",
     "url": "https://github.com/bact/pitloom",
-    "version": "0.13.2"
+    "version": "0.13.3"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,7 +80,7 @@ loom generate .
 ### GitHub Action
 
 ```yaml
-- uses: bact/pitloom@v0.13.2
+- uses: bact/pitloom@v0.13.3
 ```
 
 This creates a standalone SBOM file on the runner.
@@ -96,7 +96,7 @@ Create SBOM during Hatchling build:
 
 ```toml
 [build-system]
-requires = ["hatchling>=1.28.0", "pitloom>=0.13.2"]
+requires = ["hatchling>=1.28.0", "pitloom>=0.13.3"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.hooks.pitloom]

--- a/src/pitloom/__about__.py
+++ b/src/pitloom/__about__.py
@@ -5,4 +5,4 @@
 
 """Package information for Pitloom."""
 
-__version__ = "0.13.2"
+__version__ = "0.13.3"

--- a/src/pitloom/assemble/spdx3/creation_info.py
+++ b/src/pitloom/assemble/spdx3/creation_info.py
@@ -20,9 +20,16 @@ from spdx_python_model.bindings import v3_0_1 as spdx3
 from pitloom.__about__ import __version__
 from pitloom.assemble.spdx3.provenance import EnrichedFieldEntry
 from pitloom.core.creation import VALID_CREATOR_TYPES, CreationMetadata, Tool
-from pitloom.core.models import generate_spdx_id
+from pitloom.core.models import build_pypi_purl, generate_spdx_id
 from pitloom.enrich.base import EnrichmentResult
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
+
+#: Pitloom's own PURL, stable/known ahead of time (no PyPI lookup needed --
+#: name and running version are always known locally). SPDX 3.0.1's ``Tool``
+#: class has no ``version`` property (added in 3.1-dev), so this is the
+#: verifiable stand-in CISA's "SBOM tool version" requirement needs; it goes
+#: alongside (not instead of) ``Tool.summary``'s free-text version string.
+_PITLOOM_PURL = build_pypi_purl("pitloom", __version__)
 
 
 def parse_iso_datetime(value: str) -> datetime:
@@ -169,6 +176,13 @@ def build_tools(
         summary = _tool_summary(tool.name)
         if summary:
             tool.summary = summary
+        if tool.name == "Pitloom":
+            tool.externalIdentifier = [
+                spdx3.ExternalIdentifier(
+                    externalIdentifierType=spdx3.ExternalIdentifierType.packageUrl,
+                    identifier=_PITLOOM_PURL,
+                )
+            ]
         tools.append(tool)
     return tools
 
@@ -233,7 +247,9 @@ def build_enrichment_creation_info(
     SPDX 3.0.1 has no native ``Tool.version`` (added in 3.1-dev); version
     info goes in ``Tool.summary`` instead, same workaround
     :func:`_tool_summary` uses for the main "Pitloom" tool -- set directly
-    here rather than widening that helper's tool-name-scoped contract.
+    here rather than widening that helper's tool-name-scoped contract. The
+    Pitloom PURL is also attached as ``externalIdentifier`` -- see
+    :data:`_PITLOOM_PURL`.
     """
     ci = spdx3.CreationInfo(specVersion="3.0.1", created=spdx3_utc_now())
     tool = spdx3.Tool(
@@ -241,6 +257,12 @@ def build_enrichment_creation_info(
         name=tool_name,
         creationInfo=ci,
         summary=f"Pitloom {__version__}",
+        externalIdentifier=[
+            spdx3.ExternalIdentifier(
+                externalIdentifierType=spdx3.ExternalIdentifierType.packageUrl,
+                identifier=_PITLOOM_PURL,
+            )
+        ],
     )
     ci.createdBy = main_creation_info.createdBy
     ci.createdUsing = [require_spdx_id(tool)]

--- a/src/pitloom/assemble/spdx3/creation_info.py
+++ b/src/pitloom/assemble/spdx3/creation_info.py
@@ -32,6 +32,20 @@ from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 _PITLOOM_PURL = build_pypi_purl("pitloom", __version__)
 
 
+def _pitloom_external_identifiers() -> list[spdx3.ExternalIdentifier]:
+    """Build the ``externalIdentifier`` list identifying a Tool as Pitloom
+    itself -- shared by :func:`build_tools` (the main "Pitloom" tool) and
+    :func:`build_enrichment_creation_info` (per-enrichment-source tools),
+    both of which represent Pitloom's own identity and must stay in sync.
+    """
+    return [
+        spdx3.ExternalIdentifier(
+            externalIdentifierType=spdx3.ExternalIdentifierType.packageUrl,
+            identifier=_PITLOOM_PURL,
+        )
+    ]
+
+
 def parse_iso_datetime(value: str) -> datetime:
     """Parse a full ISO 8601 datetime string.
 
@@ -177,12 +191,7 @@ def build_tools(
         if summary:
             tool.summary = summary
         if tool.name == "Pitloom":
-            tool.externalIdentifier = [
-                spdx3.ExternalIdentifier(
-                    externalIdentifierType=spdx3.ExternalIdentifierType.packageUrl,
-                    identifier=_PITLOOM_PURL,
-                )
-            ]
+            tool.externalIdentifier = _pitloom_external_identifiers()
         tools.append(tool)
     return tools
 
@@ -257,12 +266,7 @@ def build_enrichment_creation_info(
         name=tool_name,
         creationInfo=ci,
         summary=f"Pitloom {__version__}",
-        externalIdentifier=[
-            spdx3.ExternalIdentifier(
-                externalIdentifierType=spdx3.ExternalIdentifierType.packageUrl,
-                identifier=_PITLOOM_PURL,
-            )
-        ],
+        externalIdentifier=_pitloom_external_identifiers(),
     )
     ci.createdBy = main_creation_info.createdBy
     ci.createdUsing = [require_spdx_id(tool)]

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -32,7 +32,7 @@ from pitloom.assemble.spdx3.provenance import (
 from pitloom.core.models import build_pypi_purl, generate_spdx_id
 from pitloom.core.project import PhantomDependency
 from pitloom.core.provenance import ProvenanceConfig
-from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
+from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id, sha256_hash
 from pitloom.extract._extract_utils import fetch_json
 from pitloom.extract._license import (
     normalize_license_expression,
@@ -621,9 +621,7 @@ def _enrich_from_pypi(
     if version is not None:
         digest = _extract_release_hash(release_info)
         if digest:
-            dep_package.verifiedUsing = [
-                spdx3.Hash(algorithm=spdx3.HashAlgorithm.sha256, hashValue=digest)
-            ]
+            dep_package.verifiedUsing = [sha256_hash(digest)]
             filled.add("hash")
 
     return filled
@@ -1115,11 +1113,7 @@ def add_phantom_dependencies(
         dep_package.software_primaryPurpose = spdx3.software_SoftwarePurpose.library
         dep_package.software_copyrightText = "NOASSERTION"
         if dep.digest_sha256:
-            dep_package.verifiedUsing = [
-                spdx3.Hash(
-                    algorithm=spdx3.HashAlgorithm.sha256, hashValue=dep.digest_sha256
-                )
-            ]
+            dep_package.verifiedUsing = [sha256_hash(dep.digest_sha256)]
         _add_license_noassertion(
             dep_package,
             creation_info,

--- a/src/pitloom/assemble/spdx3/document.py
+++ b/src/pitloom/assemble/spdx3/document.py
@@ -50,7 +50,7 @@ from pitloom.core.models import (
 )
 from pitloom.core.provenance import ProvenanceConfig
 from pitloom.enrich.base import EnrichmentResult
-from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
+from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id, sha256_hash
 from pitloom.ids import IdRegistry
 
 
@@ -112,11 +112,10 @@ def _build_main_package(
     # (see compute_doc_uuid), asserted here as the package's own integrity
     # hash so NTIA/CISA "integrity hash" coverage extends to the main
     # package itself, not just its individual files.
-    if merkle_root:
+    if merkle_root is not None:
         main_package.verifiedUsing = [
-            spdx3.Hash(
-                algorithm=spdx3.HashAlgorithm.sha256,
-                hashValue=merkle_root,
+            sha256_hash(
+                merkle_root,
                 comment=(
                     "SHA-256 Merkle root over all files included in the wheel, "
                     "not a hash of a single artifact"
@@ -200,12 +199,7 @@ def _add_package_files(
             creationInfo=spdx_ci,
         )
         package_entry.software_fileKind = spdx3.software_FileKindType.file
-        package_entry.verifiedUsing = [
-            spdx3.Hash(
-                algorithm=spdx3.HashAlgorithm.sha256,
-                hashValue=package_file.digest_sha256,
-            )
-        ]
+        package_entry.verifiedUsing = [sha256_hash(package_file.digest_sha256)]
         exporter.add_file(package_entry)
         file_spdx_ids[package_file.distribution_path] = require_spdx_id(package_entry)
 

--- a/src/pitloom/assemble/spdx3/document.py
+++ b/src/pitloom/assemble/spdx3/document.py
@@ -66,6 +66,7 @@ def _build_main_package(
     spdx_ci: spdx3.CreationInfo,
     agents: list[spdx3.Agent],
     doc_uuid: str,
+    merkle_root: str | None = None,
 ) -> spdx3.software_Package:
     """Create the SPDX package representing the Python project."""
     metadata = doc.project
@@ -106,6 +107,22 @@ def _build_main_package(
         main_package.software_packageUrl = build_pypi_purl(
             metadata.name, metadata.version
         )
+
+    # verifiedUsing -- the same Merkle root already folded into doc_uuid
+    # (see compute_doc_uuid), asserted here as the package's own integrity
+    # hash so NTIA/CISA "integrity hash" coverage extends to the main
+    # package itself, not just its individual files.
+    if merkle_root:
+        main_package.verifiedUsing = [
+            spdx3.Hash(
+                algorithm=spdx3.HashAlgorithm.sha256,
+                hashValue=merkle_root,
+                comment=(
+                    "SHA-256 Merkle root over all files included in the wheel, "
+                    "not a hash of a single artifact"
+                ),
+            )
+        ]
 
     return main_package
 
@@ -257,7 +274,7 @@ def build(
         exporter.object_set.add(tool)
 
     # --- Main package ---
-    main_package = _build_main_package(doc, spdx_ci, agents, doc_uuid)
+    main_package = _build_main_package(doc, spdx_ci, agents, doc_uuid, merkle_root)
 
     # --- SBOM and document envelope ---
     sbom = spdx3.software_Sbom(

--- a/src/pitloom/export/spdx3_json.py
+++ b/src/pitloom/export/spdx3_json.py
@@ -48,6 +48,22 @@ def require_spdx_id(element: spdx3.Element) -> str:
     return str(element.spdxId)
 
 
+def sha256_hash(hex_digest: str, *, comment: str | None = None) -> spdx3.Hash:
+    """Build a ``verifiedUsing`` SHA-256 ``Hash`` element for *hex_digest*.
+
+    Single source of truth for the ``algorithm=sha256`` convention used by
+    every ``verifiedUsing`` assertion pitloom emits (package files, dependency
+    packages, and the main package's own Merkle-root hash), so the convention
+    only needs fixing in one place.
+    """
+    hash_element = spdx3.Hash(
+        algorithm=spdx3.HashAlgorithm.sha256, hashValue=hex_digest
+    )
+    if comment:
+        hash_element.comment = comment
+    return hash_element
+
+
 def _graph_sort_key(element: dict[str, Any]) -> tuple[int, str, str]:
     """Return a deterministic sort key for a @graph element.
 

--- a/src/pitloom/ids.py
+++ b/src/pitloom/ids.py
@@ -461,15 +461,25 @@ def _import_sbom_element(registry: IdRegistry, obj: Any) -> None:
     if not name or not spdx_id:
         return
 
-    sha256 = _sha256_from_verified_using(obj)
-    if sha256 is not None:
-        registry.files[name] = FileEntry(spdx_id=spdx_id, sha256=sha256)
-        return
-
     get_compact_type = getattr(obj, "get_compact_type", None)
     compact_type = get_compact_type() if get_compact_type is not None else None
     if not compact_type:
         compact_type = type(obj).__name__
+
+    # A bare software_Package (the main project package, or a dependency
+    # package) can carry a verifiedUsing hash too (see document.py's
+    # _build_main_package, which sets one from the wheel's Merkle root) --
+    # that hash is content-integrity metadata about the whole package, not
+    # a file-path lookup key, so it must not land in registry.files keyed
+    # by the package's bare name. Subtypes like dataset_DatasetPackage are
+    # unaffected: get_compact_type() reports their own specific type name,
+    # never the literal "software_Package", so their hash still promotes
+    # them to registry.files as before.
+    if compact_type != "software_Package":
+        sha256 = _sha256_from_verified_using(obj)
+        if sha256 is not None:
+            registry.files[name] = FileEntry(spdx_id=spdx_id, sha256=sha256)
+            return
 
     if not compact_type or compact_type == "object":
         log.debug("Import: skipping %r (no SPDX 3 compact type)", name)

--- a/working-docs/design/hatchling-build-hook.md
+++ b/working-docs/design/hatchling-build-hook.md
@@ -118,7 +118,7 @@ The user adds `pitloom` to their build dependencies and enables the hook:
 
 ```toml
 [build-system]
-requires = ["hatchling>=1.31.0", "pitloom>=0.13.2"]
+requires = ["hatchling>=1.31.0", "pitloom>=0.13.3"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.hooks.pitloom]

--- a/working-docs/implementation/github-action.md
+++ b/working-docs/implementation/github-action.md
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: bact/pitloom@v0.13.2
+      - uses: bact/pitloom@v0.13.3
         with:
           project-path: "."
           output: "sbom.spdx3.json"
@@ -63,7 +63,7 @@ change any of it).
 ## Recipe: AI model SBOM
 
 ```yaml
-- uses: bact/pitloom@v0.13.2
+- uses: bact/pitloom@v0.13.3
   with:
     model: "models/my-model.safetensors"
     extras: "aimodel"
@@ -79,7 +79,7 @@ Pass them through `args` (the Action itself has no dedicated multi-creator
 input):
 
 ```yaml
-- uses: bact/pitloom@v0.13.2
+- uses: bact/pitloom@v0.13.3
   with:
     project-path: "."
     output: "sbom.spdx3.json"
@@ -104,7 +104,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
-      - uses: bact/pitloom@v0.13.2
+      - uses: bact/pitloom@v0.13.3
         id: pitloom
         with:
           project-path: "."
@@ -134,7 +134,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
-      - uses: bact/pitloom@v0.13.2
+      - uses: bact/pitloom@v0.13.3
         with:
           project-path: "."
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary

Add Pitloom own's Package URL and hash to the generated SBOM in the wheel

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
