### PR TITLE
Raise RuntimeError if Hatchling version is lower than 1.29.0

### DIFF
--- a/src/pitloom/plugins/hatch.py
+++ b/src/pitloom/plugins/hatch.py
@@ -11,12 +11,15 @@ import logging
 import os
 import tempfile
 from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import Any
 
 from hatchling.builders.config import BuilderConfig
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from hatchling.plugin import hookimpl
+from packaging.version import Version
 from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.assemble.spdx3.creation_info import to_spdx3_datetime
@@ -36,6 +39,46 @@ from pitloom.ids import resolve_registry
 log = logging.getLogger(__name__)
 
 _SPDX3_JSON_EXT = ".spdx3.json"
+
+#: Hatchling only started reading build_data["sbom_files"] -- the mechanism
+#: this hook relies on to place a build-time-generated SBOM at
+#: .dist-info/sboms/ -- in this release (PEP 770). Older Hatchling accepts
+#: the mutated build_data silently and never embeds the file, so the wheel
+#: builds "successfully" with no SBOM and no warning; this must therefore be
+#: checked explicitly rather than left to fail silently.
+_MIN_HATCHLING_SBOM_VERSION = "1.29.0"
+
+#: Shared prefix for every _check_hatchling_sbom_support() error, so both
+#: failure modes are easy to grep/filter for as one family of error.
+_HATCHLING_ERROR_PREFIX = "Pitloom build hook: Hatchling"
+
+
+def _check_hatchling_sbom_support() -> None:
+    """Raise if the running Hatchling can't embed the SBOM via build_data.
+
+    Raises:
+        RuntimeError: If Hatchling's installed version can't be determined,
+            or predates :data:`_MIN_HATCHLING_SBOM_VERSION`.
+    """
+    try:
+        installed = Version(_pkg_version("hatchling"))
+    except PackageNotFoundError as exc:
+        raise RuntimeError(
+            f"{_HATCHLING_ERROR_PREFIX} version unknown (no package metadata "
+            f"found); requires >= {_MIN_HATCHLING_SBOM_VERSION} for PEP 770 "
+            "SBOM embedding."
+        ) from exc
+
+    minimum = Version(_MIN_HATCHLING_SBOM_VERSION)
+    # Compare release segments only (ignoring pre/dev/post/local qualifiers)
+    # so a pre-release or dev build of the minimum version -- which already
+    # has the feature -- isn't rejected for sorting below the final release.
+    if installed.release < minimum.release:
+        raise RuntimeError(
+            f"{_HATCHLING_ERROR_PREFIX} {installed} too old for PEP 770 SBOM "
+            f"embedding (requires >= {_MIN_HATCHLING_SBOM_VERSION}); "
+            "upgrade Hatchling."
+        )
 
 
 def _resolve_build_datetime(pitloom_config: PitloomConfig) -> str:
@@ -154,8 +197,10 @@ class PitloomBuildHook(BuildHookInterface[BuilderConfig]):
     ``pyproject.toml`` and listing ``pitloom`` as a build dependency.
 
     The SBOM is written to ``.dist-info/sboms/<filename>`` inside the wheel,
-    conforming to PEP 770.  Hatchling 1.28.0+ handles the injection natively
-    via ``build_data["sbom_files"]``.
+    conforming to PEP 770.  Hatchling 1.29.0+ handles the injection natively
+    via ``build_data["sbom_files"]``; older Hatchling is rejected outright
+    (see :func:`_check_hatchling_sbom_support`) rather than silently
+    producing a wheel with no SBOM.
 
     ``[tool.hatch.build.hooks.pitloom]`` controls only whether the hook runs:
 
