### PR TITLE
Use POSIX path

### DIFF
--- a/skills/sbom-enrich/SKILL.md
+++ b/skills/sbom-enrich/SKILL.md
@@ -137,6 +137,12 @@ Steps:
    or relationships you infer from prose (e.g. a `dataset_DatasetPackage`
    plus a `trainedOn` relationship, or a `comment` refining a license
    guess). Mark every inferred value with the provenance string above.
+   If any field or comment references a file path (e.g. citing where in
+   the repo you found the evidence), write it POSIX-style
+   (`docs/model-card.md`, not `docs\model-card.md`) regardless of what OS
+   you're running on -- Pitloom-generated SBOMs are byte-identical across
+   operating systems, and a backslash path in agent-authored content would
+   be the one thing that isn't.
 
    **Default precedence: the deterministic result wins.** If step 2
    already set a field, do not silently re-propose a different value for

--- a/src/pitloom/extract/_license.py
+++ b/src/pitloom/extract/_license.py
@@ -310,7 +310,7 @@ def collect_license_candidates(project_dir: Path) -> list[tuple[str, str]]:
         try:
             text = lf.read_text(encoding="utf-8", errors="replace")
             if text.strip():
-                rel = str(lf.relative_to(project_dir))
+                rel = lf.relative_to(project_dir).as_posix()
                 candidates.append((text, f"Source: {rel}"))
         except OSError:
             pass

--- a/src/pitloom/extract/pyproject.py
+++ b/src/pitloom/extract/pyproject.py
@@ -336,7 +336,7 @@ def _extract_dynamic_version(
             if version:
                 return (
                     version,
-                    f"Source: {p.relative_to(project_dir)}"
+                    f"Source: {p.relative_to(project_dir).as_posix()}"
                     " | Method: dynamic_extraction",
                 )
 
@@ -357,7 +357,7 @@ def _extract_dynamic_version(
             if version:
                 return (
                     version,
-                    f"Source: {p.relative_to(project_dir)}"
+                    f"Source: {p.relative_to(project_dir).as_posix()}"
                     " | Method: dynamic_extraction",
                 )
 

--- a/src/pitloom/extract/setuptools.py
+++ b/src/pitloom/extract/setuptools.py
@@ -510,7 +510,7 @@ def _resolve_cfg_version(
                 if module_file.exists():
                     version = _read_version_attr(module_file, attr_name)
                     if version:
-                        rel = module_file.relative_to(project_dir)
+                        rel = module_file.relative_to(project_dir).as_posix()
                         return version, f"Source: {rel} | Method: attr_directive"
 
     return None, None

--- a/src/pitloom/loom.py
+++ b/src/pitloom/loom.py
@@ -41,7 +41,7 @@ def _get_caller_info() -> str:
             if frame_info.filename != __file__:
                 p = Path(frame_info.filename).absolute()
                 try:
-                    filename = str(p.relative_to(Path.cwd()))
+                    filename = p.relative_to(Path.cwd()).as_posix()
                 except ValueError:
                     filename = p.name
 


### PR DESCRIPTION
## Summary

Use POSIX path so hash will remain identical across OSes

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
