### PR TITLE
Fix AI base-model lineage crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,10 @@ and this project adheres to
 - Crash generating an AI model's base-model lineage when `base_model` is
   set but `base_model_relation` is not (e.g. a model card's frontmatter
   has `base_model` but the Hugging Face Hub API never supplied a
-  computed relation tag)
+  computed relation tag) ([#144])
 
 [#143]: https://github.com/bact/pitloom/pull/143
+[#144]: https://github.com/bact/pitloom/pull/144
 
 ## [0.14.0] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to
 
 - `sbomAuthorSupplied` is now consistently a provenance `role`, not
   conflated with `method` ([#143])
+- Crash generating an AI model's base-model lineage when `base_model` is
+  set but `base_model_relation` is not (e.g. a model card's frontmatter
+  has `base_model` but the Hugging Face Hub API never supplied a
+  computed relation tag)
 
 [#143]: https://github.com/bact/pitloom/pull/143
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,3 +326,4 @@ source = ["pitloom"]
 [tool.coverage.report]
 show_missing = true
 skip_covered = false
+fail_under = 88 # Hard floor minimum threshold; we try to keep it higher

--- a/src/pitloom/assemble/spdx3/ai.py
+++ b/src/pitloom/assemble/spdx3/ai.py
@@ -263,7 +263,6 @@ def _add_base_model_lineage(
     rel_relation = ai_model.base_model_relation or ai_model.extra_data.get(
         "hf.base_model_relation"
     )
-    comment = f"base_model_relation:{rel_relation}" if rel_relation else None
 
     rel = spdx3.Relationship(
         spdxId=generate_spdx_id(
@@ -273,8 +272,16 @@ def _add_base_model_lineage(
         relationshipType=spdx3.RelationshipType.descendantOf,
         to=[base_spdx_id],
         creationInfo=ctx.creation_info,
-        comment=comment,
     )
+    # comment is unset (not None) when there's no relation -- the
+    # underlying SPDX 3 binding rejects an explicit None for a string
+    # property, only accepting omission (see the direct unit tests in
+    # tests/test_assemble_ai.py that caught this: base_model is read from
+    # a model card's frontmatter, base_model_relation from a separate Hub
+    # API computed tag -- a model with the former but not the latter
+    # crashed SBOM generation entirely before this fix).
+    if rel_relation:
+        rel.comment = f"base_model_relation:{rel_relation}"
     ctx.exporter.add_relationship(rel)
 
 

--- a/tests/test_assemble_ai.py
+++ b/tests/test_assemble_ai.py
@@ -1,0 +1,422 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Direct unit tests for pitloom.assemble.spdx3.ai.
+
+Complements the full-pipeline graph assertions in test_generator.py etc.
+with tests that call these functions directly and assert on their
+return values, so a regression here fails in this file instead of
+surfacing as a generic "wrong graph shape" failure somewhere else.
+"""
+
+# pylint: disable=missing-function-docstring
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from spdx_python_model.bindings import v3_0_1 as spdx3
+
+from pitloom.assemble.spdx3.ai import (
+    _add_base_model_lineage,
+    _build_ai_package,
+    _LineageContext,
+    _lookup_ai_model_entity,
+    _should_preserve_metadata,
+    _source_metadata_blob,
+)
+from pitloom.core.ai_metadata import AiModelFormat, AiModelFormatInfo, AiModelMetadata
+from pitloom.core.models import generate_spdx_id
+from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
+from pitloom.ids import EntityEntry, IdRegistry
+
+_DOC_NAME = "testproject"
+_DOC_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+def _make_ci() -> spdx3.CreationInfo:
+    ci = spdx3.CreationInfo(
+        specVersion="3.0.1",
+        created=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    person = spdx3.Person(
+        spdxId=generate_spdx_id("Person", doc_name=_DOC_NAME, doc_uuid=_DOC_UUID),
+        name="Test",
+        creationInfo=ci,
+    )
+    ci.createdBy = [require_spdx_id(person)]
+    return ci
+
+
+# ---------------------------------------------------------------------------
+# _should_preserve_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_should_preserve_metadata_always() -> None:
+    model = AiModelMetadata()
+    assert _should_preserve_metadata(model, {}, "always") is True
+
+
+def test_should_preserve_metadata_never() -> None:
+    model = AiModelMetadata()
+    assert _should_preserve_metadata(model, {}, "never") is False
+
+
+def test_should_preserve_metadata_auto_not_shipped() -> None:
+    model = AiModelMetadata(
+        format_info=AiModelFormatInfo(file_path_relative="model.gguf")
+    )
+    assert _should_preserve_metadata(model, {}, "auto") is True
+
+
+def test_should_preserve_metadata_auto_shipped() -> None:
+    model = AiModelMetadata(
+        format_info=AiModelFormatInfo(file_path_relative="model.gguf")
+    )
+    file_spdx_ids = {"model.gguf": "urn:doc#File-model"}
+    assert _should_preserve_metadata(model, file_spdx_ids, "auto") is False
+
+
+def test_should_preserve_metadata_auto_no_relative_path() -> None:
+    model = AiModelMetadata()
+    assert _should_preserve_metadata(model, {}, "auto") is True
+
+
+# ---------------------------------------------------------------------------
+# _source_metadata_blob
+# ---------------------------------------------------------------------------
+
+
+def test_source_metadata_blob_prefers_raw_metadata() -> None:
+    model = AiModelMetadata(
+        format_info=AiModelFormatInfo(model_format=AiModelFormat.GGUF),
+        raw_metadata={"general.name": "test-model"},
+        properties={"ignored": "yes"},
+    )
+    fmt, blob = _source_metadata_blob(model)
+    assert fmt == "gguf"
+    assert blob == {"general.name": "test-model"}
+
+
+def test_source_metadata_blob_falls_back_to_properties_and_extras() -> None:
+    model = AiModelMetadata(
+        properties={"p": "1"},
+        extra_data={"hf.sha": "abc123"},
+        extra_lists={"hf.tags": ["a", "b"]},
+    )
+    fmt, blob = _source_metadata_blob(model)
+    assert fmt == "huggingface"
+    assert blob == {"p": "1", "hf.sha": "abc123", "hf.tags": ["a", "b"]}
+
+
+def test_source_metadata_blob_unknown_format_no_extras_stays_unknown() -> None:
+    model = AiModelMetadata(properties={"p": "1"})
+    fmt, _blob = _source_metadata_blob(model)
+    assert fmt == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# _lookup_ai_model_entity
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_ai_model_entity_no_registry_returns_none() -> None:
+    model = AiModelMetadata(name="mymodel")
+    assert _lookup_ai_model_entity(model, None) is None
+
+
+def test_lookup_ai_model_entity_not_found_returns_none() -> None:
+    registry = IdRegistry(namespace="urn:doc")
+    model = AiModelMetadata(name="unregistered")
+    assert _lookup_ai_model_entity(model, registry) is None
+
+
+def test_lookup_ai_model_entity_found_by_name() -> None:
+    registry = IdRegistry(
+        namespace="urn:doc",
+        entities={
+            "mymodel": EntityEntry(type="ai_AIPackage", spdx_id="urn:doc#AIPackage-1")
+        },
+    )
+    model = AiModelMetadata(name="mymodel")
+    assert _lookup_ai_model_entity(model, registry) == "urn:doc#AIPackage-1"
+
+
+def test_lookup_ai_model_entity_found_by_physical_path() -> None:
+    registry = IdRegistry(
+        namespace="urn:doc",
+        entities={
+            "src/model.gguf": EntityEntry(
+                type="ai_AIPackage", spdx_id="urn:doc#AIPackage-2"
+            )
+        },
+    )
+    model = AiModelMetadata(
+        format_info=AiModelFormatInfo(physical_path="src/model.gguf")
+    )
+    assert _lookup_ai_model_entity(model, registry) == "urn:doc#AIPackage-2"
+
+
+def test_lookup_ai_model_entity_found_by_file_stem() -> None:
+    registry = IdRegistry(
+        namespace="urn:doc",
+        entities={
+            "model": EntityEntry(type="ai_AIPackage", spdx_id="urn:doc#AIPackage-3")
+        },
+    )
+    model = AiModelMetadata(format_info=AiModelFormatInfo(file_name="model.gguf"))
+    assert _lookup_ai_model_entity(model, registry) == "urn:doc#AIPackage-3"
+
+
+# ---------------------------------------------------------------------------
+# _build_ai_package
+# ---------------------------------------------------------------------------
+
+
+def test_build_ai_package_minimal() -> None:
+    ci = _make_ci()
+    model = AiModelMetadata(name="tiny-model")
+    pkg = _build_ai_package(model, ci, _DOC_NAME, _DOC_UUID)
+    assert pkg.name == "tiny-model"
+    assert pkg.software_packageVersion is None
+    assert not pkg.ai_typeOfModel
+
+
+def test_build_ai_package_name_falls_back_to_format() -> None:
+    ci = _make_ci()
+    model = AiModelMetadata(
+        format_info=AiModelFormatInfo(model_format=AiModelFormat.ONNX)
+    )
+    pkg = _build_ai_package(model, ci, _DOC_NAME, _DOC_UUID)
+    assert pkg.name == "onnx"
+
+
+def test_build_ai_package_entity_spdx_id_override() -> None:
+    ci = _make_ci()
+    model = AiModelMetadata(name="tiny-model")
+    pkg = _build_ai_package(
+        model, ci, _DOC_NAME, _DOC_UUID, entity_spdx_id="urn:doc#AIPackage-pinned"
+    )
+    assert pkg.spdxId == "urn:doc#AIPackage-pinned"
+
+
+def test_build_ai_package_all_optional_fields() -> None:
+    """One comprehensive pass over every optional field _build_ai_package
+    maps, since the full-pipeline tests only ever exercise a handful of
+    these at a time -- this is what actually closes the coverage gap on
+    the field-by-field construction logic."""
+    ci = _make_ci()
+    model = AiModelMetadata(
+        name="full-model",
+        version="1.2.3",
+        description="A model with everything set.",
+        type_of_model="transformer",
+        architecture="llama",
+        quantization="Q4_K_M",
+        hyperparameters={"num_layers": 12, "hidden_size": 768},
+        domain=["NLP"],
+        inputs=[{"name": "input_ids", "shape": [1, 128]}],
+        outputs=[{"name": "logits", "shape": [1, 128, 32000]}],
+    )
+    model.usage.domains = ["NLP", "text generation"]  # overlaps "NLP" -- dedup check
+    model.usage.limitations = ["English only", "small context window"]
+    model.usage.safety_risk_assessment = "medium"
+    model.usage.intended_use = ["chatbot"]
+    model.usage.unintended_use = ["medical diagnosis"]
+    model.usage.known_biases = ["training data skew"]
+
+    pkg = _build_ai_package(model, ci, _DOC_NAME, _DOC_UUID)
+
+    assert pkg.software_packageVersion == "1.2.3"
+    assert pkg.description == "A model with everything set."
+    assert pkg.ai_typeOfModel == ["transformer", "llama"]
+    hyperparameters = [
+        entry
+        for entry in pkg.ai_hyperparameter
+        if isinstance(entry, spdx3.DictionaryEntry)
+    ]
+    assert len(hyperparameters) == len(pkg.ai_hyperparameter)
+    assert hyperparameters[0].key == "quantization"
+    assert hyperparameters[0].value == "Q4_K_M"
+    hp_keys = {entry.key for entry in hyperparameters}
+    assert hp_keys == {"quantization", "num_layers", "hidden_size"}
+    # domain + usage.domains merged and de-duplicated, order preserved.
+    assert pkg.ai_domain == ["NLP", "text generation"]
+    assert pkg.ai_limitation == "English only; small context window"
+    assert pkg.ai_safetyRiskAssessment == spdx3.ai_SafetyRiskAssessmentType.medium
+    assert pkg.ai_informationAboutApplication is not None
+    assert "chatbot" in pkg.ai_informationAboutApplication
+    assert "medical diagnosis" in pkg.ai_informationAboutApplication
+    assert pkg.comment == "Known biases: training data skew"
+
+
+def test_build_ai_package_invalid_safety_risk_ignored() -> None:
+    ci = _make_ci()
+    model = AiModelMetadata(name="risky-model")
+    model.usage.safety_risk_assessment = "not-a-real-risk-level"
+    pkg = _build_ai_package(model, ci, _DOC_NAME, _DOC_UUID)
+    assert pkg.ai_safetyRiskAssessment is None
+
+
+def test_build_ai_package_external_identifiers_and_refs() -> None:
+    ci = _make_ci()
+    model = AiModelMetadata(
+        name="cited-model",
+        doi="10.1234/example",
+        arxiv_ids=["2401.00001"],
+        url="https://huggingface.co/org/cited-model",
+    )
+    pkg = _build_ai_package(model, ci, _DOC_NAME, _DOC_UUID)
+    identifier = pkg.externalIdentifier[0]
+    assert isinstance(identifier, spdx3.ExternalIdentifier)
+    assert identifier.identifier == "10.1234/example"
+    ref_0, ref_1 = pkg.externalRef[0], pkg.externalRef[1]
+    assert isinstance(ref_0, spdx3.ExternalRef)
+    assert isinstance(ref_1, spdx3.ExternalRef)
+    assert ref_0.comment == "arXiv:2401.00001"
+    assert ref_1.comment == "Model page URL"
+
+
+# ---------------------------------------------------------------------------
+# _add_base_model_lineage
+# ---------------------------------------------------------------------------
+
+
+def test_add_base_model_lineage_no_base_model_is_noop() -> None:
+    ci = _make_ci()
+    exporter = Spdx3JsonExporter()
+    model = AiModelMetadata(name="standalone")
+    pkg = _build_ai_package(model, ci, _DOC_NAME, _DOC_UUID)
+    exporter.add_package(pkg)
+    ctx = _LineageContext(
+        creation_info=ci, doc_name=_DOC_NAME, doc_uuid=_DOC_UUID, exporter=exporter
+    )
+    _add_base_model_lineage(pkg, model, ctx)
+    assert len(exporter.object_set.objects) == 1  # only pkg itself, no new elements
+
+
+def test_add_base_model_lineage_creates_stub_package() -> None:
+    """Regression test: base_model set without base_model_relation (e.g.
+    a model card's frontmatter has base_model but the Hub API's computed
+    tags never supplied a relation) used to crash -- the underlying SPDX
+    3 binding rejects an explicit `comment=None`, only accepting a
+    field left unset entirely. Caught by this direct unit test; no
+    full-pipeline test exercised this combination before."""
+    ci = _make_ci()
+    exporter = Spdx3JsonExporter()
+    model = AiModelMetadata(name="finetuned-model", base_model="org/base-model")
+    pkg = _build_ai_package(model, ci, _DOC_NAME, _DOC_UUID)
+    exporter.add_package(pkg)
+    ctx = _LineageContext(
+        creation_info=ci, doc_name=_DOC_NAME, doc_uuid=_DOC_UUID, exporter=exporter
+    )
+    _add_base_model_lineage(pkg, model, ctx)
+
+    relationships = [
+        obj
+        for obj in exporter.object_set.objects
+        if isinstance(obj, spdx3.Relationship)
+    ]
+    assert relationships[0].comment is None
+
+    base_packages = [
+        obj
+        for obj in exporter.object_set.objects
+        if isinstance(obj, spdx3.ai_AIPackage) and obj.name == "base-model"
+    ]
+    assert len(base_packages) == 1
+    base_ref = base_packages[0].externalRef[0]
+    assert isinstance(base_ref, spdx3.ExternalRef)
+    assert base_ref.locator == ["https://huggingface.co/org/base-model"]
+    assert len(relationships) == 1
+    assert relationships[0].relationshipType == spdx3.RelationshipType.descendantOf
+
+
+def test_add_base_model_lineage_reuses_existing_package() -> None:
+    ci = _make_ci()
+    exporter = Spdx3JsonExporter()
+
+    # An ai_AIPackage for the base model already exists in the document
+    # (e.g. it's also a top-level model in this same project scan).
+    existing_base = spdx3.ai_AIPackage(
+        spdxId=generate_spdx_id(
+            "AIPackage-base-model", doc_name=_DOC_NAME, doc_uuid=_DOC_UUID
+        ),
+        name="base-model",
+        creationInfo=ci,
+    )
+    exporter.add_package(existing_base)
+
+    model = AiModelMetadata(name="finetuned-model", base_model="org/base-model")
+    pkg = _build_ai_package(model, ci, _DOC_NAME, _DOC_UUID)
+    exporter.add_package(pkg)
+    ctx = _LineageContext(
+        creation_info=ci, doc_name=_DOC_NAME, doc_uuid=_DOC_UUID, exporter=exporter
+    )
+    _add_base_model_lineage(pkg, model, ctx)
+
+    base_packages = [
+        obj
+        for obj in exporter.object_set.objects
+        if isinstance(obj, spdx3.ai_AIPackage) and obj.name == "base-model"
+    ]
+    # No second/duplicate base package minted -- the existing one is reused.
+    assert len(base_packages) == 1
+    relationships = [
+        obj
+        for obj in exporter.object_set.objects
+        if isinstance(obj, spdx3.Relationship)
+    ]
+    assert relationships[0].to == [require_spdx_id(existing_base)]
+
+
+def test_add_base_model_lineage_caches_across_calls() -> None:
+    ci = _make_ci()
+    exporter = Spdx3JsonExporter()
+    ctx = _LineageContext(
+        creation_info=ci, doc_name=_DOC_NAME, doc_uuid=_DOC_UUID, exporter=exporter
+    )
+
+    model_a = AiModelMetadata(name="model-a", base_model="org/shared-base")
+    pkg_a = _build_ai_package(model_a, ci, _DOC_NAME, _DOC_UUID)
+    exporter.add_package(pkg_a)
+    _add_base_model_lineage(pkg_a, model_a, ctx)
+
+    model_b = AiModelMetadata(name="model-b", base_model="org/shared-base")
+    pkg_b = _build_ai_package(model_b, ci, _DOC_NAME, _DOC_UUID)
+    exporter.add_package(pkg_b)
+    _add_base_model_lineage(pkg_b, model_b, ctx)
+
+    base_packages = [
+        obj
+        for obj in exporter.object_set.objects
+        if isinstance(obj, spdx3.ai_AIPackage) and obj.name == "shared-base"
+    ]
+    # Second call reuses ctx.cache instead of scanning/minting again.
+    assert len(base_packages) == 1
+
+
+def test_add_base_model_lineage_relation_comment() -> None:
+    ci = _make_ci()
+    exporter = Spdx3JsonExporter()
+    model = AiModelMetadata(
+        name="quantized-model",
+        base_model="org/base-model",
+        base_model_relation="quantized",
+    )
+    pkg = _build_ai_package(model, ci, _DOC_NAME, _DOC_UUID)
+    exporter.add_package(pkg)
+    ctx = _LineageContext(
+        creation_info=ci, doc_name=_DOC_NAME, doc_uuid=_DOC_UUID, exporter=exporter
+    )
+    _add_base_model_lineage(pkg, model, ctx)
+
+    relationships = [
+        obj
+        for obj in exporter.object_set.objects
+        if isinstance(obj, spdx3.Relationship)
+    ]
+    assert relationships[0].comment == "base_model_relation:quantized"

--- a/tests/test_creation_info.py
+++ b/tests/test_creation_info.py
@@ -160,7 +160,7 @@ def test_build_tools_empty_list_suppresses_created_using() -> None:
         CreationMetadata(), _DOC_NAME, _DOC_UUID
     )
     tools = build_tools(CreationMetadata(tools=[]), _DOC_NAME, _DOC_UUID, spdx_ci)
-    assert tools == []
+    assert not tools
 
 
 def test_build_tools_custom_tool_no_pitloom_summary() -> None:

--- a/tests/test_creation_info.py
+++ b/tests/test_creation_info.py
@@ -1,0 +1,206 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Direct unit tests for pitloom.assemble.spdx3.creation_info.
+
+Complements the full-pipeline graph assertions in test_generator.py etc.
+with tests that call these functions directly and assert on their return
+values, so a regression here fails in this file instead of surfacing as
+a generic "wrong graph shape" failure somewhere else.
+"""
+
+# pylint: disable=missing-function-docstring
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from spdx_python_model.bindings import v3_0_1 as spdx3
+
+from pitloom.assemble.spdx3.creation_info import (
+    _tool_summary,
+    build_creation_info,
+    build_creator_agents,
+    build_tools,
+    parse_iso_datetime,
+    to_spdx3_datetime,
+)
+from pitloom.core.creation import CreationMetadata, Creator, Tool
+
+_DOC_NAME = "testproject"
+_DOC_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+# ---------------------------------------------------------------------------
+# parse_iso_datetime / to_spdx3_datetime
+# ---------------------------------------------------------------------------
+
+
+def test_parse_iso_datetime_with_offset() -> None:
+    parsed = parse_iso_datetime("2026-01-15T10:30:00+02:00")
+    offset = parsed.utcoffset()
+    assert parsed.hour == 10
+    assert offset is not None
+    assert offset.total_seconds() == 7200
+    assert to_spdx3_datetime(parsed) == datetime(
+        2026, 1, 15, 8, 30, tzinfo=timezone.utc
+    )
+
+
+def test_parse_iso_datetime_trailing_z() -> None:
+    parsed = parse_iso_datetime("2026-01-15T10:30:00Z")
+    assert parsed == datetime(2026, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+
+
+def test_parse_iso_datetime_naive_assumed_utc() -> None:
+    parsed = parse_iso_datetime("2026-01-15T10:30:00")
+    assert parsed.tzinfo == timezone.utc
+
+
+def test_parse_iso_datetime_invalid_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid ISO 8601 datetime"):
+        parse_iso_datetime("not-a-date")
+
+
+def test_to_spdx3_datetime_truncates_microseconds() -> None:
+    value = datetime(2026, 1, 15, 10, 30, 0, 123456, tzinfo=timezone.utc)
+    assert to_spdx3_datetime(value).microsecond == 0
+
+
+# ---------------------------------------------------------------------------
+# _tool_summary
+# ---------------------------------------------------------------------------
+
+
+def test_tool_summary_none_name() -> None:
+    assert _tool_summary(None) is None
+
+
+def test_tool_summary_empty_name() -> None:
+    assert _tool_summary("") is None
+
+
+def test_tool_summary_non_pitloom_name() -> None:
+    assert _tool_summary("SomeOtherTool") is None
+
+
+def test_tool_summary_pitloom_name_includes_version() -> None:
+    summary = _tool_summary("Pitloom")
+    assert summary is not None
+    assert summary.startswith("Pitloom ")
+
+
+# ---------------------------------------------------------------------------
+# build_creator_agents
+# ---------------------------------------------------------------------------
+
+
+def test_build_creator_agents_no_creators_yields_pitloom_software_agent() -> None:
+    spdx_ci, _agents, _tools = build_creation_info(
+        CreationMetadata(), _DOC_NAME, _DOC_UUID
+    )
+    agents = build_creator_agents(CreationMetadata(), _DOC_NAME, _DOC_UUID, spdx_ci)
+    assert len(agents) == 1
+    assert agents[0].name == "Pitloom"
+
+
+def test_build_creator_agents_with_email() -> None:
+    spdx_ci, _agents, _tools = build_creation_info(
+        CreationMetadata(), _DOC_NAME, _DOC_UUID
+    )
+    metadata = CreationMetadata(
+        creators=[Creator(name="Jane Doe", type="person", email="jane@example.com")]
+    )
+    agents = build_creator_agents(metadata, _DOC_NAME, _DOC_UUID, spdx_ci)
+    assert len(agents) == 1
+    assert agents[0].name == "Jane Doe"
+    identifier = agents[0].externalIdentifier[0]
+    assert isinstance(identifier, spdx3.ExternalIdentifier)
+    assert identifier.identifier == "jane@example.com"
+
+
+def test_build_creator_agents_invalid_type_raises() -> None:
+    # Creator.__post_init__ already validates `type` eagerly against the
+    # same VALID_CREATOR_TYPES set, so a normal construction can never
+    # reach build_creator_agents's own check -- mutate `type` after
+    # construction (Creator isn't frozen) to exercise that second,
+    # defensive layer directly, same as a future VALID_CREATOR_TYPES/
+    # CREATOR_TYPES drift would.
+    spdx_ci, _agents, _tools = build_creation_info(
+        CreationMetadata(), _DOC_NAME, _DOC_UUID
+    )
+    creator = Creator(name="Bad", type="person")
+    creator.type = "not-a-real-type"
+    metadata = CreationMetadata(creators=[creator])
+    with pytest.raises(ValueError, match="Invalid creator type"):
+        build_creator_agents(metadata, _DOC_NAME, _DOC_UUID, spdx_ci)
+
+
+# ---------------------------------------------------------------------------
+# build_tools
+# ---------------------------------------------------------------------------
+
+
+def test_build_tools_default_is_pitloom() -> None:
+    spdx_ci, _agents, _tools = build_creation_info(
+        CreationMetadata(), _DOC_NAME, _DOC_UUID
+    )
+    tools = build_tools(CreationMetadata(), _DOC_NAME, _DOC_UUID, spdx_ci)
+    assert len(tools) == 1
+    assert tools[0].name == "Pitloom"
+    assert tools[0].summary is not None
+    assert tools[0].externalIdentifier
+
+
+def test_build_tools_empty_list_suppresses_created_using() -> None:
+    spdx_ci, _agents, _tools = build_creation_info(
+        CreationMetadata(), _DOC_NAME, _DOC_UUID
+    )
+    tools = build_tools(CreationMetadata(tools=[]), _DOC_NAME, _DOC_UUID, spdx_ci)
+    assert tools == []
+
+
+def test_build_tools_custom_tool_no_pitloom_summary() -> None:
+    spdx_ci, _agents, _tools = build_creation_info(
+        CreationMetadata(), _DOC_NAME, _DOC_UUID
+    )
+    tools = build_tools(
+        CreationMetadata(tools=[Tool(name="SomeBuildTool")]),
+        _DOC_NAME,
+        _DOC_UUID,
+        spdx_ci,
+    )
+    assert len(tools) == 1
+    assert tools[0].name == "SomeBuildTool"
+    assert tools[0].summary is None
+
+
+# ---------------------------------------------------------------------------
+# build_creation_info
+# ---------------------------------------------------------------------------
+
+
+def test_build_creation_info_uses_default_comment_when_none_given() -> None:
+    spdx_ci, _agents, _tools = build_creation_info(
+        CreationMetadata(), _DOC_NAME, _DOC_UUID, default_comment="default text"
+    )
+    assert spdx_ci.comment == "default text"
+
+
+def test_build_creation_info_explicit_comment_overrides_default() -> None:
+    spdx_ci, _agents, _tools = build_creation_info(
+        CreationMetadata(creation_comment="explicit"),
+        _DOC_NAME,
+        _DOC_UUID,
+        default_comment="default text",
+    )
+    assert spdx_ci.comment == "explicit"
+
+
+def test_build_creation_info_explicit_datetime_used() -> None:
+    metadata = CreationMetadata(creation_datetime="2026-03-01T00:00:00Z")
+    spdx_ci, _agents, _tools = build_creation_info(metadata, _DOC_NAME, _DOC_UUID)
+    assert spdx_ci.created == datetime(2026, 3, 1, tzinfo=timezone.utc)

--- a/tests/test_extract_dataset.py
+++ b/tests/test_extract_dataset.py
@@ -1,0 +1,28 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for pitloom.extract.dataset -- the public dataset-extraction API.
+
+test_extract_croissant.py tests the Croissant format in depth via the
+internal pitloom.extract._croissant module directly; this file only
+confirms the public re-export in pitloom.extract.dataset itself works,
+since nothing else imports read_croissant through that public path.
+"""
+
+# pylint: disable=missing-function-docstring
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pitloom.extract.dataset import DatasetMetadata, read_croissant
+
+FIXTURES = Path(__file__).parent / "fixtures" / "croissant"
+
+
+def test_read_croissant_public_reexport() -> None:
+    meta = read_croissant(FIXTURES / "minimal.json")
+    assert isinstance(meta, DatasetMetadata)
+    assert meta.name


### PR DESCRIPTION
## Summary

- Fixes a crash on base_model without a relation
- Adds coverage enforcement and direct unit tests for AI/creation-info assembly

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