@@ -183,7 +228,7 @@ class PitloomBuildHook(BuildHookInterface[BuilderConfig]):
         """Generate the SBOM and register it for injection into the wheel.
 
         Called by Hatchling before packaging.  The staged SBOM path is
-        appended to ``build_data["sbom_files"]``, which Hatchling 1.28.0+
+        appended to ``build_data["sbom_files"]``, which Hatchling 1.29.0+
         places at ``.dist-info/sboms/<basename>`` inside the wheel
         (PEP 770).  The temporary staging directory is cleaned up in
         :meth:`finalize`.
@@ -200,6 +245,9 @@ class PitloomBuildHook(BuildHookInterface[BuilderConfig]):
                 or is otherwise invalid.
             FileNotFoundError: If ``pyproject.toml`` is absent from the
                 project root.
+            RuntimeError: If the installed Hatchling's version can't be
+                determined, or predates 1.29.0 and can't embed the SBOM
+                (see :func:`_check_hatchling_sbom_support`).
         """
         log.debug("Pitloom build hook: build variant %r", version)
 
@@ -219,6 +267,8 @@ class PitloomBuildHook(BuildHookInterface[BuilderConfig]):
                 self.target_name,
             )
             return
+
+        _check_hatchling_sbom_support()
 
         project_dir = Path(self.root)
         pitloom_config: PitloomConfig = read_pitloom_config(
@@ -256,7 +306,7 @@ class PitloomBuildHook(BuildHookInterface[BuilderConfig]):
             sbom_json, sbom_filename
         )
 
-        # Hatchling 1.28.0+ places each path in sbom_files at
+        # Hatchling 1.29.0+ places each path in sbom_files at
         # .dist-info/sboms/<basename> inside the wheel (PEP 770).
         build_data.setdefault("sbom_files", []).append(str(self._sbom_staging_path))
 

--- a/tests/test_hatch_hook.py
+++ b/tests/test_hatch_hook.py
@@ -13,9 +13,11 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import tempfile
 import types
 from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -42,7 +44,9 @@ from pitloom.export.spdx3_json import (  # noqa: E402
 from pitloom.extract.hatchling import metadata_from_hatchling  # noqa: E402
 from pitloom.extract.pyproject import read_pyproject  # noqa: E402
 from pitloom.plugins.hatch import (  # noqa: E402
+    _HATCHLING_ERROR_PREFIX,
     PitloomBuildHook,
+    _check_hatchling_sbom_support,
     _validate_config,
 )
 
@@ -1271,6 +1275,105 @@ def test_hook_skips_non_wheel_target() -> None:
         assert hook._sbom_staging_path is None
         assert hook._staging_dir is None
         assert "sbom_files" not in build_data
+
+
+# ---------------------------------------------------------------------------
+# Hatchling version gate (build_data["sbom_files"] needs Hatchling >= 1.29.0)
+# ---------------------------------------------------------------------------
+
+
+def test_check_hatchling_sbom_support_passes_for_current_hatchling() -> None:
+    """The Hatchling installed in the test environment must satisfy the gate."""
+    _check_hatchling_sbom_support()  # must not raise
+
+
+@pytest.mark.parametrize("bad_version", ["1.28.0", "1.27.0", "1.0.0"])
+def test_check_hatchling_sbom_support_raises_below_minimum(bad_version: str) -> None:
+    """Hatchling older than the minimum must raise a clear ``RuntimeError``."""
+    with patch("pitloom.plugins.hatch._pkg_version", return_value=bad_version):
+        with pytest.raises(RuntimeError, match="too old for PEP 770 SBOM embedding"):
+            _check_hatchling_sbom_support()
+
+
+def test_check_hatchling_sbom_support_accepts_exact_minimum() -> None:
+    """Hatchling exactly at the minimum version must not raise."""
+    with patch("pitloom.plugins.hatch._pkg_version", return_value="1.29.0"):
+        _check_hatchling_sbom_support()
+
+
+def test_check_hatchling_sbom_support_accepts_dev_build_of_minimum() -> None:
+    """A pre-release/dev build of the minimum version already has the
+    ``build_data["sbom_files"]`` mechanism, so it must not be rejected for
+    sorting below the final release under plain PEP 440 ordering."""
+    with patch(
+        "pitloom.plugins.hatch._pkg_version",
+        return_value="1.29.0.dev0+gabcdef",
+    ):
+        _check_hatchling_sbom_support()
+
+
+def test_check_hatchling_sbom_support_raises_when_metadata_missing() -> None:
+    """If Hatchling's version can't be determined, raise a clear
+    ``RuntimeError`` rather than letting a raw ``PackageNotFoundError``
+    escape (e.g. a vendored copy or zipapp bundle without dist-info)."""
+    with patch(
+        "pitloom.plugins.hatch._pkg_version",
+        side_effect=PackageNotFoundError("hatchling"),
+    ):
+        with pytest.raises(RuntimeError, match="version unknown"):
+            _check_hatchling_sbom_support()
+
+
+@pytest.mark.parametrize(
+    "bad_version_or_error",
+    ["1.27.0", PackageNotFoundError("hatchling")],
+)
+def test_check_hatchling_sbom_support_errors_share_filterable_prefix(
+    bad_version_or_error: str | PackageNotFoundError,
+) -> None:
+    """Every failure mode must share one prefix, so callers can grep/filter
+    for this whole family of error with a single, stable string."""
+    patch_kwargs = (
+        {"side_effect": bad_version_or_error}
+        if isinstance(bad_version_or_error, Exception)
+        else {"return_value": bad_version_or_error}
+    )
+    with patch("pitloom.plugins.hatch._pkg_version", **patch_kwargs):
+        with pytest.raises(RuntimeError, match=re.escape(_HATCHLING_ERROR_PREFIX)):
+            _check_hatchling_sbom_support()
+
+
+def test_hook_initialize_raises_for_old_hatchling() -> None:
+    """initialize() must surface the version-gate error for a wheel target."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        write_pyproject(tmp_path)
+
+        hook = make_hook(tmp, {})
+        build_data: dict[str, Any] = {}
+        with (
+            patch("pitloom.plugins.hatch._pkg_version", return_value="1.27.0"),
+            pytest.raises(RuntimeError, match="too old for PEP 770 SBOM embedding"),
+        ):
+            hook.initialize("standard", build_data)
+
+        assert hook._sbom_staging_path is None
+        assert hook._staging_dir is None
+
+
+def test_hook_skips_hatchling_check_for_non_wheel_target() -> None:
+    """The version gate only applies to wheel builds; sdist must not raise
+    even under an Hatchling older than the minimum."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        write_pyproject(tmp_path)
+
+        hook = make_hook(tmp, {}, target_name="sdist")
+        build_data: dict[str, Any] = {}
+        with patch("pitloom.plugins.hatch._pkg_version", return_value="1.27.0"):
+            hook.initialize("standard", build_data)  # must not raise
+
+        assert hook._sbom_staging_path is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hatch_hook.py
+++ b/tests/test_hatch_hook.py
@@ -1333,12 +1333,15 @@ def test_check_hatchling_sbom_support_errors_share_filterable_prefix(
 ) -> None:
     """Every failure mode must share one prefix, so callers can grep/filter
     for this whole family of error with a single, stable string."""
-    patch_kwargs = (
-        {"side_effect": bad_version_or_error}
-        if isinstance(bad_version_or_error, Exception)
-        else {"return_value": bad_version_or_error}
-    )
-    with patch("pitloom.plugins.hatch._pkg_version", **patch_kwargs):
+    if isinstance(bad_version_or_error, Exception):
+        mock_patch = patch(
+            "pitloom.plugins.hatch._pkg_version", side_effect=bad_version_or_error
+        )
+    else:
+        mock_patch = patch(
+            "pitloom.plugins.hatch._pkg_version", return_value=bad_version_or_error
+        )
+    with mock_patch:
         with pytest.raises(RuntimeError, match=re.escape(_HATCHLING_ERROR_PREFIX)):
             _check_hatchling_sbom_support()
 


### PR DESCRIPTION
## Summary

So SBOM will not silently disappear when build a wheel.

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
