### PR TITLE
Add PEP 770 wheel SBOM embedding to CLI and GitHub Action

### DIFF
--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -47,13 +47,11 @@ jobs:
           cache-dependency-path: pyproject.toml
 
       - name: Install Pitloom from checkout
-        # Self-test runs project mode (no --model, no --content-type), so it
-        # never touches the ai/content-type extras' extraction code paths --
-        # a plain editable install is enough to dogfood the composite action.
+        # Self-test runs project mode and embed-wheel mode.
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install spdx3-validate
+          pip install build check-wheel-contents installer spdx3-validate
 
       - name: Build licenseid database
         run: licenseid update
@@ -125,3 +123,43 @@ jobs:
         run: |
           spdx3-validate --json "${{ steps.pitloom.outputs.sbom-path }}"
         continue-on-error: true
+
+      - name: Build a wheel
+        run: |
+          python -m build --wheel --no-isolation --outdir dist/
+
+      - name: Run Pitloom action with embed-wheel
+        id: pitloom-embed
+        uses: ./
+        with:
+          embed-wheel: "dist/*.whl"
+          project-path: "."
+          output: "embedded-selftest-sbom.spdx3.json"
+          pretty: "true"
+          install: "false"
+          upload-artifact: "false"
+
+      - name: Validate embedded wheel and SBOM with authoritative tools
+        run: |
+          set -euo pipefail
+
+          # 1. spdx3-validate
+          spdx3-validate --json "${{ steps.pitloom-embed.outputs.sbom-path }}"
+
+          # 2. PyPA installer (RECORD verification)
+          python -c '
+          import glob
+          from installer.sources import WheelFile
+          wheels = glob.glob("dist/*.whl")
+          assert len(wheels) > 0, "No wheels found in dist/"
+          for w in wheels:
+              with WheelFile.open(w) as wf:
+                  wf.validate_record()
+              print(f"PyPA installer validation passed for {w}")
+          '
+
+          # 3. check-wheel-contents
+          check-wheel-contents dist/*.whl
+
+          # 4. pip install --dry-run
+          pip install --dry-run --target /tmp/pip-test --no-deps dist/*.whl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,11 @@
 - The CLI (`pitloom.__main__`) and `pitloom.assemble.generate_project_sbom()`'s default parsing path both resolve metadata/config from the project directory via the shared `pitloom.extract.project.read_project()` helper (`pyproject.toml` -> `setup.cfg`/`setup.py` -> error), so each parses its inputs once. The CLI passes its already-parsed `project_metadata`/`pitloom_config` into `generate_project_sbom()` so it never re-parses.
 - Both paths converge on the same `pitloom.assemble.spdx3.document.build()` assembly layer, so the emitted SBOM shape (file hashes, PURLs, licensing, etc.) is identical regardless of metadata source.
 
+## Design principles
+
+- **Honor user intent over silent fallbacks**: Do not implement implicit fallbacks that contradict the user's explicit instructions or command semantics (e.g. if the user specifies a standalone mode, do not silently parse a project directory).
+- **No silent deviations**: If Pitloom must deviate from the user's instruction to ensure correctness or safety, it must never do so silently. Always emit a clear `WARNING:` log or stderr message explaining what decision was made and why.
+
 ## CLI output
 
 Unix philosophy. Consistent, predictable, parseable.
@@ -95,6 +100,13 @@ Unix philosophy. Consistent, predictable, parseable.
 - `requires-python` must match actual min version.
 - Make packages zip-safe when possible.
 - Packaging metadata follows Core metadata spec: <https://packaging.python.org/en/latest/specifications/core-metadata/>
+
+## Cross-platform compatibility
+
+- Pitloom must work seamlessly across Windows, macOS, and Linux.
+- Be vigilant about OS differences: file locking semantics (e.g. Windows `PermissionError` when replacing or deleting an open file), path separators (`\` vs `/`), pipe behaviors, and filesystem case-sensitivity.
+- Always use `pathlib.Path` for file resolution and manipulation; never concatenate paths as strings.
+- Ensure automated tests run smoothly across platforms without leaving orphaned temporary files behind.
 
 ### Import order
 
@@ -199,6 +211,7 @@ a human or agent judge a doc's staleness without checking git history.
 ## Testing
 
 - Add tests for new behavior -- cover success, failure, edge cases.
+- **Bug fixes and regressions**: When fixing a bug, always add a regression test that fails without the fix and passes with it. Prove the bug is dead and ensure it stays dead.
 - Use pytest patterns, not `unittest.TestCase`.
 - `spec`/`autospec` when mocking.
 - `time_machine` for time-dependent tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ and this project adheres to
 
 - Reorganize project documentation ([#146])
 
+### Fixed
+
+- SBOM `created` now honours `SOURCE_DATE_EPOCH` (same priority as the
+  Hatchling build hook's `builtTime`) -- previously only the embedded
+  wheel's ZIP entry timestamp respected it, so a wheel embedded under a
+  reproducible-build environment still carried a different SBOM `created`
+  value on every rebuild, even with `SOURCE_DATE_EPOCH` set ([#148])
+
 [#146]: https://github.com/bact/pitloom/pull/146
 [#148]: https://github.com/bact/pitloom/pull/148
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,14 @@ and this project adheres to
 ### Added
 
 - `loom wheel --embed`, `loom embed-wheel`, and GitHub Action support for
-  embedding SPDX 3 SBOMs into Python wheels
+  embedding SPDX 3 SBOMs into Python wheels ([#148])
 
 ### Changed
 
 - Reorganize project documentation ([#146])
 
 [#146]: https://github.com/bact/pitloom/pull/146
+[#148]: https://github.com/bact/pitloom/pull/148
 
 ## [0.14.1] 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-Last-Modified: 2026-08-13
+Last-Modified: 2026-08-14
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -20,6 +20,13 @@ and this project adheres to
 - Commit history: <https://github.com/bact/pitloom/compare/v0.14.0...v0.14.1>
 
 ## [Unreleased]
+
+### Added
+
+- `loom wheel --embed`, `loom embed-wheel`, and GitHub Action support for
+  embedding SPDX 3 SBOMs into Python wheels
+
+### Changed
 
 - Reorganize project documentation ([#146])
 

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,13 @@ inputs:
       setup.cfg, or setup.py). Ignored when "model" is set.
     required: false
     default: "."
+  embed-wheel:
+    description: >-
+      Path or glob pattern of built wheel file(s) to embed the generated
+      SBOM into (PEP 770). Example: "dist/*.whl". When set, runs
+      "loom embed-wheel <embed-wheel>" instead of project/model mode.
+    required: false
+    default: ""
   model:
     description: >-
       Path to a local AI model file, or a Hugging Face URL / model ID.
@@ -145,6 +152,7 @@ runs:
       shell: bash
       env:
         PL_PROJECT_PATH: ${{ inputs.project-path }}
+        PL_EMBED_WHEEL: ${{ inputs.embed-wheel }}
         PL_MODEL: ${{ inputs.model }}
         PL_OUTPUT: ${{ inputs.output }}
         PL_PRETTY: ${{ inputs.pretty }}
@@ -157,7 +165,12 @@ runs:
         set -euo pipefail
 
         declare -a loom_args
-        if [ -n "${PL_MODEL}" ]; then
+        if [ -n "${PL_EMBED_WHEEL}" ]; then
+          loom_args+=("embed-wheel" "${PL_EMBED_WHEEL}")
+          if [ -n "${PL_PROJECT_PATH}" ]; then
+            loom_args+=("--project-dir" "${PL_PROJECT_PATH}")
+          fi
+        elif [ -n "${PL_MODEL}" ]; then
           loom_args+=("model" "${PL_MODEL}")
         else
           loom_args+=("project" "${PL_PROJECT_PATH}")

--- a/action.yml
+++ b/action.yml
@@ -164,8 +164,17 @@ runs:
       run: |
         set -euo pipefail
 
+        # Resolve a python binary up front -- used both for the embed-wheel
+        # match count below and for the PL_ARGS shlex split further down.
+        # When install=false, "Set up Python" is skipped, so don't assume
+        # python3 specifically is on PATH.
+        python_bin=python3
+        command -v "${python_bin}" >/dev/null 2>&1 || python_bin=python
+
         declare -a loom_args
+        is_embed=false
         if [ -n "${PL_EMBED_WHEEL}" ]; then
+          is_embed=true
           loom_args+=("embed-wheel" "${PL_EMBED_WHEEL}")
           if [ -n "${PL_PROJECT_PATH}" ]; then
             loom_args+=("--project-dir" "${PL_PROJECT_PATH}")
@@ -175,7 +184,25 @@ runs:
         else
           loom_args+=("project" "${PL_PROJECT_PATH}")
         fi
-        loom_args+=("-o" "${PL_OUTPUT}")
+
+        # "loom embed-wheel" rejects --output when its pattern matches more
+        # than one wheel (a standalone copy is ambiguous across wheels), so
+        # mirror that check here rather than crash: only pass -o (and later
+        # report sbom-path) when the pattern resolves to exactly one wheel.
+        skip_output=false
+        if [ "${is_embed}" = true ]; then
+          wheel_count=$(
+            "${python_bin}" -c 'import glob, sys; print(len(glob.glob(sys.argv[1])))' \
+              "${PL_EMBED_WHEEL}"
+          )
+          if [ "${wheel_count}" -ne 1 ]; then
+            skip_output=true
+          fi
+        fi
+        if [ "${skip_output}" = false ]; then
+          loom_args+=("-o" "${PL_OUTPUT}")
+        fi
+
         if [ "${PL_PRETTY}" = "true" ]; then
           loom_args+=("--pretty")
         fi
@@ -202,12 +229,8 @@ runs:
           # (e.g. '--creator-name "CI Bot"'), not a single token. Plain bash
           # word-splitting (extra_args=(${PL_ARGS})) has no quote-awareness
           # and would break a quoted multi-word value into separate tokens,
-          # so split it with Python's shlex instead.
-          #
-          # When install=false, "Set up Python" is skipped, so don't assume
-          # python3 specifically is on PATH -- fall back to python.
-          python_bin=python3
-          command -v "${python_bin}" >/dev/null 2>&1 || python_bin=python
+          # so split it with Python's shlex instead. (python_bin was
+          # resolved above.)
           readarray -t extra_args < <(
             "${python_bin}" -c 'import shlex, sys; print(*shlex.split(sys.argv[1]), sep="\n")' \
               "${PL_ARGS}"
@@ -217,10 +240,12 @@ runs:
 
         loom "${loom_args[@]}"
 
-        echo "sbom-path=${PL_OUTPUT}" >> "${GITHUB_OUTPUT}"
+        if [ "${skip_output}" = false ]; then
+          echo "sbom-path=${PL_OUTPUT}" >> "${GITHUB_OUTPUT}"
+        fi
 
     - name: Upload SBOM artifact
-      if: inputs.upload-artifact == 'true'
+      if: inputs.upload-artifact == 'true' && steps.generate.outputs.sbom-path != ''
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       with:
         name: ${{ inputs.artifact-name }}

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -22,7 +22,9 @@ page -- it installs the exact same three `SKILL.md` files described here.
 Pitloom ships three Skills:
 
 - `sbom-generate` -- generates a base SBOM/AIBOM for a project, wheel, or
-  AI/ML model file.
+  AI/ML model file. Also embeds a generated (or pre-existing) SBOM
+  directly into a built wheel per PEP 770's `.dist-info/sboms/`
+  convention.
 - `sbom-enrich` -- reads a README or model card and contributes inferred
   detail (a license guess, a `trainedOn` dataset) back into an existing
   SBOM as a provenance-marked fragment; in an interactive session it can
@@ -101,6 +103,18 @@ line](cli.md) page). See
 for the full recipe set.
 
 [sbom-generate-examples]: https://github.com/bact/pitloom/blob/main/skills/sbom-generate/references/examples.md
+
+### Embed an SBOM into a wheel (PEP 770)
+
+```text
+/sbom-generate .                                          # build the SBOM
+loom embed-wheel dist/mypackage-1.0.0-py3-none-any.whl    # embed it (or --sbom <file>)
+```
+
+Runs `loom embed-wheel` (or `loom wheel --embed` for a single wheel's own
+Analyzed SBOM, no project directory) under the hood, mutating the `.whl`
+archive in place and updating `RECORD` to match -- works on any wheel
+regardless of build backend, since a wheel is just a ZIP archive.
 
 ### Enrich an existing SBOM
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -58,6 +58,28 @@ binaries as phantom dependencies):
 loom wheel path/to/mypackage-1.0.0-py3-none-any.whl -o sbom.spdx3.json
 ```
 
+### Embed an SBOM into a wheel (PEP 770)
+
+Generate and embed an SPDX 3 SBOM directly into one or more built `.whl`
+files (writing to `.dist-info/sboms/` and updating `.dist-info/RECORD`):
+
+```bash
+loom embed-wheel dist/mypackage-1.0.0-py3-none-any.whl
+loom embed-wheel dist/*.whl --project-dir .
+```
+
+Or inject an existing pre-generated SBOM into built wheels:
+
+```bash
+loom embed-wheel dist/*.whl --sbom sbom.spdx3.json
+```
+
+Or use `--embed` directly on `loom wheel`:
+
+```bash
+loom wheel dist/mypackage-1.0.0-py3-none-any.whl --embed
+```
+
 Generate a **Deployed SBOM** reflecting the exact installed environment
 graph:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,6 +127,20 @@ environments that already export it for reproducibility without needing
 a per-project `creation-datetime` pin, but an explicit pin always
 overrides it.
 
+**Embedding into a wheel (`loom embed-wheel`, `loom wheel --embed`):** a
+`.whl` is a ZIP archive, and the ZIP format's own per-entry timestamp
+field can only represent dates from 1980-01-01 onward -- a binary format
+limitation, unrelated to Unix time (what `SOURCE_DATE_EPOCH` counts from,
+starting 1970-01-01) or to the SBOM's own `created` field (plain JSON,
+no such limit). A `SOURCE_DATE_EPOCH` set below 1980 (e.g. `0`, a
+value some build systems use deliberately as a fixed placeholder) is
+floored to `1980-01-01` for the wheel's embedded ZIP entry only -- the
+SBOM's own `created` field keeps the true value, so the two can
+legitimately diverge. When this happens, Pitloom prints an `INFO:` line
+rather than silently rewriting the SBOM's stated creation date to match
+the ZIP format's limitation. To avoid the divergence entirely, set
+`SOURCE_DATE_EPOCH` to `315532800` (1980-01-01) or later.
+
 [source-date-epoch]: https://reproducible-builds.org/specs/source-date-epoch/
 
 ## `[[tool.pitloom.creator]]` / `[[tool.pitloom.creation-tool]]`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-08-12
-Last-Modified: 2026-08-12
+Last-Modified: 2026-08-14
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -115,6 +115,19 @@ key) since it's expected to grow more fragment-related settings.
 | `creation-datetime` | string (ISO 8601) | *(current time)* | `--creation-datetime` | Overrides the SBOM's recorded creation timestamp. |
 | `creation-comment` | string | `null` | `--creation-comment` | Free-text comment on `CreationInfo`. |
 | `no-creation-tool` | bool | `false` | `--no-creation-tool` | Omit the default `"Pitloom"` creation-tool entry. |
+
+**`creation-datetime` resolution order:** an explicit pin here (or
+`--creation-datetime`) always wins when set -- it is a deliberate,
+per-SBOM value and so takes priority over the ambient,
+workspace-wide [`SOURCE_DATE_EPOCH`][source-date-epoch] environment
+variable (reproducible-builds.org). When neither is set, the current UTC
+time is used. The same priority order applies to the Hatchling build
+hook's `builtTime` field. `SOURCE_DATE_EPOCH` is a useful default for CI
+environments that already export it for reproducibility without needing
+a per-project `creation-datetime` pin, but an explicit pin always
+overrides it.
+
+[source-date-epoch]: https://reproducible-builds.org/specs/source-date-epoch/
 
 ## `[[tool.pitloom.creator]]` / `[[tool.pitloom.creation-tool]]`
 

--- a/docs/creation-metadata.md
+++ b/docs/creation-metadata.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-07-08
-Last-Modified: 2026-08-09
+Last-Modified: 2026-08-14
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -54,7 +54,7 @@ explicit `creation_metadata=CreationMetadata(...)` to that call.
 | :--- | :--- | :--- |
 | `createdBy` (**≥1**) | *Who* created it | One or more **creators**: a person, organization, software agent, or generic agent for each one you name (`--creator-name`, repeatable); otherwise Pitloom itself, acting unattended (see below). |
 | `createdUsing` (0+) | *What* tool produced it | **Pitloom** by default, with a version summary; repeat `--creation-tool` for more than one. Suppress with `--no-creation-tool`. |
-| `created` (1) | *When* | `--creation-datetime` if set, else the current UTC time. |
+| `created` (1) | *When* | `--creation-datetime` if set, else [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/) if set, else the current UTC time. |
 | `comment` (0-1) | *How* it was invoked | A short static note per channel (`Generated via Pitloom CLI`, `... Hatchling build hook`, `... loom SDK`), or your `--creation-comment`. |
 
 Pitloom's design distinguishes *who acted* from *what tool was used* --

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -107,7 +107,7 @@ Output:
 
 | Output | Meaning |
 | :--- | :--- |
-| `sbom-path` | Path to the generated SBOM file. |
+| `sbom-path` | Path to the generated SBOM file. Empty when `embed-wheel` matches more than one wheel -- a standalone copy is ambiguous across wheels, so only the embedded copies are produced and `upload-artifact` is skipped for that run. |
 
 ## Code example: Build and Publish PEP 770 Wheel
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-08-11
-Last-Modified: 2026-08-11
+Last-Modified: 2026-08-14
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -9,20 +9,26 @@ SPDX-License-Identifier: CC0-1.0
 # GitHub Action
 
 Use this when your project isn't Hatchling-based, or you just want CI to
-produce an SBOM artifact with one `uses:` line -- for any Python build
-backend, not just Hatchling.
+produce an SBOM artifact or embed PEP 770 SBOMs into built wheels with
+one `uses:` line -- for any Python build backend, not just Hatchling.
 
-The action creates a standalone SBOM file on the runner. It's useful for
-compliance logs, CI/CD audits, and release assets.
-
-> Running the GitHub Action alone does not embed the SBOM inside your
-> distributed Python wheel -- use the [Hatchling build
-> hook](hatchling-build-hook.md) for PEP 770 wheel embedding.
+The action can create a standalone SBOM file on the runner, or embed the
+generated SBOM directly into built `.whl` files via `embed-wheel: "dist/*.whl"`.
 
 ## Quick guide
 
+Standalone SBOM artifact:
+
 ```yaml
-- uses: bact/pitloom@v0.14.1
+- uses: bact/pitloom@v0.15.0
+```
+
+Generate and embed PEP 770 SBOM into built wheels:
+
+```yaml
+- uses: bact/pitloom@v0.15.0
+  with:
+    embed-wheel: "dist/*.whl"
 ```
 
 ## Installation
@@ -35,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: bact/pitloom@v0.14.1
+      - uses: bact/pitloom@v0.15.0
 ```
 
-Pin to a specific release tag (`@v0.14.1`) rather than a branch, the same
+Pin to a specific release tag (`@v0.15.0`) rather than a branch, the same
 as any third-party action.
 
 ## Usage details
@@ -48,16 +54,25 @@ writes `sbom.spdx3.json`. Point it at an AI model instead of a project
 directory with `model:`:
 
 ```yaml
-- uses: bact/pitloom@v0.14.1
+- uses: bact/pitloom@v0.15.0
   with:
     model: path/to/model.safetensors
+```
+
+Embed the SBOM into built wheels (PEP 770) for any build backend
+(`flit`, `setuptools`, `poetry-core`, `maturin`, etc.):
+
+```yaml
+- uses: bact/pitloom@v0.15.0
+  with:
+    embed-wheel: "dist/*.whl"
 ```
 
 Pass extra raw CLI flags through with `args:` (shell-quoted, e.g. for
 [creator/creation metadata](creation-metadata.md)):
 
 ```yaml
-- uses: bact/pitloom@v0.14.1
+- uses: bact/pitloom@v0.15.0
   with:
     args: '--creator-name "CI Bot" --creator-type software-agent'
 ```
@@ -72,6 +87,7 @@ Inputs (all optional):
 | Input | Default | Meaning |
 | :--- | :--- | :--- |
 | `project-path` | `.` | Directory to scan for a Python project. Ignored when `model` is set. |
+| `embed-wheel` | *(empty)* | Path or glob pattern of built wheel(s) to embed the SBOM into (PEP 770), e.g. `dist/*.whl`. |
 | `model` | *(empty)* | Local model file path, or Hugging Face URL/model ID. Switches to model mode. |
 | `output` | `sbom.spdx3.json` | SBOM output file path. |
 | `extras` | *(empty)* | Comma-separated pip extras to install alongside Pitloom, e.g. `ai` (all AI model formats, including Hugging Face Hub support). |
@@ -81,7 +97,7 @@ Inputs (all optional):
 | `content-type` | *(empty)* | `true`/`false` to force per-file content-type detection on or off; empty defers to `[tool.pitloom.content-type] enabled` (off by default). |
 | `content-type-method` | *(empty)* | `auto`/`magika`/`extension` -- which detector resolves content-type values; empty defers to `[tool.pitloom.content-type] method` (`auto` by default). |
 | `args` | *(empty)* | Extra raw flags passed through to the `loom` command. |
-| `pitloom-version` | *(empty)* | Pitloom version/specifier to install, e.g. `0.14.1` or `>=0.13,<1.0`. Empty installs the latest release. |
+| `pitloom-version` | *(empty)* | Pitloom version/specifier to install, e.g. `0.15.0` or `>=0.13,<1.0`. Empty installs the latest release. |
 | `python-version` | `3.x` | Python version passed to `actions/setup-python`. |
 | `install` | `true` | Set `false` to skip installing Python/Pitloom and assume `loom` is already on `PATH`. |
 | `upload-artifact` | `true` | Upload the generated SBOM via `actions/upload-artifact`. |
@@ -93,26 +109,35 @@ Output:
 | :--- | :--- |
 | `sbom-path` | Path to the generated SBOM file. |
 
-## Code example
+## Code example: Build and Publish PEP 770 Wheel
 
 ```yaml
-name: SBOM
+name: Build and Publish
 on: [push]
 jobs:
-  sbom:
+  build-and-publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: bact/pitloom@v0.14.1
+
+      # 1. Build wheel using ANY build backend (Flit, Setuptools, Maturin, etc.)
+      - name: Build wheel
+        run: python -m build --wheel
+
+      # 2. Generate and embed PEP 770 SBOM into built wheels
+      - name: Embed PEP 770 SBOM
+        uses: bact/pitloom@v0.15.0
         with:
-          extras: ai
-          pretty: "true"
-          artifact-name: my-project-sbom
+          embed-wheel: "dist/*.whl"
+
+      # 3. Publish PEP 770-compliant wheel to PyPI
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypa-publish@release/v1
 ```
 
 ## See also
 
 - [Command line](cli.md) -- the same generation options this action
-  wraps, run directly.
-- [Hatchling build hook](hatchling-build-hook.md) -- for embedding the
-  SBOM into the wheel itself, not just a CI artifact.
+  wraps, run directly (`loom embed-wheel`).
+- [Hatchling build hook](hatchling-build-hook.md) -- build-time SBOM
+  embedding for Hatchling projects.

--- a/docs/hatchling-build-hook.md
+++ b/docs/hatchling-build-hook.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-08-11
-Last-Modified: 2026-08-11
+Last-Modified: 2026-08-14
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -81,6 +81,9 @@ provenance](metadata-provenance.md).
 
 ## See also
 
-- [Command line](cli.md) -- generate an SBOM manually, outside a build.
+- [Command line](cli.md) -- generate an SBOM manually or post-process built
+  wheels with `loom embed-wheel`.
+- [GitHub Action](github-action.md) -- embed PEP 770 SBOMs in CI for any
+  build backend.
 - [Python API](python-api.md) -- the tracking decorator that produces the
   fragments this hook merges.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -83,6 +83,28 @@ kinds the [CLI](cli.md)'s `loom wheel` / `loom model` / `loom env`
 subcommands cover. See [AI model formats](ai-model-formats.md) for what
 `generate_model_sbom()` accepts.
 
+### Wheel embedding functions
+
+For programmatic PEP 770 post-build wheel injection:
+
+```python
+from pathlib import Path
+from pitloom.assemble import embed_sbom_in_wheel, embed_wheel_sbom
+
+# 1. Generate and embed SBOM in one step
+modified_wheel, arcname, sbom_json = embed_wheel_sbom(
+    wheel_path=Path("dist/mypackage-1.0.0-py3-none-any.whl"),
+    project_dir=Path("."),
+)
+
+# 2. Or embed arbitrary pre-generated SBOM content
+modified_wheel, arcname = embed_sbom_in_wheel(
+    wheel_path=Path("dist/mypackage-1.0.0-py3-none-any.whl"),
+    sbom_content=sbom_json_string,
+    sbom_filename="custom.spdx3.json",  # optional
+)
+```
+
 ### Config
 
 Pass `creation_metadata=CreationMetadata(...)` to name creators, tools, a

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -89,21 +89,26 @@ For programmatic PEP 770 post-build wheel injection:
 
 ```python
 from pathlib import Path
-from pitloom.assemble import embed_sbom_in_wheel, embed_wheel_sbom
+from pitloom.assemble import ConfigOverrides, embed_sbom_in_wheel, embed_wheel_sbom
 
 # 1. Generate and embed SBOM in one step
-modified_wheel, arcname, sbom_json = embed_wheel_sbom(
+modified_wheel, arcname, sbom_json, removed, floored = embed_wheel_sbom(
     wheel_path=Path("dist/mypackage-1.0.0-py3-none-any.whl"),
     project_dir=Path("."),
+    overrides=ConfigOverrides(offline=True),  # optional
 )
 
 # 2. Or embed arbitrary pre-generated SBOM content
-modified_wheel, arcname = embed_sbom_in_wheel(
+modified_wheel, arcname, removed, floored = embed_sbom_in_wheel(
     wheel_path=Path("dist/mypackage-1.0.0-py3-none-any.whl"),
     sbom_content=sbom_json_string,
     sbom_filename="custom.spdx3.json",  # optional
 )
 ```
+
+`removed` lists any prior Pitloom-embedded SBOM entries cleaned up as part
+of the embed; `floored` is `True` when the wheel's ZIP entry timestamp had
+to be floored to 1980-01-01 (see [Configuration](configuration.md#tool-pitloomcreation)).
 
 ### Config
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-03-26
-Last-Modified: 2026-08-09
+Last-Modified: 2026-08-14
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -92,6 +92,10 @@ SPDX-License-Identifier: CC0-1.0
 
 ## Other resources
 
+- Reproducible Builds -- `SOURCE_DATE_EPOCH` specification (the timestamp
+  convention Pitloom honours for deterministic SBOM `created`/`builtTime`
+  fields and embedded-wheel ZIP entries):
+  <https://reproducible-builds.org/specs/source-date-epoch/>
 - Agent Skills standard <https://agentskills.io/>
 - SARIF (standard format for static analysis)
   - <https://sarifweb.azurewebsites.net/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,14 @@ issues = "https://github.com/bact/pitloom/issues"
 
 [dependency-groups]
 lint = ["bandit>=1.9.4", "flake8>=7.3.0", "pylint>=4.0.6", "ruff>=0.16.2"]
-test = ["pytest>=9.1.1", "pytest-cov>=7.1.0", "stav>=0.4.1"]
+test = [
+    "check-wheel-contents>=0.6.0",
+    "installer>=0.7.0",
+    "pytest>=9.1.1",
+    "pytest-cov>=7.1.0",
+    "spdx3-validate>=0.0.7",
+    "stav>=0.4.1",
+]
 typecheck = ["mypy>=2.3.0", "pyrefly>=1.2.0", "pyright>=1.1.411"]
 docs = [
     "mkdocs>=1.6.1",

--- a/skills/sbom-generate/SKILL.md
+++ b/skills/sbom-generate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 # Created: 2026-07-05
-# Last-Modified: 2026-08-13
+# Last-Modified: 2026-08-14
 # SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
@@ -21,7 +21,13 @@ description: >-
   Also triggers, with enrichment layered on top (see "Combine with
   enrichment" below), on "generate SBOM and enrich it", "give me a complete
   SBOM", "create an SBOM and fill in information as much as possible", and
-  "help me get a full SBOM".
+  "help me get a full SBOM". Also triggers on requests to embed an SBOM
+  directly into a built wheel per PEP 770 -- "embed the SBOM in this
+  wheel", "embed SBOM to the wheel", "embed SBOM to python wheel",
+  "embed-wheel", "add the SBOM to dist/*.whl", "put the SBOM in the
+  wheel", "create SBOM in the wheel", "create PEP 770 SBOM", "PEP 770
+  wheel embedding", and similar phrasings naming an SBOM together with a
+  wheel/PEP 770 -- see "Embed an SBOM into a wheel (PEP 770)" below.
 license: Apache-2.0
 argument-hint: "[target]"
 ---
@@ -101,6 +107,38 @@ loom env -o env.spdx3.json
 # 5. Fragment Merging
 loom merge .spdx3-fragments/ -o combined.spdx3.json
 ```
+
+## Embed an SBOM into a wheel (PEP 770)
+
+For a request to *embed* an SBOM into a built wheel rather than write it
+as a standalone file -- PEP 770's `.dist-info/sboms/` convention -- use
+`embed-wheel` instead of `wheel`:
+
+```bash
+loom embed-wheel dist/mypackage-1.0.0-py3-none-any.whl
+loom embed-wheel dist/*.whl --project-dir .   # multiple wheels, Build SBOM
+```
+
+Or embed an already-generated SBOM file directly:
+
+```bash
+loom embed-wheel dist/*.whl --sbom sbom.spdx3.json
+```
+
+Or embed directly on `loom wheel` for a single wheel's own Analyzed SBOM
+(no project-directory scanning):
+
+```bash
+loom wheel dist/mypackage-1.0.0-py3-none-any.whl --embed
+```
+
+`embed-wheel` mutates the `.whl` archive in place (RECORD is updated to
+match); it works on any wheel regardless of build backend, since a wheel
+is just a ZIP archive -- unlike the Hatchling-specific build hook. See
+[`docs/cli.md`](https://github.com/bact/pitloom/blob/main/docs/cli.md)
+for the full flag reference, including `--output` (rejected when more
+than one wheel matches, since a single standalone copy would be
+ambiguous) and `--sbom-basename`.
 
 ## Useful flags
 

--- a/skills/sbom-generate/references/examples.md
+++ b/skills/sbom-generate/references/examples.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-07-05
-Last-Modified: 2026-08-10
+Last-Modified: 2026-08-14
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -30,6 +30,26 @@ loom project /path/to/project -o sbom.spdx3.json
 
 ```bash
 loom wheel dist/mypackage-1.0.0-py3-none-any.whl -o wheel.spdx3.json
+```
+
+## Embed an SBOM into a built wheel (PEP 770)
+
+```bash
+loom embed-wheel dist/mypackage-1.0.0-py3-none-any.whl --project-dir .
+# or, for a single wheel's own Analyzed SBOM, no project dir:
+loom wheel dist/mypackage-1.0.0-py3-none-any.whl --embed
+```
+
+Confirm the embed:
+
+```bash
+python3 -c '
+import zipfile, sys
+with zipfile.ZipFile(sys.argv[1]) as zf:
+    sboms = [n for n in zf.namelist() if "/sboms/" in n]
+    assert sboms, "no SBOM embedded"
+    print(f"Embedded: {sboms}")
+' dist/mypackage-1.0.0-py3-none-any.whl
 ```
 
 ## AI model SBOM, local file

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 
 from pitloom.__about__ import __version__
 from pitloom.assemble import (
+    ConfigOverrides,
     embed_sbom_in_wheel,
     embed_wheel_sbom,
     enrich_model,
@@ -1135,6 +1136,13 @@ def _run_embed_wheel_mode(args: argparse.Namespace) -> int:
 
         creation = _resolve_creation_metadata(args, pitloom_config)
 
+        overrides = ConfigOverrides(
+            enrich=args.enrich,
+            extract_file_header=args.extract_file_header,
+            content_type=args.content_type,
+            content_type_method=args.content_type_method,
+            offline=args.offline or None,
+        )
         for wheel_path in unique_wheels:
             output_path = args.output if len(unique_wheels) == 1 else None
             _, arcname, _, removed, floored = embed_wheel_sbom(
@@ -1145,11 +1153,7 @@ def _run_embed_wheel_mode(args: argparse.Namespace) -> int:
                 sbom_basename=args.sbom_basename,
                 creation_metadata=creation.to_creation_metadata(),
                 registry=args.registry,
-                enrich=args.enrich,
-                extract_file_header=args.extract_file_header,
-                content_type=args.content_type,
-                content_type_method=args.content_type_method,
-                offline=args.offline or None,
+                overrides=overrides,
             )
             _report_embed_result(arcname, wheel_path.name, removed, floored)
         return 0

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -966,7 +966,16 @@ def _run_project_mode(args: argparse.Namespace) -> int:
 
 
 def _run_wheel_mode(args: argparse.Namespace) -> int:
-    """Generate an Analyzed SBOM from a built wheel."""
+    """Generate an Analyzed SBOM from a built wheel.
+
+    ``--embed`` here is deliberately narrower than the ``embed-wheel``
+    command (see :func:`_run_embed_wheel_mode`): always the wheel's own
+    Analyzed SBOM, one wheel, no project-directory scanning. Both paths
+    converge on :func:`~pitloom.embed.embed_sbom_in_wheel` for the actual
+    archive mutation (RECORD update, stale-entry cleanup, atomic
+    rewrite), so a fix there benefits both without needing to be
+    duplicated -- only SBOM *content* generation differs by design.
+    """
     target: str = args.target
     try:
         wheel_path: Path = Path(target).resolve()
@@ -1010,8 +1019,7 @@ def _run_wheel_mode(args: argparse.Namespace) -> int:
 
         if embed:
             _, arcname, removed = embed_sbom_in_wheel(wheel_path, sbom_json)
-            print(f"pitloom: embedded {arcname} into {wheel_path.name}")
-            _print_removed_stale_sboms(removed, wheel_path.name)
+            _report_embed_result(arcname, wheel_path.name, removed)
 
         return 0
 
@@ -1022,10 +1030,15 @@ def _run_wheel_mode(args: argparse.Namespace) -> int:
         return 1
 
 
-def _print_removed_stale_sboms(removed: tuple[str, ...], wheel_name: str) -> None:
-    """Report any prior Pitloom-embedded SBOM entries cleaned up on re-embed."""
-    for arcname in removed:
-        print(f"INFO: removed stale SBOM {arcname} from {wheel_name}")
+def _report_embed_result(arcname: str, wheel_name: str, removed: tuple[str, ...]) -> None:
+    """Print the embed confirmation, plus one line per stale SBOM cleaned up.
+
+    Shared by ``wheel --embed`` and ``embed-wheel`` so both report results
+    identically -- see :func:`_run_wheel_mode`/:func:`_run_embed_wheel_mode`.
+    """
+    print(f"pitloom: embedded {arcname} into {wheel_name}")
+    for stale_arcname in removed:
+        print(f"INFO: removed stale SBOM {stale_arcname} from {wheel_name}")
 
 
 def _collect_wheel_paths(patterns: list[str]) -> list[Path]:
@@ -1066,7 +1079,14 @@ def _collect_wheel_paths(patterns: list[str]) -> list[Path]:
 
 
 def _run_embed_wheel_mode(args: argparse.Namespace) -> int:
-    """Embed an SPDX 3 SBOM into one or more built wheels (PEP 770)."""
+    """Embed an SPDX 3 SBOM into one or more built wheels (PEP 770).
+
+    The richer counterpart to ``wheel --embed`` (see :func:`_run_wheel_mode`):
+    supports multiple wheels, a project directory (Build-type SBOM), a
+    pre-generated ``--sbom`` file, and a custom ``--sbom-basename``. Both
+    commands converge on :func:`~pitloom.embed.embed_sbom_in_wheel` for
+    the actual archive mutation.
+    """
     try:
         unique_wheels = _collect_wheel_paths(args.wheel_files)
         if not unique_wheels:
@@ -1120,8 +1140,7 @@ def _run_embed_wheel_mode(args: argparse.Namespace) -> int:
                 content_type_method=args.content_type_method,
                 offline=args.offline or None,
             )
-            print(f"pitloom: embedded {arcname} into {wheel_path.name}")
-            _print_removed_stale_sboms(removed, wheel_path.name)
+            _report_embed_result(arcname, wheel_path.name, removed)
         return 0
 
     except Exception as e:  # pylint: disable=broad-exception-caught

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import argparse
+import glob
 import logging
 import sys
 import traceback
@@ -986,8 +987,10 @@ def _run_wheel_mode(args: argparse.Namespace) -> int:
         # With --embed, only write a standalone copy if the user explicitly
         # asked for one via -o; embedding into the wheel is the primary
         # output and shouldn't also litter cwd with a same-named file.
-        output_path = args.output if embed else args.output or (
-            Path.cwd() / f"{wheel_path.name}{_SPDX3_JSON_EXT}"
+        output_path = (
+            args.output
+            if embed
+            else args.output or (Path.cwd() / f"{wheel_path.name}{_SPDX3_JSON_EXT}")
         )
 
         if args.verbose:
@@ -1030,18 +1033,10 @@ def _collect_wheel_paths(patterns: list[str]) -> list[Path]:
     for pattern in patterns:
         if any(c in pattern for c in ("*", "?", "[")):
             matched = [
-                p
-                for p in Path.cwd().glob(pattern)
-                if p.is_file() and p.name.endswith(".whl")
+                Path(p).resolve()
+                for p in glob.glob(pattern)
+                if Path(p).is_file() and p.endswith(".whl")
             ]
-            if not matched:
-                p_obj = Path(pattern)
-                parent = p_obj.parent if p_obj.parent != Path(".") else Path.cwd()
-                matched = [
-                    p
-                    for p in parent.glob(p_obj.name)
-                    if p.is_file() and p.name.endswith(".whl")
-                ]
             wheel_paths.extend(matched)
         else:
             p = Path(pattern).resolve()
@@ -1070,6 +1065,13 @@ def _run_embed_wheel_mode(args: argparse.Namespace) -> int:
                 return 1
             print(
                 f"ERROR: no wheel files matched: {' '.join(args.wheel_files)}",
+                file=sys.stderr,
+            )
+            return 1
+
+        if len(unique_wheels) > 1 and args.output is not None:
+            print(
+                "ERROR: --output cannot be used when embedding multiple wheels",
                 file=sys.stderr,
             )
             return 1

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -1018,8 +1018,8 @@ def _run_wheel_mode(args: argparse.Namespace) -> int:
         )
 
         if embed:
-            _, arcname, removed = embed_sbom_in_wheel(wheel_path, sbom_json)
-            _report_embed_result(arcname, wheel_path.name, removed)
+            _, arcname, removed, floored = embed_sbom_in_wheel(wheel_path, sbom_json)
+            _report_embed_result(arcname, wheel_path.name, removed, floored)
 
         return 0
 
@@ -1030,8 +1030,13 @@ def _run_wheel_mode(args: argparse.Namespace) -> int:
         return 1
 
 
-def _report_embed_result(arcname: str, wheel_name: str, removed: tuple[str, ...]) -> None:
-    """Print the embed confirmation, plus one line per stale SBOM cleaned up.
+def _report_embed_result(
+    arcname: str,
+    wheel_name: str,
+    removed: tuple[str, ...],
+    timestamp_floored: bool = False,
+) -> None:
+    """Print the embed confirmation, plus one line per notable side effect.
 
     Shared by ``wheel --embed`` and ``embed-wheel`` so both report results
     identically -- see :func:`_run_wheel_mode`/:func:`_run_embed_wheel_mode`.
@@ -1039,6 +1044,12 @@ def _report_embed_result(arcname: str, wheel_name: str, removed: tuple[str, ...]
     print(f"pitloom: embedded {arcname} into {wheel_name}")
     for stale_arcname in removed:
         print(f"INFO: removed stale SBOM {stale_arcname} from {wheel_name}")
+    if timestamp_floored:
+        print(
+            f"INFO: {wheel_name}'s embedded SBOM entry timestamp was before "
+            "1980 and was floored to 1980-01-01 (ZIP format limitation); "
+            "the SBOM's own 'created' field keeps the true value"
+        )
 
 
 def _collect_wheel_paths(patterns: list[str]) -> list[Path]:
@@ -1126,7 +1137,7 @@ def _run_embed_wheel_mode(args: argparse.Namespace) -> int:
 
         for wheel_path in unique_wheels:
             output_path = args.output if len(unique_wheels) == 1 else None
-            _, arcname, _, removed = embed_wheel_sbom(
+            _, arcname, _, removed, floored = embed_wheel_sbom(
                 wheel_path,
                 project_dir=project_dir,
                 sbom_path=args.sbom,
@@ -1140,7 +1151,7 @@ def _run_embed_wheel_mode(args: argparse.Namespace) -> int:
                 content_type_method=args.content_type_method,
                 offline=args.offline or None,
             )
-            _report_embed_result(arcname, wheel_path.name, removed)
+            _report_embed_result(arcname, wheel_path.name, removed, floored)
         return 0
 
     except Exception as e:  # pylint: disable=broad-exception-caught

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -18,6 +18,7 @@ from uuid import uuid4
 
 from pitloom.__about__ import __version__
 from pitloom.assemble import (
+    embed_sbom_in_wheel,
     embed_wheel_sbom,
     enrich_model,
     generate,
@@ -990,23 +991,7 @@ def _run_wheel_mode(args: argparse.Namespace) -> int:
             print(f"Wheel file      : {wheel_path}")
             print(f"Output path     : {output_path}")
 
-        if getattr(args, "embed", False):
-            _, arcname, _ = embed_wheel_sbom(
-                wheel_path,
-                output_path=args.output,
-                creation_metadata=creation.to_creation_metadata(),
-                registry=args.registry,
-                provenance=pitloom_config.provenance,
-                enrich=args.enrich,
-                extract_file_header=args.extract_file_header,
-                content_type=args.content_type,
-                content_type_method=args.content_type_method,
-                offline=args.offline or None,
-            )
-            print(f"pitloom: embedded {arcname} into {wheel_path.name}")
-            return 0
-
-        generate_wheel_sbom(
+        sbom_json = generate_wheel_sbom(
             wheel_path,
             output_path=output_path,
             creation_metadata=creation.to_creation_metadata(),
@@ -1015,6 +1000,11 @@ def _run_wheel_mode(args: argparse.Namespace) -> int:
             registry=args.registry,
             offline=args.offline or None,
         )
+
+        if getattr(args, "embed", False):
+            _, arcname = embed_sbom_in_wheel(wheel_path, sbom_json)
+            print(f"pitloom: embedded {arcname} into {wheel_path.name}")
+
         return 0
 
     except Exception as e:  # pylint: disable=broad-exception-caught
@@ -1025,8 +1015,14 @@ def _run_wheel_mode(args: argparse.Namespace) -> int:
 
 
 def _collect_wheel_paths(patterns: list[str]) -> list[Path]:
-    """Resolve and expand wheel file paths and glob patterns."""
+    """Resolve and expand wheel file paths and glob patterns.
+
+    Every pattern is validated before returning, so all invalid literal
+    paths get reported -- not just the first one encountered. Returns an
+    empty list if any pattern is invalid.
+    """
     wheel_paths: list[Path] = []
+    had_error = False
     for pattern in patterns:
         if any(c in pattern for c in ("*", "?", "[")):
             matched = [
@@ -1047,11 +1043,15 @@ def _collect_wheel_paths(patterns: list[str]) -> list[Path]:
             p = Path(pattern).resolve()
             if not p.exists():
                 print(f"ERROR: wheel file not found: {p}", file=sys.stderr)
-                return []
+                had_error = True
+                continue
             if not p.name.endswith(".whl"):
                 print(f"ERROR: not a .whl file: {p}", file=sys.stderr)
-                return []
+                had_error = True
+                continue
             wheel_paths.append(p)
+    if had_error:
+        return []
     return list(dict.fromkeys(wheel_paths))
 
 

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -1009,8 +1009,9 @@ def _run_wheel_mode(args: argparse.Namespace) -> int:
         )
 
         if embed:
-            _, arcname = embed_sbom_in_wheel(wheel_path, sbom_json)
+            _, arcname, removed = embed_sbom_in_wheel(wheel_path, sbom_json)
             print(f"pitloom: embedded {arcname} into {wheel_path.name}")
+            _print_removed_stale_sboms(removed, wheel_path.name)
 
         return 0
 
@@ -1021,12 +1022,18 @@ def _run_wheel_mode(args: argparse.Namespace) -> int:
         return 1
 
 
+def _print_removed_stale_sboms(removed: tuple[str, ...], wheel_name: str) -> None:
+    """Report any prior Pitloom-embedded SBOM entries cleaned up on re-embed."""
+    for arcname in removed:
+        print(f"INFO: removed stale SBOM {arcname} from {wheel_name}")
+
+
 def _collect_wheel_paths(patterns: list[str]) -> list[Path]:
     """Resolve and expand wheel file paths and glob patterns.
 
-    Every pattern is validated before returning, so all invalid literal
-    paths get reported -- not just the first one encountered. Returns an
-    empty list if any pattern is invalid.
+    Every pattern is validated before returning, and every error is
+    reported here -- the caller can treat an empty return as "already
+    explained on stderr", with no need to re-inspect the patterns itself.
     """
     wheel_paths: list[Path] = []
     had_error = False
@@ -1037,6 +1044,10 @@ def _collect_wheel_paths(patterns: list[str]) -> list[Path]:
                 for p in glob.glob(pattern)
                 if Path(p).is_file() and p.endswith(".whl")
             ]
+            if not matched:
+                print(f"ERROR: no wheel files matched: {pattern}", file=sys.stderr)
+                had_error = True
+                continue
             wheel_paths.extend(matched)
         else:
             p = Path(pattern).resolve()
@@ -1059,14 +1070,6 @@ def _run_embed_wheel_mode(args: argparse.Namespace) -> int:
     try:
         unique_wheels = _collect_wheel_paths(args.wheel_files)
         if not unique_wheels:
-            if not any(
-                any(c in pat for c in ("*", "?", "[")) for pat in args.wheel_files
-            ):
-                return 1
-            print(
-                f"ERROR: no wheel files matched: {' '.join(args.wheel_files)}",
-                file=sys.stderr,
-            )
             return 1
 
         if len(unique_wheels) > 1 and args.output is not None:
@@ -1103,7 +1106,7 @@ def _run_embed_wheel_mode(args: argparse.Namespace) -> int:
 
         for wheel_path in unique_wheels:
             output_path = args.output if len(unique_wheels) == 1 else None
-            _, arcname, _ = embed_wheel_sbom(
+            _, arcname, _, removed = embed_wheel_sbom(
                 wheel_path,
                 project_dir=project_dir,
                 sbom_path=args.sbom,
@@ -1118,6 +1121,7 @@ def _run_embed_wheel_mode(args: argparse.Namespace) -> int:
                 offline=args.offline or None,
             )
             print(f"pitloom: embedded {arcname} into {wheel_path.name}")
+            _print_removed_stale_sboms(removed, wheel_path.name)
         return 0
 
     except Exception as e:  # pylint: disable=broad-exception-caught

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -982,14 +982,18 @@ def _run_wheel_mode(args: argparse.Namespace) -> int:
             else False
         )
 
-        output_path = args.output or (
+        embed = getattr(args, "embed", False)
+        # With --embed, only write a standalone copy if the user explicitly
+        # asked for one via -o; embedding into the wheel is the primary
+        # output and shouldn't also litter cwd with a same-named file.
+        output_path = args.output if embed else args.output or (
             Path.cwd() / f"{wheel_path.name}{_SPDX3_JSON_EXT}"
         )
 
         if args.verbose:
             print(f"Pitloom version : {__version__}")
             print(f"Wheel file      : {wheel_path}")
-            print(f"Output path     : {output_path}")
+            print(f"Output path     : {output_path or '(embedded only)'}")
 
         sbom_json = generate_wheel_sbom(
             wheel_path,
@@ -1001,7 +1005,7 @@ def _run_wheel_mode(args: argparse.Namespace) -> int:
             offline=args.offline or None,
         )
 
-        if getattr(args, "embed", False):
+        if embed:
             _, arcname = embed_sbom_in_wheel(wheel_path, sbom_json)
             print(f"pitloom: embedded {arcname} into {wheel_path.name}")
 

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -1124,12 +1124,18 @@ def _run_embed_wheel_mode(args: argparse.Namespace) -> int:
             try:
                 _, pitloom_config, _ = read_project(proj_path)
             except FileNotFoundError:
-                pass
+                print(
+                    "ERROR: No pyproject.toml or setup.cfg found "
+                    f"in project directory: {proj_path}",
+                    file=sys.stderr,
+                )
+                return 1
         else:
             for cand in ("pyproject.toml", "setup.cfg", "setup.py"):
                 if (Path.cwd() / cand).exists():
                     try:
                         _, pitloom_config, _ = read_project(Path.cwd())
+                        project_dir = Path.cwd()
                     except FileNotFoundError:
                         pass
                     break
@@ -1148,6 +1154,7 @@ def _run_embed_wheel_mode(args: argparse.Namespace) -> int:
             _, arcname, _, removed, floored = embed_wheel_sbom(
                 wheel_path,
                 project_dir=project_dir,
+                pitloom_config=pitloom_config,
                 sbom_path=args.sbom,
                 output_path=output_path,
                 sbom_basename=args.sbom_basename,

--- a/src/pitloom/__main__.py
+++ b/src/pitloom/__main__.py
@@ -18,6 +18,7 @@ from uuid import uuid4
 
 from pitloom.__about__ import __version__
 from pitloom.assemble import (
+    embed_wheel_sbom,
     enrich_model,
     generate,
     generate_env_sbom,
@@ -358,12 +359,61 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Path to the built .whl file.",
     )
     wheel_parser.add_argument(
+        "--embed",
+        action="store_true",
+        help="Embed the generated SBOM directly into the wheel archive (PEP 770).",
+    )
+    wheel_parser.add_argument(
         "--offline",
         action="store_true",
         help=(
             "Forbid network access -- skip PyPI lookup, no error "
             "(local metadata already covers what it can)."
         ),
+    )
+
+    # 3b. Embed into Wheel: loom embed-wheel <WHEEL_FILES...>
+    embed_parser = subparsers.add_parser(
+        "embed-wheel",
+        parents=[parent_parser],
+        help="Embed an SPDX 3 SBOM into one or more built wheels (PEP 770).",
+    )
+    embed_parser.add_argument(
+        "wheel_files",
+        type=str,
+        nargs="+",
+        help="Path(s) or glob pattern(s) of built .whl file(s) to embed the SBOM into.",
+    )
+    embed_parser.add_argument(
+        "--project-dir",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help=(
+            "Project directory containing pyproject.toml to extract project "
+            "metadata, AI models, and file headers from (defaults to cwd)."
+        ),
+    )
+    embed_parser.add_argument(
+        "--sbom",
+        type=Path,
+        default=None,
+        metavar="FILE",
+        help=(
+            "Pre-generated SBOM JSON file to embed directly instead of generating one."
+        ),
+    )
+    embed_parser.add_argument(
+        "--sbom-basename",
+        type=str,
+        default=None,
+        metavar="NAME",
+        help="Custom basename for the embedded SBOM inside .dist-info/sboms/.",
+    )
+    embed_parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Forbid network access during SBOM generation.",
     )
 
     # 4. AI Model Asset: loom model <SOURCE> [--offline]
@@ -819,6 +869,7 @@ def main() -> int:
         "generate": _run_generate_mode,
         "project": _run_project_mode,
         "wheel": _run_wheel_mode,
+        "embed-wheel": _run_embed_wheel_mode,
         "model": _run_model_mode,
         "enrich": _run_enrich_mode,
         "env": _run_env_mode,
@@ -939,6 +990,22 @@ def _run_wheel_mode(args: argparse.Namespace) -> int:
             print(f"Wheel file      : {wheel_path}")
             print(f"Output path     : {output_path}")
 
+        if getattr(args, "embed", False):
+            _, arcname, _ = embed_wheel_sbom(
+                wheel_path,
+                output_path=args.output,
+                creation_metadata=creation.to_creation_metadata(),
+                registry=args.registry,
+                provenance=pitloom_config.provenance,
+                enrich=args.enrich,
+                extract_file_header=args.extract_file_header,
+                content_type=args.content_type,
+                content_type_method=args.content_type_method,
+                offline=args.offline or None,
+            )
+            print(f"pitloom: embedded {arcname} into {wheel_path.name}")
+            return 0
+
         generate_wheel_sbom(
             wheel_path,
             output_path=output_path,
@@ -952,6 +1019,103 @@ def _run_wheel_mode(args: argparse.Namespace) -> int:
 
     except Exception as e:  # pylint: disable=broad-exception-caught
         print(f"ERROR: wheel SBOM generation failed: {e}", file=sys.stderr)
+        if args.verbose:
+            traceback.print_exc()
+        return 1
+
+
+def _collect_wheel_paths(patterns: list[str]) -> list[Path]:
+    """Resolve and expand wheel file paths and glob patterns."""
+    wheel_paths: list[Path] = []
+    for pattern in patterns:
+        if any(c in pattern for c in ("*", "?", "[")):
+            matched = [
+                p
+                for p in Path.cwd().glob(pattern)
+                if p.is_file() and p.name.endswith(".whl")
+            ]
+            if not matched:
+                p_obj = Path(pattern)
+                parent = p_obj.parent if p_obj.parent != Path(".") else Path.cwd()
+                matched = [
+                    p
+                    for p in parent.glob(p_obj.name)
+                    if p.is_file() and p.name.endswith(".whl")
+                ]
+            wheel_paths.extend(matched)
+        else:
+            p = Path(pattern).resolve()
+            if not p.exists():
+                print(f"ERROR: wheel file not found: {p}", file=sys.stderr)
+                return []
+            if not p.name.endswith(".whl"):
+                print(f"ERROR: not a .whl file: {p}", file=sys.stderr)
+                return []
+            wheel_paths.append(p)
+    return list(dict.fromkeys(wheel_paths))
+
+
+def _run_embed_wheel_mode(args: argparse.Namespace) -> int:
+    """Embed an SPDX 3 SBOM into one or more built wheels (PEP 770)."""
+    try:
+        unique_wheels = _collect_wheel_paths(args.wheel_files)
+        if not unique_wheels:
+            if not any(
+                any(c in pat for c in ("*", "?", "[")) for pat in args.wheel_files
+            ):
+                return 1
+            print(
+                f"ERROR: no wheel files matched: {' '.join(args.wheel_files)}",
+                file=sys.stderr,
+            )
+            return 1
+
+        project_dir = args.project_dir
+        pitloom_config = PitloomConfig()
+        if project_dir is not None:
+            proj_path = Path(project_dir).resolve()
+            if not proj_path.exists():
+                print(
+                    f"ERROR: project directory not found: {proj_path}",
+                    file=sys.stderr,
+                )
+                return 1
+            try:
+                _, pitloom_config, _ = read_project(proj_path)
+            except FileNotFoundError:
+                pass
+        else:
+            for cand in ("pyproject.toml", "setup.cfg", "setup.py"):
+                if (Path.cwd() / cand).exists():
+                    try:
+                        _, pitloom_config, _ = read_project(Path.cwd())
+                    except FileNotFoundError:
+                        pass
+                    break
+
+        creation = _resolve_creation_metadata(args, pitloom_config)
+
+        for wheel_path in unique_wheels:
+            output_path = args.output if len(unique_wheels) == 1 else None
+            _, arcname, _ = embed_wheel_sbom(
+                wheel_path,
+                project_dir=project_dir,
+                sbom_path=args.sbom,
+                output_path=output_path,
+                sbom_basename=args.sbom_basename,
+                creation_metadata=creation.to_creation_metadata(),
+                registry=args.registry,
+                enrich=args.enrich,
+                extract_file_header=args.extract_file_header,
+                content_type=args.content_type,
+                content_type_method=args.content_type_method,
+                offline=args.offline or None,
+            )
+            print(f"pitloom: embedded {arcname} into {wheel_path.name}")
+        return 0
+
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print(f"ERROR: wheel SBOM embedding failed: {e}", file=sys.stderr)
         if args.verbose:
             traceback.print_exc()
         return 1

--- a/src/pitloom/assemble/__init__.py
+++ b/src/pitloom/assemble/__init__.py
@@ -370,7 +370,7 @@ def generate_model_sbom(
     else:
         model_path = Path(source)
         model = read_ai_model(model_path)
-        resolved_registry = resolve_registry(model_path.parent, registry)
+        resolved_registry = resolve_registry(Path.cwd(), registry)
         entity_spdx_id = (
             resolved_registry.lookup_entity(model_path.stem, "ai_AIPackage")
             if resolved_registry is not None
@@ -483,7 +483,7 @@ def enrich_model(
         if project_target is not None
         else None
     )
-    resolved_registry = resolve_registry(model_path.parent, registry)
+    resolved_registry = resolve_registry(Path.cwd(), registry)
     entity_spdx_id = (
         resolved_registry.lookup_entity(model_path.stem, "ai_AIPackage")
         if resolved_registry is not None

--- a/src/pitloom/assemble/__init__.py
+++ b/src/pitloom/assemble/__init__.py
@@ -31,6 +31,7 @@ from pitloom.core.enrich_config import EnrichConfig
 from pitloom.core.models import compute_doc_uuid, get_wheel_files
 from pitloom.core.project import ProjectMetadata
 from pitloom.core.provenance import ProvenanceConfig
+from pitloom.embed import embed_sbom_in_wheel, embed_wheel_sbom
 from pitloom.enrich import run_enrichers, run_enrichers_for_models
 from pitloom.enrich.base import EnrichmentResult
 from pitloom.extract._huggingface import is_huggingface_source, read_huggingface
@@ -700,6 +701,8 @@ def generate(
 
 __all__ = [
     "ProvenanceConfig",
+    "embed_sbom_in_wheel",
+    "embed_wheel_sbom",
     "enrich_model",
     "generate",
     "generate_env_sbom",

--- a/src/pitloom/assemble/__init__.py
+++ b/src/pitloom/assemble/__init__.py
@@ -228,12 +228,8 @@ def generate_project_sbom(
         ai_models, effective_enrich_config, target_path
     )
 
-    resolved_registry = (
-        registry
-        if isinstance(registry, IdRegistry)
-        else IdRegistry.load(search_root / registry)
-        if registry is not None
-        else resolve_registry(search_root, pitloom_config.ids_file)
+    resolved_registry = resolve_registry(
+        search_root, registry if registry is not None else pitloom_config.ids_file
     )
 
     doc = DocumentModel(
@@ -294,13 +290,7 @@ def generate_wheel_sbom(
     effective_offline = (
         _resolve_local_offline_default(cwd) if offline is None else offline
     )
-    resolved_registry = (
-        registry
-        if isinstance(registry, IdRegistry)
-        else IdRegistry.load(cwd / registry)
-        if registry is not None
-        else resolve_registry(cwd, None)
-    )
+    resolved_registry = resolve_registry(cwd, registry)
 
     doc = DocumentModel(
         project=project_metadata,
@@ -380,13 +370,7 @@ def generate_model_sbom(
     else:
         model_path = Path(source)
         model = read_ai_model(model_path)
-        resolved_registry = (
-            registry
-            if isinstance(registry, IdRegistry)
-            else IdRegistry.load(Path(registry))
-            if registry is not None
-            else IdRegistry.find()
-        )
+        resolved_registry = resolve_registry(model_path.parent, registry)
         entity_spdx_id = (
             resolved_registry.lookup_entity(model_path.stem, "ai_AIPackage")
             if resolved_registry is not None
@@ -499,13 +483,7 @@ def enrich_model(
         if project_target is not None
         else None
     )
-    resolved_registry = (
-        registry
-        if isinstance(registry, IdRegistry)
-        else IdRegistry.load(Path(registry))
-        if registry is not None
-        else IdRegistry.find()
-    )
+    resolved_registry = resolve_registry(model_path.parent, registry)
     entity_spdx_id = (
         resolved_registry.lookup_entity(model_path.stem, "ai_AIPackage")
         if resolved_registry is not None
@@ -554,13 +532,7 @@ def generate_env_sbom(
     effective_offline = (
         _resolve_local_offline_default(cwd) if offline is None else offline
     )
-    resolved_registry = (
-        registry
-        if isinstance(registry, IdRegistry)
-        else IdRegistry.load(cwd / registry)
-        if registry is not None
-        else resolve_registry(cwd, None)
-    )
+    resolved_registry = resolve_registry(cwd, registry)
 
     doc = DocumentModel(
         project=project_metadata,

--- a/src/pitloom/assemble/__init__.py
+++ b/src/pitloom/assemble/__init__.py
@@ -31,7 +31,7 @@ from pitloom.core.enrich_config import EnrichConfig
 from pitloom.core.models import compute_doc_uuid, get_wheel_files
 from pitloom.core.project import ProjectMetadata
 from pitloom.core.provenance import ProvenanceConfig
-from pitloom.embed import embed_sbom_in_wheel, embed_wheel_sbom
+from pitloom.embed import ConfigOverrides, embed_sbom_in_wheel, embed_wheel_sbom
 from pitloom.enrich import run_enrichers, run_enrichers_for_models
 from pitloom.enrich.base import EnrichmentResult
 from pitloom.extract._huggingface import is_huggingface_source, read_huggingface
@@ -672,6 +672,7 @@ def generate(
 
 
 __all__ = [
+    "ConfigOverrides",
     "ProvenanceConfig",
     "embed_sbom_in_wheel",
     "embed_wheel_sbom",

--- a/src/pitloom/assemble/spdx3/creation_info.py
+++ b/src/pitloom/assemble/spdx3/creation_info.py
@@ -227,7 +227,9 @@ def build_creation_info(
         )
     else:
         epoch_dt = resolve_source_date_epoch()
-        created = to_spdx3_datetime(epoch_dt) if epoch_dt is not None else spdx3_utc_now()
+        created = (
+            to_spdx3_datetime(epoch_dt) if epoch_dt is not None else spdx3_utc_now()
+        )
     spdx_ci = spdx3.CreationInfo(specVersion="3.0.1", created=created)
 
     comment = (

--- a/src/pitloom/assemble/spdx3/creation_info.py
+++ b/src/pitloom/assemble/spdx3/creation_info.py
@@ -210,25 +210,24 @@ def build_creation_info(
 ) -> tuple[spdx3.CreationInfo, list[spdx3.Agent], list[spdx3.Tool]]:
     """Assemble a ``CreationInfo`` plus its creator Agents and Tools.
 
-    ``created`` priority: ``SOURCE_DATE_EPOCH`` (reproducible-builds.org,
-    see :func:`~pitloom.core.creation.resolve_source_date_epoch`) if set,
-    else ``creation_metadata.creation_datetime`` (normalised to SPDX
-    DateTime) if set, else the current UTC time -- same priority order as
-    the Hatchling build hook's ``builtTime`` resolution, so a build
-    environment's reproducibility setting isn't silently defeated by a
-    stale config pin. ``comment`` uses ``creation_metadata.creation_comment``
-    if set, else *default_comment*. The creator Agents go in ``createdBy``
-    and the Tools (when present) in ``createdUsing``.
+    ``created`` priority: ``creation_metadata.creation_datetime`` (a
+    deliberate, explicit pin -- normalised to SPDX DateTime) if set, else
+    ``SOURCE_DATE_EPOCH`` (reproducible-builds.org, see
+    :func:`~pitloom.core.creation.resolve_source_date_epoch`) if set, else
+    the current UTC time -- an explicit per-SBOM pin is more specific than
+    the ambient, workspace-wide ``SOURCE_DATE_EPOCH`` signal, so it wins;
+    same priority order as the Hatchling build hook's ``builtTime``
+    resolution. ``comment`` uses ``creation_metadata.creation_comment`` if
+    set, else *default_comment*. The creator Agents go in ``createdBy`` and
+    the Tools (when present) in ``createdUsing``.
     """
-    epoch_dt = resolve_source_date_epoch()
-    if epoch_dt is not None:
-        created = to_spdx3_datetime(epoch_dt)
-    elif creation_metadata.creation_datetime:
+    if creation_metadata.creation_datetime:
         created = to_spdx3_datetime(
             parse_iso_datetime(creation_metadata.creation_datetime)
         )
     else:
-        created = spdx3_utc_now()
+        epoch_dt = resolve_source_date_epoch()
+        created = to_spdx3_datetime(epoch_dt) if epoch_dt is not None else spdx3_utc_now()
     spdx_ci = spdx3.CreationInfo(specVersion="3.0.1", created=created)
 
     comment = (

--- a/src/pitloom/assemble/spdx3/creation_info.py
+++ b/src/pitloom/assemble/spdx3/creation_info.py
@@ -19,7 +19,12 @@ from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.__about__ import __version__
 from pitloom.assemble.spdx3.provenance import EnrichedFieldEntry
-from pitloom.core.creation import VALID_CREATOR_TYPES, CreationMetadata, Tool
+from pitloom.core.creation import (
+    VALID_CREATOR_TYPES,
+    CreationMetadata,
+    Tool,
+    resolve_source_date_epoch,
+)
 from pitloom.core.models import build_pypi_purl, generate_spdx_id
 from pitloom.enrich.base import EnrichmentResult
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
@@ -205,17 +210,25 @@ def build_creation_info(
 ) -> tuple[spdx3.CreationInfo, list[spdx3.Agent], list[spdx3.Tool]]:
     """Assemble a ``CreationInfo`` plus its creator Agents and Tools.
 
-    ``created`` comes from ``creation_metadata.creation_datetime`` (normalised
-    to SPDX DateTime) or the current UTC time.  ``comment`` uses
-    ``creation_metadata.creation_comment`` if set, else *default_comment*.
-    The creator Agents go in ``createdBy`` and the Tools (when present) in
-    ``createdUsing``.
+    ``created`` priority: ``SOURCE_DATE_EPOCH`` (reproducible-builds.org,
+    see :func:`~pitloom.core.creation.resolve_source_date_epoch`) if set,
+    else ``creation_metadata.creation_datetime`` (normalised to SPDX
+    DateTime) if set, else the current UTC time -- same priority order as
+    the Hatchling build hook's ``builtTime`` resolution, so a build
+    environment's reproducibility setting isn't silently defeated by a
+    stale config pin. ``comment`` uses ``creation_metadata.creation_comment``
+    if set, else *default_comment*. The creator Agents go in ``createdBy``
+    and the Tools (when present) in ``createdUsing``.
     """
-    created = (
-        to_spdx3_datetime(parse_iso_datetime(creation_metadata.creation_datetime))
-        if creation_metadata.creation_datetime
-        else spdx3_utc_now()
-    )
+    epoch_dt = resolve_source_date_epoch()
+    if epoch_dt is not None:
+        created = to_spdx3_datetime(epoch_dt)
+    elif creation_metadata.creation_datetime:
+        created = to_spdx3_datetime(
+            parse_iso_datetime(creation_metadata.creation_datetime)
+        )
+    else:
+        created = spdx3_utc_now()
     spdx_ci = spdx3.CreationInfo(specVersion="3.0.1", created=created)
 
     comment = (

--- a/src/pitloom/core/config.py
+++ b/src/pitloom/core/config.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from pitloom.core.content_type_config import ContentTypeConfig, ContentTypeOverride
-from pitloom.core.creation import Creator, Tool
+from pitloom.core.creation import CreationMetadata, Creator, Tool
 from pitloom.core.enrich_config import EnrichConfig
 from pitloom.core.provenance import ProvenanceConfig
 
@@ -220,6 +220,16 @@ class PitloomConfig:
     def enrich(self) -> EnrichConfig:
         """Return EnrichConfig constructed from current config settings."""
         return EnrichConfig(local=self.enrich_local)
+
+    @property
+    def creation_metadata(self) -> CreationMetadata:
+        """Return CreationMetadata constructed from current config settings."""
+        return CreationMetadata(
+            creators=self.creators,
+            tools=self.tools,
+            creation_datetime=self.creation_datetime,
+            creation_comment=self.creation_comment,
+        )
 
 
 def _check_moved_creation_keys(

--- a/src/pitloom/core/creation.py
+++ b/src/pitloom/core/creation.py
@@ -7,7 +7,12 @@
 
 from __future__ import annotations
 
+import logging
+import os
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+log = logging.getLogger(__name__)
 
 #: Valid ``Creator.type`` values -- the SPDX 3 Agent subclass a creator maps
 #: onto is selected by one of these names.  ``"agent"`` is the generic base
@@ -103,7 +108,9 @@ class CreationMetadata:
             seconds). Pitloom preserves input precision internally and
             normalises to SPDX 3 DateTime (``YYYY-MM-DDThh:mm:ssZ``)
             only at export time.
-            When ``None`` the assembler uses the current UTC time.
+            When ``None``, the assembler falls back to ``SOURCE_DATE_EPOCH``
+            (reproducible-builds.org) if set, else the current UTC time --
+            see :func:`resolve_source_date_epoch`.
         creation_comment: Optional comment to include on the SPDX
             ``CreationInfo`` element.  Callers (CLI, Hatchling build hook)
             set this to a static description of the invocation channel,
@@ -122,4 +129,36 @@ class CreationMetadata:
     build_datetime: str | None = None
 
 
-__all__ = ["VALID_CREATOR_TYPES", "CreationMetadata", "Creator", "Tool"]
+def resolve_source_date_epoch() -> datetime | None:
+    """Read ``SOURCE_DATE_EPOCH`` as a UTC datetime, per reproducible-builds.org.
+
+    <https://reproducible-builds.org/specs/source-date-epoch/>: a single
+    environment variable the whole build toolchain honours for every
+    embedded timestamp, so an operator opts a build into reproducibility
+    once rather than configuring each tool individually. Shared by every
+    Pitloom timestamp that should respect it (SBOM ``created``, the
+    Hatchling build hook's ``builtTime``, embedded wheel ZIP entries) so
+    the parsing/validation rule -- and what counts as invalid -- stays in
+    one place.
+
+    Returns:
+        The resolved UTC datetime, or ``None`` when unset or invalid
+        (logged as a warning) -- callers fall back to their own default.
+    """
+    raw = os.environ.get("SOURCE_DATE_EPOCH")
+    if not raw:
+        return None
+    try:
+        return datetime.fromtimestamp(int(raw), tz=timezone.utc)
+    except (ValueError, OverflowError, OSError) as exc:
+        log.warning("Ignoring invalid SOURCE_DATE_EPOCH: %s", exc)
+        return None
+
+
+__all__ = [
+    "VALID_CREATOR_TYPES",
+    "CreationMetadata",
+    "Creator",
+    "Tool",
+    "resolve_source_date_epoch",
+]

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -24,7 +24,7 @@ from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.assemble.spdx3.document import build as assemble_spdx3
 from pitloom.assemble.spdx3.fragments import merge_fragments
-from pitloom.core.config import PitloomConfig
+from pitloom.core.config import VALID_CONTENT_TYPE_METHODS, PitloomConfig
 from pitloom.core.creation import CreationMetadata
 from pitloom.core.document import DocumentModel
 from pitloom.core.models import get_wheel_files
@@ -39,6 +39,7 @@ from pitloom.ids import IdRegistry, resolve_registry
 
 _SPDX3_JSON_EXT = ".spdx3.json"
 _DEFAULT_FILE_ATTR = 0o644 << 16
+_ZIP_EPOCH_MIN = 315532800  # 1980-01-01T00:00:00Z, earliest zipfile supports
 
 
 def _find_dist_info_prefix(zf: zipfile.ZipFile, wheel_path: Path) -> str:
@@ -73,7 +74,8 @@ def _resolve_zip_timestamp(
     source_date_epoch = os.environ.get("SOURCE_DATE_EPOCH")
     if source_date_epoch:
         try:
-            dt = datetime.fromtimestamp(int(source_date_epoch), tz=timezone.utc)
+            epoch = max(int(source_date_epoch), _ZIP_EPOCH_MIN)
+            dt = datetime.fromtimestamp(epoch, tz=timezone.utc)
             return (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
         except (ValueError, OverflowError, OSError):
             pass
@@ -95,8 +97,14 @@ def _update_record_lines(
     sbom_hash: str,
     sbom_size: int,
     dist_info_prefix: str,
+    stale_arcnames: frozenset[str] = frozenset(),
 ) -> str:
-    """Update or insert the SBOM entry in RECORD and ensure RECORD,, is intact."""
+    """Update or insert the SBOM entry in RECORD and ensure RECORD,, is intact.
+
+    ``stale_arcnames`` are prior embedded-SBOM entries (e.g. left behind by
+    an earlier run under a different basename) whose rows are dropped so
+    RECORD does not go stale relative to the rewritten archive.
+    """
     rows: list[list[str]] = []
     reader = csv.reader(io.StringIO(record_text))
     found_sbom = False
@@ -108,7 +116,7 @@ def _update_record_lines(
         if row[0] == sbom_arcname:
             rows.append([sbom_arcname, f"sha256={sbom_hash}", str(sbom_size)])
             found_sbom = True
-        elif row[0] == record_arcname:
+        elif row[0] == record_arcname or row[0] in stale_arcnames:
             continue
         else:
             rows.append(row)
@@ -164,8 +172,17 @@ def embed_sbom_in_wheel(
             if sbom_filename is not None
             else _derive_wheel_sbom_filename(original_zf, dist_info)
         )
+        _validate_sbom_filename(target_name)
         sbom_arcname = f"{dist_info}sboms/{target_name}"
         record_arcname = f"{dist_info}RECORD"
+        sboms_prefix = f"{dist_info}sboms/"
+        stale_arcnames = frozenset(
+            name
+            for name in original_zf.namelist()
+            if name.startswith(sboms_prefix)
+            and name.endswith(_SPDX3_JSON_EXT)
+            and name != sbom_arcname
+        )
 
         record_info = None
         for info in original_zf.infolist():
@@ -182,6 +199,7 @@ def embed_sbom_in_wheel(
             sbom_hash,
             sbom_size,
             dist_info,
+            stale_arcnames,
         )
         new_record_bytes = new_record_text.encode("utf-8")
 
@@ -196,9 +214,21 @@ def embed_sbom_in_wheel(
             record_arcname,
             new_record_bytes,
             timestamp,
+            stale_arcnames,
         )
 
     return wheel_obj, sbom_arcname
+
+
+def _validate_sbom_filename(filename: str) -> None:
+    """Guard against path traversal in an embedded SBOM filename (CWE-22).
+
+    ``filename`` may come from wheel METADATA (untrusted archive content)
+    or a user-supplied ``--sbom-basename``, so it must resolve to a plain
+    filename with no path separators or traversal segments.
+    """
+    if not filename or "/" in filename or "\\" in filename or filename in (".", ".."):
+        raise ValueError(f"Invalid SBOM filename: {filename!r}")
 
 
 def _derive_wheel_sbom_filename(zf: zipfile.ZipFile, dist_info: str) -> str:
@@ -229,8 +259,14 @@ def _rewrite_wheel_archive(
     record_arcname: str,
     record_bytes: bytes,
     timestamp: tuple[int, int, int, int, int, int],
+    stale_arcnames: frozenset[str] = frozenset(),
 ) -> None:
-    """Write updated entries to a temporary file and atomically replace target."""
+    """Write updated entries to a temporary file and atomically replace target.
+
+    ``stale_arcnames`` are dropped from the rewritten archive rather than
+    copied through, so a prior embedded SBOM under a different basename
+    does not linger unlisted in the new RECORD.
+    """
     temp_dir = wheel_path.parent
     with tempfile.NamedTemporaryFile(
         dir=temp_dir,
@@ -246,6 +282,8 @@ def _rewrite_wheel_archive(
         ) as new_zf:
             for info in original_zf.infolist():
                 if info.filename in (record_arcname, sbom_arcname):
+                    continue
+                if info.filename in stale_arcnames:
                     continue
                 with original_zf.open(info, "r") as src, new_zf.open(info, "w") as dst:
                     shutil.copyfileobj(src, dst)
@@ -430,6 +468,11 @@ def _apply_config_overrides(
     if content_type is not None:
         changes["content_type_enabled"] = content_type
     if content_type_method is not None:
+        if content_type_method not in VALID_CONTENT_TYPE_METHODS:
+            raise ValueError(
+                "content_type_method must be one of "
+                f"{sorted(VALID_CONTENT_TYPE_METHODS)}, got {content_type_method!r}"
+            )
         changes["content_type_method"] = content_type_method
     if offline is not None:
         changes["offline"] = offline

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -14,6 +14,7 @@ import email
 import hashlib
 import io
 import json
+import logging
 import os
 import shutil
 import tempfile
@@ -38,6 +39,8 @@ from pitloom.extract.project import read_project
 from pitloom.extract.scanner import scan_project_for_ai_models
 from pitloom.extract.wheel import read_wheel
 from pitloom.ids import IdRegistry, resolve_registry
+
+log = logging.getLogger(__name__)
 
 _SPDX3_JSON_EXT = ".spdx3.json"
 _DEFAULT_FILE_ATTR = 0o644 << 16
@@ -83,8 +86,8 @@ def _resolve_zip_timestamp(
             epoch = max(int(source_date_epoch), _ZIP_EPOCH_MIN)
             dt = datetime.fromtimestamp(epoch, tz=timezone.utc)
             return (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
-        except (ValueError, OverflowError, OSError):
-            pass
+        except (ValueError, OverflowError, OSError) as exc:
+            log.warning("Ignoring invalid SOURCE_DATE_EPOCH: %s", exc)
     if fallback is not None:
         if fallback[0] >= 1980:
             return fallback

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -247,10 +247,12 @@ def embed_sbom_in_wheel(
     if not sbom_bytes.strip():
         raise ValueError("SBOM content cannot be empty")
 
+    orig_mode = wheel_obj.stat().st_mode if wheel_obj.exists() else None
+
     with zipfile.ZipFile(wheel_obj, "r") as original_zf:
         dist_info = _find_dist_info_prefix(original_zf, wheel_obj)
         plan = _plan_embed(original_zf, dist_info, sbom_filename, sbom_bytes)
-        _rewrite_wheel_archive(
+        temp_path = _rewrite_wheel_archive(
             wheel_obj,
             original_zf,
             plan.sbom_arcname,
@@ -260,6 +262,17 @@ def embed_sbom_in_wheel(
             plan.timestamp,
             plan.stale_arcnames,
         )
+
+    try:
+        os.replace(temp_path, wheel_obj)
+        if orig_mode is not None:
+            try:
+                os.chmod(wheel_obj, orig_mode)
+            except OSError:
+                pass
+    finally:
+        if temp_path.exists():
+            temp_path.unlink()
 
     return (
         wheel_obj,
@@ -381,14 +394,13 @@ def _rewrite_wheel_archive(
     record_bytes: bytes,
     timestamp: tuple[int, int, int, int, int, int],
     stale_arcnames: frozenset[str] = frozenset(),
-) -> None:
-    """Write updated entries to a temporary file and atomically replace target.
+) -> Path:
+    """Write updated entries to a temporary file.
 
     ``stale_arcnames`` are dropped from the rewritten archive rather than
     copied through -- see :func:`_looks_like_pitloom_sbom`.
     """
     temp_dir = wheel_path.parent
-    orig_mode = wheel_path.stat().st_mode if wheel_path.exists() else None
     with tempfile.NamedTemporaryFile(
         dir=temp_dir,
         delete=False,
@@ -419,15 +431,11 @@ def _rewrite_wheel_archive(
             rec_info.external_attr = _DEFAULT_FILE_ATTR
             new_zf.writestr(rec_info, record_bytes)
 
-        os.replace(temp_path, wheel_path)
-        if orig_mode is not None:
-            try:
-                os.chmod(wheel_path, orig_mode)
-            except OSError:
-                pass
-    finally:
+        return temp_path
+    except Exception:
         if temp_path.exists():
             temp_path.unlink()
+        raise
 
 
 def _build_sbom_from_project_and_wheel(
@@ -487,10 +495,12 @@ class ConfigOverrides:
     offline: bool | None = None
 
 
+# pylint: disable=too-many-arguments
 def embed_wheel_sbom(
     wheel_path: Path | str,
     *,
     project_dir: Path | str | None = None,
+    pitloom_config: PitloomConfig | None = None,
     sbom_path: Path | str | None = None,
     output_path: Path | str | None = None,
     sbom_basename: str | None = None,
@@ -503,6 +513,8 @@ def embed_wheel_sbom(
     Args:
         wheel_path: Path to the target .whl file.
         project_dir: Optional source project root containing pyproject.toml.
+        project_metadata: Optional pre-parsed project metadata.
+        pitloom_config: Optional pre-parsed pitloom config.
         sbom_path: Optional path to a pre-generated SBOM to embed directly.
         output_path: Optional path to write a standalone copy of the SBOM.
         sbom_basename: Custom basename for the embedded SBOM file.
@@ -524,6 +536,7 @@ def embed_wheel_sbom(
     sbom_json, eff_basename = _generate_embed_sbom_json(
         wheel_metadata,
         project_dir=project_dir,
+        pitloom_config=pitloom_config,
         sbom_path=sbom_path,
         sbom_basename=sbom_basename,
         creation_metadata=creation_metadata,
@@ -546,10 +559,12 @@ def embed_wheel_sbom(
     return res_path, arcname, sbom_json, removed_arcnames, timestamp_floored
 
 
+# pylint: disable=too-many-arguments
 def _generate_embed_sbom_json(
     wheel_metadata: ProjectMetadata,
     *,
     project_dir: Path | str | None,
+    pitloom_config: PitloomConfig | None,
     sbom_path: Path | str | None,
     sbom_basename: str | None,
     creation_metadata: CreationMetadata | None,
@@ -565,8 +580,7 @@ def _generate_embed_sbom_json(
     if sbom_path is not None:
         return Path(sbom_path).read_text(encoding="utf-8"), sbom_basename
 
-    proj_root = _resolve_project_root(project_dir)
-    if proj_root is None:
+    if project_dir is None:
         sbom_json = _build_sbom_standalone_wheel(
             wheel_metadata,
             creation_metadata,
@@ -576,7 +590,12 @@ def _generate_embed_sbom_json(
         )
         return sbom_json, sbom_basename
 
-    _, cfg, _ = read_project(proj_root)
+    proj_root = Path(project_dir).resolve()
+    if pitloom_config is None:
+        _, cfg, _ = read_project(proj_root)
+    else:
+        cfg = pitloom_config
+
     cfg = _apply_config_overrides(cfg, overrides)
     eff_registry = registry if registry is not None else cfg.ids_file
     reg = resolve_registry(proj_root, eff_registry)
@@ -584,19 +603,6 @@ def _generate_embed_sbom_json(
         proj_root, wheel_metadata, cfg, reg, creation_metadata or cfg.creation_metadata
     )
     return sbom_json, sbom_basename or cfg.sbom_basename
-
-
-def _resolve_project_root(project_dir: Path | str | None) -> Path | None:
-    """Resolve project directory if explicitly given or present in cwd."""
-    if project_dir is not None:
-        candidate = Path(project_dir).resolve()
-        if candidate.exists():
-            return candidate
-    cwd_candidate = Path.cwd()
-    for fname in ("pyproject.toml", "setup.cfg", "setup.py"):
-        if (cwd_candidate / fname).exists():
-            return cwd_candidate
-    return None
 
 
 def _apply_config_overrides(

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -426,13 +426,8 @@ def embed_wheel_sbom(
                 content_type_method=content_type_method,
                 offline=offline,
             )
-            reg = (
-                registry
-                if isinstance(registry, IdRegistry)
-                else IdRegistry.load(proj_root / registry)
-                if registry is not None
-                else resolve_registry(proj_root, cfg.ids_file)
-            )
+            eff_registry = registry if registry is not None else cfg.ids_file
+            reg = resolve_registry(proj_root, eff_registry)
             eff_creation = creation_metadata or CreationMetadata(
                 creators=cfg.creators,
                 tools=cfg.tools,
@@ -523,14 +518,7 @@ def _build_sbom_standalone_wheel(
     offline: bool | None,
 ) -> str:
     """Build SBOM from standalone wheel when no source project dir is present."""
-    cwd = Path.cwd()
-    reg = (
-        registry
-        if isinstance(registry, IdRegistry)
-        else IdRegistry.load(cwd / registry)
-        if registry is not None
-        else resolve_registry(cwd, None)
-    )
+    reg = resolve_registry(Path.cwd(), registry)
     doc = DocumentModel(
         project=wheel_metadata,
         creation_metadata=creation_metadata or CreationMetadata(),

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -57,7 +57,11 @@ def _find_dist_info_prefix(zf: zipfile.ZipFile, wheel_path: Path) -> str:
     if len(dist_infos) > 1:
         # Prefer dist-info matching the wheel file name prefix if ambiguous
         stem_prefix = wheel_path.stem.split("-")[0]
-        matching = [d for d in dist_infos if d.startswith(stem_prefix)]
+        matching = [
+            d
+            for d in dist_infos
+            if d.startswith(f"{stem_prefix}-") or d == f"{stem_prefix}.dist-info/"
+        ]
         if len(matching) == 1:
             return matching[0]
         raise ValueError(
@@ -80,7 +84,9 @@ def _resolve_zip_timestamp(
         except (ValueError, OverflowError, OSError):
             pass
     if fallback is not None:
-        return fallback
+        if fallback[0] >= 1980:
+            return fallback
+        return (1980, 1, 1, 0, 0, 0)
     now = datetime.now(timezone.utc)
     return (now.year, now.month, now.day, now.hour, now.minute, now.second)
 
@@ -162,6 +168,8 @@ def embed_sbom_in_wheel(
     sbom_bytes = (
         sbom_content.encode("utf-8") if isinstance(sbom_content, str) else sbom_content
     )
+    if not sbom_bytes.strip():
+        raise ValueError("SBOM content cannot be empty")
     sbom_hash = _calculate_record_hash(sbom_bytes)
     sbom_size = len(sbom_bytes)
 
@@ -220,6 +228,9 @@ def embed_sbom_in_wheel(
     return wheel_obj, sbom_arcname
 
 
+_INVALID_FILENAME_CHARS = frozenset({"/", "\\", "\x00"})
+
+
 def _validate_sbom_filename(filename: str) -> None:
     """Guard against path traversal in an embedded SBOM filename (CWE-22).
 
@@ -227,7 +238,12 @@ def _validate_sbom_filename(filename: str) -> None:
     or a user-supplied ``--sbom-basename``, so it must resolve to a plain
     filename with no path separators or traversal segments.
     """
-    if not filename or "/" in filename or "\\" in filename or filename in (".", ".."):
+    clean = filename.strip()
+    if (
+        not clean
+        or clean in (".", "..")
+        or any(c in clean for c in _INVALID_FILENAME_CHARS)
+    ):
         raise ValueError(f"Invalid SBOM filename: {filename!r}")
 
 
@@ -239,10 +255,13 @@ def _derive_wheel_sbom_filename(zf: zipfile.ZipFile, dist_info: str) -> str:
     if metadata_path in zf.namelist():
         content = zf.read(metadata_path).decode("utf-8", errors="replace")
         for line in content.splitlines():
-            if line.startswith("Name: ") and not meta_name:
-                meta_name = line.split("Name: ", 1)[1].strip()
-            elif line.startswith("Version: ") and not meta_version:
-                meta_version = line.split("Version: ", 1)[1].strip()
+            lower = line.lower()
+            if lower.startswith("name: ") and not meta_name:
+                meta_name = line.split(":", 1)[1].strip()
+            elif lower.startswith("version: ") and not meta_version:
+                meta_version = line.split(":", 1)[1].strip()
+            elif not line.strip() and (meta_name or meta_version):
+                break
             if meta_name and meta_version:
                 break
     if meta_name and meta_version:
@@ -268,6 +287,7 @@ def _rewrite_wheel_archive(
     does not linger unlisted in the new RECORD.
     """
     temp_dir = wheel_path.parent
+    orig_mode = wheel_path.stat().st_mode if wheel_path.exists() else None
     with tempfile.NamedTemporaryFile(
         dir=temp_dir,
         delete=False,
@@ -299,6 +319,11 @@ def _rewrite_wheel_archive(
             new_zf.writestr(rec_info, record_bytes)
 
         os.replace(temp_path, wheel_path)
+        if orig_mode is not None:
+            try:
+                os.chmod(wheel_path, orig_mode)
+            except OSError:
+                pass
     finally:
         if temp_path.exists():
             temp_path.unlink()
@@ -418,7 +443,12 @@ def embed_wheel_sbom(
             )
             eff_basename = sbom_basename
 
-    target_filename = f"{eff_basename}{_SPDX3_JSON_EXT}" if eff_basename else None
+    if eff_basename:
+        eff_clean = eff_basename.removesuffix(_SPDX3_JSON_EXT)
+        target_filename = f"{eff_clean}{_SPDX3_JSON_EXT}"
+    else:
+        target_filename = None
+
     res_path, arcname = embed_sbom_in_wheel(
         wheel_obj, sbom_json, sbom_filename=target_filename
     )

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -13,6 +13,7 @@ import dataclasses
 import email
 import hashlib
 import io
+import json
 import os
 import shutil
 import tempfile
@@ -98,6 +99,32 @@ def _calculate_record_hash(content: bytes) -> str:
     return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
 
 
+def _looks_like_pitloom_sbom(content: bytes) -> bool:
+    """Check whether an SPDX 3 JSON-LD payload was created by Pitloom.
+
+    Used to decide whether a pre-existing ``sboms/`` entry left by an
+    earlier run under a different filename is safe to clean up on
+    re-embed. PEP 770 allows multiple SBOMs from different tools to
+    coexist under ``sboms/``, so cleanup must not touch anything that
+    doesn't look like Pitloom's own prior output -- malformed/unparseable
+    content or the absence of a ``Tool``/``SoftwareAgent`` named
+    ``"Pitloom"`` in ``@graph`` means "leave it alone".
+    """
+    try:
+        doc = json.loads(content)
+    except (ValueError, UnicodeDecodeError):
+        return False
+    graph = doc.get("@graph") if isinstance(doc, dict) else None
+    if not isinstance(graph, list):
+        return False
+    return any(
+        isinstance(node, dict)
+        and node.get("type") in ("Tool", "SoftwareAgent")
+        and node.get("name") == "Pitloom"
+        for node in graph
+    )
+
+
 def _update_record_lines(
     record_text: str,
     sbom_arcname: str,
@@ -108,9 +135,9 @@ def _update_record_lines(
 ) -> str:
     """Update or insert the SBOM entry in RECORD and ensure RECORD,, is intact.
 
-    ``stale_arcnames`` are prior embedded-SBOM entries (e.g. left behind by
-    an earlier run under a different basename) whose rows are dropped so
-    RECORD does not go stale relative to the rewritten archive.
+    ``stale_arcnames`` are prior Pitloom-embedded SBOM entries (e.g. left
+    behind by an earlier run under a different basename) whose rows are
+    dropped so RECORD does not go stale relative to the rewritten archive.
     """
     rows: list[list[str]] = []
     reader = csv.reader(io.StringIO(record_text))
@@ -144,7 +171,7 @@ def embed_sbom_in_wheel(
     sbom_content: str | bytes,
     *,
     sbom_filename: str | None = None,
-) -> tuple[Path, str]:
+) -> tuple[Path, str, tuple[str, ...]]:
     """Embed an SPDX 3 SBOM into a built wheel archive (PEP 770).
 
     Args:
@@ -154,9 +181,12 @@ def embed_sbom_in_wheel(
             Defaults to '<name>-<version>.spdx3.json' read from wheel metadata.
 
     Returns:
-        A tuple of (wheel_path, embedded_arcname), where embedded_arcname is
-        the relative path inside the wheel (e.g.
-        'pkg-1.0.dist-info/sboms/pkg-1.0.spdx3.json').
+        A tuple of (wheel_path, embedded_arcname, removed_arcnames).
+        ``embedded_arcname`` is the relative path inside the wheel (e.g.
+        'pkg-1.0.dist-info/sboms/pkg-1.0.spdx3.json'). ``removed_arcnames``
+        lists any prior Pitloom-embedded SBOM entries (under a different
+        filename) that were cleaned up as part of this embed -- see
+        :func:`_looks_like_pitloom_sbom`.
 
     Raises:
         ValueError: If the wheel archive has no valid .dist-info directory.
@@ -191,6 +221,7 @@ def embed_sbom_in_wheel(
             if name.startswith(sboms_prefix)
             and name.endswith(_SPDX3_JSON_EXT)
             and name != sbom_arcname
+            and _looks_like_pitloom_sbom(original_zf.read(name))
         )
 
         record_info = None
@@ -226,7 +257,7 @@ def embed_sbom_in_wheel(
             stale_arcnames,
         )
 
-    return wheel_obj, sbom_arcname
+    return wheel_obj, sbom_arcname, tuple(sorted(stale_arcnames))
 
 
 _INVALID_FILENAME_CHARS = frozenset({"/", "\\", "\x00"})
@@ -277,8 +308,7 @@ def _rewrite_wheel_archive(
     """Write updated entries to a temporary file and atomically replace target.
 
     ``stale_arcnames`` are dropped from the rewritten archive rather than
-    copied through, so a prior embedded SBOM under a different basename
-    does not linger unlisted in the new RECORD.
+    copied through -- see :func:`_looks_like_pitloom_sbom`.
     """
     temp_dir = wheel_path.parent
     orig_mode = wheel_path.stat().st_mode if wheel_path.exists() else None
@@ -379,7 +409,7 @@ def embed_wheel_sbom(
     content_type: bool | None = None,
     content_type_method: str | None = None,
     offline: bool | None = None,
-) -> tuple[Path, str, str]:
+) -> tuple[Path, str, str, tuple[str, ...]]:
     """Generate and embed a PEP 770 SBOM into a built Python wheel.
 
     Args:
@@ -399,7 +429,8 @@ def embed_wheel_sbom(
         offline: Offline mode flag.
 
     Returns:
-        Tuple of (modified_wheel_path, embedded_arcname, sbom_json_string).
+        Tuple of (modified_wheel_path, embedded_arcname, sbom_json_string,
+        removed_arcnames) -- see :func:`embed_sbom_in_wheel`.
     """
     wheel_obj = Path(wheel_path).resolve()
     wheel_metadata, _ = read_wheel(wheel_obj)
@@ -439,14 +470,14 @@ def embed_wheel_sbom(
     else:
         target_filename = None
 
-    res_path, arcname = embed_sbom_in_wheel(
+    res_path, arcname, removed_arcnames = embed_sbom_in_wheel(
         wheel_obj, sbom_json, sbom_filename=target_filename
     )
 
     if output_path is not None:
         Path(output_path).write_text(sbom_json, encoding="utf-8")
 
-    return res_path, arcname, sbom_json
+    return res_path, arcname, sbom_json, removed_arcnames
 
 
 def _resolve_project_root(project_dir: Path | str | None) -> Path | None:

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -14,7 +14,6 @@ import email
 import hashlib
 import io
 import json
-import logging
 import os
 import shutil
 import tempfile
@@ -28,7 +27,7 @@ from spdx_python_model.bindings import v3_0_1 as spdx3
 from pitloom.assemble.spdx3.document import build as assemble_spdx3
 from pitloom.assemble.spdx3.fragments import merge_fragments
 from pitloom.core.config import VALID_CONTENT_TYPE_METHODS, PitloomConfig
-from pitloom.core.creation import CreationMetadata
+from pitloom.core.creation import CreationMetadata, resolve_source_date_epoch
 from pitloom.core.document import DocumentModel
 from pitloom.core.models import get_wheel_files
 from pitloom.core.project import ProjectMetadata
@@ -40,11 +39,9 @@ from pitloom.extract.scanner import scan_project_for_ai_models
 from pitloom.extract.wheel import read_wheel
 from pitloom.ids import IdRegistry, resolve_registry
 
-log = logging.getLogger(__name__)
-
 _SPDX3_JSON_EXT = ".spdx3.json"
 _DEFAULT_FILE_ATTR = 0o644 << 16
-_ZIP_EPOCH_MIN = 315532800  # 1980-01-01T00:00:00Z, earliest zipfile supports
+_ZIP_EPOCH_FLOOR = datetime(1980, 1, 1, tzinfo=timezone.utc)  # earliest zipfile supports
 
 
 def _find_dist_info_prefix(zf: zipfile.ZipFile, wheel_path: Path) -> str:
@@ -80,14 +77,17 @@ def _resolve_zip_timestamp(
     fallback: tuple[int, int, int, int, int, int] | None = None,
 ) -> tuple[int, int, int, int, int, int]:
     """Resolve entry timestamp respecting SOURCE_DATE_EPOCH if set."""
-    source_date_epoch = os.environ.get("SOURCE_DATE_EPOCH")
-    if source_date_epoch:
-        try:
-            epoch = max(int(source_date_epoch), _ZIP_EPOCH_MIN)
-            dt = datetime.fromtimestamp(epoch, tz=timezone.utc)
-            return (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
-        except (ValueError, OverflowError, OSError) as exc:
-            log.warning("Ignoring invalid SOURCE_DATE_EPOCH: %s", exc)
+    epoch_dt = resolve_source_date_epoch()
+    if epoch_dt is not None:
+        clamped = max(epoch_dt, _ZIP_EPOCH_FLOOR)
+        return (
+            clamped.year,
+            clamped.month,
+            clamped.day,
+            clamped.hour,
+            clamped.minute,
+            clamped.second,
+        )
     if fallback is not None:
         if fallback[0] >= 1980:
             return fallback

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -41,7 +41,26 @@ from pitloom.ids import IdRegistry, resolve_registry
 
 _SPDX3_JSON_EXT = ".spdx3.json"
 _DEFAULT_FILE_ATTR = 0o644 << 16
-_ZIP_EPOCH_FLOOR = datetime(1980, 1, 1, tzinfo=timezone.utc)  # earliest zipfile supports
+
+#: Two different epoch floors are in play here, from unrelated conventions:
+#: - Unix time (what ``SOURCE_DATE_EPOCH`` counts from) starts 1970-01-01 --
+#:   ``SOURCE_DATE_EPOCH=0`` is a legitimate, deliberately-chosen value (some
+#:   build systems use it as a fixed "don't care, just be deterministic"
+#:   placeholder), not an error.
+#: - The ZIP format's per-entry timestamp field (DOS date/time, inherited
+#:   from MS-DOS's own timestamp format) can only represent 1980-01-01
+#:   onward -- a binary format limitation, unrelated to Unix time or to
+#:   what date is semantically correct.
+#: A `SOURCE_DATE_EPOCH` between these two floors (or an unset entry with
+#: no fallback, defaulting to the Unix epoch) is valid Unix time but not
+#: representable in a ZIP entry, so it must be floored to 1980-01-01 for
+#: the archive entry specifically -- see :func:`_resolve_zip_timestamp`.
+#: The embedded SBOM's own ``created`` field has no such constraint (plain
+#: JSON/ISO 8601) and is never floored, so the two can legitimately diverge;
+#: callers surface this via the ``floored`` return value rather than
+#: silently rewriting the SBOM's stated creation date to match the ZIP
+#: format's limitation -- see :func:`~pitloom.core.creation.CreationMetadata`.
+_ZIP_EPOCH_FLOOR = datetime(1980, 1, 1, tzinfo=timezone.utc)
 
 
 def _find_dist_info_prefix(zf: zipfile.ZipFile, wheel_path: Path) -> str:
@@ -75,25 +94,38 @@ def _find_dist_info_prefix(zf: zipfile.ZipFile, wheel_path: Path) -> str:
 
 def _resolve_zip_timestamp(
     fallback: tuple[int, int, int, int, int, int] | None = None,
-) -> tuple[int, int, int, int, int, int]:
-    """Resolve entry timestamp respecting SOURCE_DATE_EPOCH if set."""
+) -> tuple[tuple[int, int, int, int, int, int], bool]:
+    """Resolve entry timestamp respecting SOURCE_DATE_EPOCH if set.
+
+    Returns ``(timestamp, floored)`` -- ``floored`` is ``True`` when the
+    resolved value was below ``_ZIP_EPOCH_FLOOR`` and had to be bumped up
+    to it, since the ZIP format (unlike the SBOM's own JSON ``created``
+    field) cannot represent a pre-1980 date. Most commonly triggered by
+    ``SOURCE_DATE_EPOCH=0``, a common reproducible-builds convention for
+    "pin to a fixed placeholder" -- callers should surface ``floored`` to
+    the user, since it means the embedded SBOM's stated ``created`` and
+    the wheel archive's own entry timestamp now silently diverge.
+    """
     epoch_dt = resolve_source_date_epoch()
     if epoch_dt is not None:
         clamped = max(epoch_dt, _ZIP_EPOCH_FLOOR)
         return (
-            clamped.year,
-            clamped.month,
-            clamped.day,
-            clamped.hour,
-            clamped.minute,
-            clamped.second,
+            (
+                clamped.year,
+                clamped.month,
+                clamped.day,
+                clamped.hour,
+                clamped.minute,
+                clamped.second,
+            ),
+            clamped != epoch_dt,
         )
     if fallback is not None:
         if fallback[0] >= 1980:
-            return fallback
-        return (1980, 1, 1, 0, 0, 0)
+            return fallback, False
+        return (1980, 1, 1, 0, 0, 0), True
     now = datetime.now(timezone.utc)
-    return (now.year, now.month, now.day, now.hour, now.minute, now.second)
+    return (now.year, now.month, now.day, now.hour, now.minute, now.second), False
 
 
 def _calculate_record_hash(content: bytes) -> str:
@@ -174,7 +206,7 @@ def embed_sbom_in_wheel(
     sbom_content: str | bytes,
     *,
     sbom_filename: str | None = None,
-) -> tuple[Path, str, tuple[str, ...]]:
+) -> tuple[Path, str, tuple[str, ...], bool]:
     """Embed an SPDX 3 SBOM into a built wheel archive (PEP 770).
 
     Args:
@@ -184,12 +216,16 @@ def embed_sbom_in_wheel(
             Defaults to '<name>-<version>.spdx3.json' read from wheel metadata.
 
     Returns:
-        A tuple of (wheel_path, embedded_arcname, removed_arcnames).
-        ``embedded_arcname`` is the relative path inside the wheel (e.g.
-        'pkg-1.0.dist-info/sboms/pkg-1.0.spdx3.json'). ``removed_arcnames``
-        lists any prior Pitloom-embedded SBOM entries (under a different
-        filename) that were cleaned up as part of this embed -- see
-        :func:`_looks_like_pitloom_sbom`.
+        A tuple of (wheel_path, embedded_arcname, removed_arcnames,
+        zip_timestamp_floored). ``embedded_arcname`` is the relative path
+        inside the wheel (e.g. 'pkg-1.0.dist-info/sboms/pkg-1.0.spdx3.json').
+        ``removed_arcnames`` lists any prior Pitloom-embedded SBOM entries
+        (under a different filename) that were cleaned up as part of this
+        embed -- see :func:`_looks_like_pitloom_sbom`. ``zip_timestamp_floored``
+        is ``True`` when the resolved entry timestamp was before 1980 and
+        had to be bumped up to the ZIP format's floor -- see
+        :func:`_resolve_zip_timestamp`; the embedded SBOM's own ``created``
+        is unaffected and keeps the true (possibly pre-1980) value.
 
     Raises:
         ValueError: If the wheel archive has no valid .dist-info directory.
@@ -246,7 +282,7 @@ def embed_sbom_in_wheel(
         )
         new_record_bytes = new_record_text.encode("utf-8")
 
-        timestamp = _resolve_zip_timestamp(
+        timestamp, timestamp_floored = _resolve_zip_timestamp(
             record_info.date_time if record_info else None
         )
         _rewrite_wheel_archive(
@@ -260,7 +296,7 @@ def embed_sbom_in_wheel(
             stale_arcnames,
         )
 
-    return wheel_obj, sbom_arcname, tuple(sorted(stale_arcnames))
+    return wheel_obj, sbom_arcname, tuple(sorted(stale_arcnames)), timestamp_floored
 
 
 _INVALID_FILENAME_CHARS = frozenset({"/", "\\", "\x00"})
@@ -412,7 +448,7 @@ def embed_wheel_sbom(
     content_type: bool | None = None,
     content_type_method: str | None = None,
     offline: bool | None = None,
-) -> tuple[Path, str, str, tuple[str, ...]]:
+) -> tuple[Path, str, str, tuple[str, ...], bool]:
     """Generate and embed a PEP 770 SBOM into a built Python wheel.
 
     Args:
@@ -433,7 +469,8 @@ def embed_wheel_sbom(
 
     Returns:
         Tuple of (modified_wheel_path, embedded_arcname, sbom_json_string,
-        removed_arcnames) -- see :func:`embed_sbom_in_wheel`.
+        removed_arcnames, zip_timestamp_floored) -- see
+        :func:`embed_sbom_in_wheel`.
     """
     wheel_obj = Path(wheel_path).resolve()
     wheel_metadata, _ = read_wheel(wheel_obj)
@@ -473,14 +510,14 @@ def embed_wheel_sbom(
     else:
         target_filename = None
 
-    res_path, arcname, removed_arcnames = embed_sbom_in_wheel(
+    res_path, arcname, removed_arcnames, timestamp_floored = embed_sbom_in_wheel(
         wheel_obj, sbom_json, sbom_filename=target_filename
     )
 
     if output_path is not None:
         Path(output_path).write_text(sbom_json, encoding="utf-8")
 
-    return res_path, arcname, sbom_json, removed_arcnames
+    return res_path, arcname, sbom_json, removed_arcnames, timestamp_floored
 
 
 def _resolve_project_root(project_dir: Path | str | None) -> Path | None:

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -433,8 +433,14 @@ def embed_wheel_sbom(
                 if registry is not None
                 else resolve_registry(proj_root, cfg.ids_file)
             )
+            eff_creation = creation_metadata or CreationMetadata(
+                creators=cfg.creators,
+                tools=cfg.tools,
+                creation_datetime=cfg.creation_datetime,
+                creation_comment=cfg.creation_comment,
+            )
             sbom_json = _build_sbom_from_project_and_wheel(
-                proj_root, wheel_metadata, cfg, reg, creation_metadata
+                proj_root, wheel_metadata, cfg, reg, eff_creation
             )
             eff_basename = sbom_basename or cfg.sbom_basename
         else:

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -39,6 +39,12 @@ from pitloom.extract.scanner import scan_project_for_ai_models
 from pitloom.extract.wheel import read_wheel
 from pitloom.ids import IdRegistry, resolve_registry
 
+__all__ = [
+    "ConfigOverrides",
+    "embed_sbom_in_wheel",
+    "embed_wheel_sbom",
+]
+
 _SPDX3_JSON_EXT = ".spdx3.json"
 _DEFAULT_FILE_ATTR = 0o644 << 16
 
@@ -648,6 +654,3 @@ def _build_sbom_standalone_wheel(
         offline=offline or False,
     )
     return exporter.to_json(pretty=False)
-
-
-__all__ = ["embed_sbom_in_wheel", "embed_wheel_sbom"]

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -1,0 +1,472 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Embed SPDX 3 SBOMs into built Python wheels (PEP 770)."""
+
+from __future__ import annotations
+
+import base64
+import csv
+import dataclasses
+import hashlib
+import io
+import os
+import shutil
+import tempfile
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from spdx_python_model.bindings import v3_0_1 as spdx3
+
+from pitloom.assemble.spdx3.document import build as assemble_spdx3
+from pitloom.assemble.spdx3.fragments import merge_fragments
+from pitloom.core.config import PitloomConfig
+from pitloom.core.creation import CreationMetadata
+from pitloom.core.document import DocumentModel
+from pitloom.core.models import get_wheel_files
+from pitloom.core.project import ProjectMetadata
+from pitloom.core.provenance import ProvenanceConfig
+from pitloom.enrich import run_enrichers_for_models
+from pitloom.extract.binary import find_phantom_dependencies
+from pitloom.extract.project import read_project
+from pitloom.extract.scanner import scan_project_for_ai_models
+from pitloom.extract.wheel import read_wheel
+from pitloom.ids import IdRegistry, resolve_registry
+
+_SPDX3_JSON_EXT = ".spdx3.json"
+_DEFAULT_FILE_ATTR = 0o644 << 16
+
+
+def _find_dist_info_prefix(zf: zipfile.ZipFile, wheel_path: Path) -> str:
+    """Find the single .dist-info directory prefix in the wheel ZIP archive."""
+    dist_infos: set[str] = set()
+    for name in zf.namelist():
+        parts = name.split("/")
+        if len(parts) >= 2 and parts[0].endswith(".dist-info"):
+            dist_infos.add(f"{parts[0]}/")
+
+    if not dist_infos:
+        raise ValueError(
+            f"Invalid wheel archive {wheel_path.name}: no .dist-info directory found"
+        )
+    if len(dist_infos) > 1:
+        # Prefer dist-info matching the wheel file name prefix if ambiguous
+        stem_prefix = wheel_path.stem.split("-")[0]
+        matching = [d for d in dist_infos if d.startswith(stem_prefix)]
+        if len(matching) == 1:
+            return matching[0]
+        raise ValueError(
+            f"Invalid wheel archive {wheel_path.name}: multiple .dist-info "
+            f"directories found ({sorted(dist_infos)})"
+        )
+    return next(iter(dist_infos))
+
+
+def _resolve_zip_timestamp(
+    fallback: tuple[int, int, int, int, int, int] | None = None,
+) -> tuple[int, int, int, int, int, int]:
+    """Resolve entry timestamp respecting SOURCE_DATE_EPOCH if set."""
+    source_date_epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    if source_date_epoch:
+        try:
+            dt = datetime.fromtimestamp(int(source_date_epoch), tz=timezone.utc)
+            return (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
+        except (ValueError, OverflowError, OSError):
+            pass
+    if fallback is not None:
+        return fallback
+    now = datetime.now(timezone.utc)
+    return (now.year, now.month, now.day, now.hour, now.minute, now.second)
+
+
+def _calculate_record_hash(content: bytes) -> str:
+    """Compute base64url SHA-256 digest without trailing padding (PEP 376)."""
+    digest = hashlib.sha256(content).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+
+def _update_record_lines(
+    record_text: str,
+    sbom_arcname: str,
+    sbom_hash: str,
+    sbom_size: int,
+    dist_info_prefix: str,
+) -> str:
+    """Update or insert the SBOM entry in RECORD and ensure RECORD,, is intact."""
+    rows: list[list[str]] = []
+    reader = csv.reader(io.StringIO(record_text))
+    found_sbom = False
+    record_arcname = f"{dist_info_prefix}RECORD"
+
+    for row in reader:
+        if not row:
+            continue
+        if row[0] == sbom_arcname:
+            rows.append([sbom_arcname, f"sha256={sbom_hash}", str(sbom_size)])
+            found_sbom = True
+        elif row[0] == record_arcname:
+            continue
+        else:
+            rows.append(row)
+
+    if not found_sbom:
+        rows.append([sbom_arcname, f"sha256={sbom_hash}", str(sbom_size)])
+
+    rows.append([record_arcname, "", ""])
+
+    out = io.StringIO()
+    writer = csv.writer(out, lineterminator="\n")
+    writer.writerows(rows)
+    return out.getvalue()
+
+
+def embed_sbom_in_wheel(
+    wheel_path: Path | str,
+    sbom_content: str | bytes,
+    *,
+    sbom_filename: str | None = None,
+) -> tuple[Path, str]:
+    """Embed an SPDX 3 SBOM into a built wheel archive (PEP 770).
+
+    Args:
+        wheel_path: Path to the target .whl file to modify in place.
+        sbom_content: Raw SBOM JSON-LD content (string or bytes).
+        sbom_filename: Custom filename inside .dist-info/sboms/.
+            Defaults to '<name>-<version>.spdx3.json' read from wheel metadata.
+
+    Returns:
+        A tuple of (wheel_path, embedded_arcname), where embedded_arcname is
+        the relative path inside the wheel (e.g.
+        'pkg-1.0.dist-info/sboms/pkg-1.0.spdx3.json').
+
+    Raises:
+        ValueError: If the wheel archive has no valid .dist-info directory.
+        FileNotFoundError: If the wheel file does not exist.
+    """
+    wheel_obj = Path(wheel_path).resolve()
+    if not wheel_obj.exists():
+        raise FileNotFoundError(f"Wheel file not found: {wheel_obj}")
+
+    sbom_bytes = (
+        sbom_content.encode("utf-8") if isinstance(sbom_content, str) else sbom_content
+    )
+    sbom_hash = _calculate_record_hash(sbom_bytes)
+    sbom_size = len(sbom_bytes)
+
+    with zipfile.ZipFile(wheel_obj, "r") as original_zf:
+        dist_info = _find_dist_info_prefix(original_zf, wheel_obj)
+        target_name = (
+            sbom_filename
+            if sbom_filename is not None
+            else _derive_wheel_sbom_filename(original_zf, dist_info)
+        )
+        sbom_arcname = f"{dist_info}sboms/{target_name}"
+        record_arcname = f"{dist_info}RECORD"
+
+        record_info = None
+        for info in original_zf.infolist():
+            if info.filename == record_arcname:
+                record_info = info
+                break
+
+        old_record_text = (
+            original_zf.read(record_arcname).decode("utf-8") if record_info else ""
+        )
+        new_record_text = _update_record_lines(
+            old_record_text,
+            sbom_arcname,
+            sbom_hash,
+            sbom_size,
+            dist_info,
+        )
+        new_record_bytes = new_record_text.encode("utf-8")
+
+        timestamp = _resolve_zip_timestamp(
+            record_info.date_time if record_info else None
+        )
+        _rewrite_wheel_archive(
+            wheel_obj,
+            original_zf,
+            sbom_arcname,
+            sbom_bytes,
+            record_arcname,
+            new_record_bytes,
+            timestamp,
+        )
+
+    return wheel_obj, sbom_arcname
+
+
+def _derive_wheel_sbom_filename(zf: zipfile.ZipFile, dist_info: str) -> str:
+    """Derive default SBOM filename from wheel METADATA."""
+    meta_name: str | None = None
+    meta_version: str | None = None
+    metadata_path = f"{dist_info}METADATA"
+    if metadata_path in zf.namelist():
+        content = zf.read(metadata_path).decode("utf-8", errors="replace")
+        for line in content.splitlines():
+            if line.startswith("Name: ") and not meta_name:
+                meta_name = line.split("Name: ", 1)[1].strip()
+            elif line.startswith("Version: ") and not meta_version:
+                meta_version = line.split("Version: ", 1)[1].strip()
+            if meta_name and meta_version:
+                break
+    if meta_name and meta_version:
+        return f"{meta_name}-{meta_version}{_SPDX3_JSON_EXT}"
+    prefix = dist_info.rstrip("/").removesuffix(".dist-info")
+    return f"{prefix}{_SPDX3_JSON_EXT}" if prefix else f"sbom{_SPDX3_JSON_EXT}"
+
+
+def _rewrite_wheel_archive(
+    wheel_path: Path,
+    original_zf: zipfile.ZipFile,
+    sbom_arcname: str,
+    sbom_bytes: bytes,
+    record_arcname: str,
+    record_bytes: bytes,
+    timestamp: tuple[int, int, int, int, int, int],
+) -> None:
+    """Write updated entries to a temporary file and atomically replace target."""
+    temp_dir = wheel_path.parent
+    with tempfile.NamedTemporaryFile(
+        dir=temp_dir,
+        delete=False,
+        prefix=f"{wheel_path.stem}.",
+        suffix=".tmp",
+    ) as temp_file:
+        temp_path = Path(temp_file.name)
+
+    try:
+        with zipfile.ZipFile(
+            temp_path, "w", compression=zipfile.ZIP_DEFLATED
+        ) as new_zf:
+            for info in original_zf.infolist():
+                if info.filename in (record_arcname, sbom_arcname):
+                    continue
+                with original_zf.open(info, "r") as src, new_zf.open(info, "w") as dst:
+                    shutil.copyfileobj(src, dst)
+
+            sbom_info = zipfile.ZipInfo(sbom_arcname, date_time=timestamp)
+            sbom_info.compress_type = zipfile.ZIP_DEFLATED
+            sbom_info.external_attr = _DEFAULT_FILE_ATTR
+            new_zf.writestr(sbom_info, sbom_bytes)
+
+            rec_info = zipfile.ZipInfo(record_arcname, date_time=timestamp)
+            rec_info.compress_type = zipfile.ZIP_DEFLATED
+            rec_info.external_attr = _DEFAULT_FILE_ATTR
+            new_zf.writestr(rec_info, record_bytes)
+
+        os.replace(temp_path, wheel_path)
+    finally:
+        if temp_path.exists():
+            temp_path.unlink()
+
+
+def _build_sbom_from_project_and_wheel(
+    project_dir: Path,
+    wheel_metadata: ProjectMetadata,
+    pitloom_config: PitloomConfig,
+    registry: IdRegistry | None,
+    creation_metadata: CreationMetadata | None,
+) -> str:
+    """Generate a canonical Build SBOM from project sources and wheel files."""
+    merkle_root, project_files = get_wheel_files(
+        project_dir,
+        scan_file_headers=pitloom_config.extract_file_header,
+        detect_content_type=pitloom_config.content_type.enabled,
+        content_type_method=pitloom_config.content_type.method,
+        content_type_overrides=pitloom_config.content_type.overrides,
+    )
+    ai_models = scan_project_for_ai_models(project_dir, project_files)
+    phantom_deps = find_phantom_dependencies(wheel_metadata.files)
+    enrichment_results = run_enrichers_for_models(
+        ai_models, pitloom_config.enrich, project_dir
+    )
+
+    doc = DocumentModel(
+        project=wheel_metadata,
+        creation_metadata=creation_metadata or CreationMetadata(),
+        ai_models=ai_models,
+        phantom_dependencies=phantom_deps,
+    )
+    exporter = assemble_spdx3(
+        doc,
+        merkle_root=merkle_root,
+        sbom_type=spdx3.software_SbomType.build,
+        registry=registry,
+        provenance=pitloom_config.provenance,
+        enrichment_results_by_model=enrichment_results,
+        offline=pitloom_config.offline,
+    )
+    merge_fragments(project_dir, pitloom_config.fragments, exporter)
+    return exporter.to_json(pretty=False)
+
+
+# pylint: disable=too-many-arguments,too-many-locals,too-many-positional-arguments
+def embed_wheel_sbom(
+    wheel_path: Path | str,
+    *,
+    project_dir: Path | str | None = None,
+    sbom_path: Path | str | None = None,
+    output_path: Path | str | None = None,
+    sbom_basename: str | None = None,
+    creation_metadata: CreationMetadata | None = None,
+    registry: str | Path | IdRegistry | None = None,
+    provenance: ProvenanceConfig | None = None,
+    enrich: bool | None = None,
+    extract_file_header: bool | None = None,
+    content_type: bool | None = None,
+    content_type_method: str | None = None,
+    offline: bool | None = None,
+) -> tuple[Path, str, str]:
+    """Generate and embed a PEP 770 SBOM into a built Python wheel.
+
+    Args:
+        wheel_path: Path to the target .whl file.
+        project_dir: Optional source project root containing pyproject.toml.
+        sbom_path: Optional path to a pre-generated SBOM to embed directly.
+        output_path: Optional path to write a standalone copy of the SBOM.
+        sbom_basename: Custom basename for the embedded SBOM file.
+        creation_metadata: Optional creation metadata overrides.
+        registry: ID registry or path.
+        provenance: Metadata provenance config.
+        enrich: Override enrichment setting.
+        extract_file_header: Override SPDX header extraction.
+        content_type: Override content type detection.
+        content_type_method: Content type detection method
+            ('auto'/'magika'/'extension').
+        offline: Offline mode flag.
+
+    Returns:
+        Tuple of (modified_wheel_path, embedded_arcname, sbom_json_string).
+    """
+    wheel_obj = Path(wheel_path).resolve()
+    wheel_metadata, _ = read_wheel(wheel_obj)
+
+    if sbom_path is not None:
+        sbom_json = Path(sbom_path).read_text(encoding="utf-8")
+        eff_basename = sbom_basename
+    else:
+        proj_root = _resolve_project_root(project_dir)
+        if proj_root is not None:
+            _, cfg, _ = read_project(proj_root)
+            cfg = _apply_config_overrides(
+                cfg,
+                provenance=provenance,
+                enrich=enrich,
+                extract_file_header=extract_file_header,
+                content_type=content_type,
+                content_type_method=content_type_method,
+                offline=offline,
+            )
+            reg = (
+                registry
+                if isinstance(registry, IdRegistry)
+                else IdRegistry.load(proj_root / registry)
+                if registry is not None
+                else resolve_registry(proj_root, cfg.ids_file)
+            )
+            sbom_json = _build_sbom_from_project_and_wheel(
+                proj_root, wheel_metadata, cfg, reg, creation_metadata
+            )
+            eff_basename = sbom_basename or cfg.sbom_basename
+        else:
+            sbom_json = _build_sbom_standalone_wheel(
+                wheel_metadata, creation_metadata, registry, provenance, offline
+            )
+            eff_basename = sbom_basename
+
+    target_filename = f"{eff_basename}{_SPDX3_JSON_EXT}" if eff_basename else None
+    res_path, arcname = embed_sbom_in_wheel(
+        wheel_obj, sbom_json, sbom_filename=target_filename
+    )
+
+    if output_path is not None:
+        Path(output_path).write_text(sbom_json, encoding="utf-8")
+
+    return res_path, arcname, sbom_json
+
+
+def _resolve_project_root(project_dir: Path | str | None) -> Path | None:
+    """Resolve project directory if explicitly given or present in cwd."""
+    if project_dir is not None:
+        candidate = Path(project_dir).resolve()
+        if candidate.exists():
+            return candidate
+    cwd_candidate = Path.cwd()
+    for fname in ("pyproject.toml", "setup.cfg", "setup.py"):
+        if (cwd_candidate / fname).exists():
+            return cwd_candidate
+    return None
+
+
+def _apply_config_overrides(
+    cfg: PitloomConfig,
+    *,
+    provenance: ProvenanceConfig | None,
+    enrich: bool | None,
+    extract_file_header: bool | None,
+    content_type: bool | None,
+    content_type_method: str | None,
+    offline: bool | None,
+) -> PitloomConfig:
+    """Apply CLI overrides to PitloomConfig."""
+    changes: dict[str, Any] = {}
+    if provenance is not None:
+        changes["provenance_format"] = provenance.format
+        changes["provenance_schema"] = provenance.schema
+        changes["provenance_detail"] = provenance.detail
+        changes["provenance_preserve_source_metadata"] = (
+            provenance.preserve_source_metadata
+        )
+    if enrich is not None:
+        changes["enrich_local"] = enrich
+    if extract_file_header is not None:
+        changes["extract_file_header"] = extract_file_header
+    if content_type is not None:
+        changes["content_type_enabled"] = content_type
+    if content_type_method is not None:
+        changes["content_type_method"] = content_type_method
+    if offline is not None:
+        changes["offline"] = offline
+    return dataclasses.replace(cfg, **changes)
+
+
+def _build_sbom_standalone_wheel(
+    wheel_metadata: ProjectMetadata,
+    creation_metadata: CreationMetadata | None,
+    registry: str | Path | IdRegistry | None,
+    provenance: ProvenanceConfig | None,
+    offline: bool | None,
+) -> str:
+    """Build SBOM from standalone wheel when no source project dir is present."""
+    cwd = Path.cwd()
+    reg = (
+        registry
+        if isinstance(registry, IdRegistry)
+        else IdRegistry.load(cwd / registry)
+        if registry is not None
+        else resolve_registry(cwd, None)
+    )
+    doc = DocumentModel(
+        project=wheel_metadata,
+        creation_metadata=creation_metadata or CreationMetadata(),
+        ai_models=[],
+        phantom_dependencies=find_phantom_dependencies(wheel_metadata.files),
+    )
+    exporter = assemble_spdx3(
+        doc,
+        merkle_root=None,
+        sbom_type=spdx3.software_SbomType.analyzed,
+        registry=reg,
+        provenance=provenance,
+        offline=offline or False,
+    )
+    return exporter.to_json(pretty=False)
+
+
+__all__ = ["embed_sbom_in_wheel", "embed_wheel_sbom"]

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import base64
 import csv
 import dataclasses
+import email
 import hashlib
 import io
 import os
@@ -254,16 +255,9 @@ def _derive_wheel_sbom_filename(zf: zipfile.ZipFile, dist_info: str) -> str:
     metadata_path = f"{dist_info}METADATA"
     if metadata_path in zf.namelist():
         content = zf.read(metadata_path).decode("utf-8", errors="replace")
-        for line in content.splitlines():
-            lower = line.lower()
-            if lower.startswith("name: ") and not meta_name:
-                meta_name = line.split(":", 1)[1].strip()
-            elif lower.startswith("version: ") and not meta_version:
-                meta_version = line.split(":", 1)[1].strip()
-            elif not line.strip() and (meta_name or meta_version):
-                break
-            if meta_name and meta_version:
-                break
+        msg = email.message_from_string(content)
+        meta_name = msg.get("Name")
+        meta_version = msg.get("Version")
     if meta_name and meta_version:
         return f"{meta_name}-{meta_version}{_SPDX3_JSON_EXT}"
     prefix = dist_info.rstrip("/").removesuffix(".dist-info")
@@ -428,12 +422,7 @@ def embed_wheel_sbom(
             )
             eff_registry = registry if registry is not None else cfg.ids_file
             reg = resolve_registry(proj_root, eff_registry)
-            eff_creation = creation_metadata or CreationMetadata(
-                creators=cfg.creators,
-                tools=cfg.tools,
-                creation_datetime=cfg.creation_datetime,
-                creation_comment=cfg.creation_comment,
-            )
+            eff_creation = creation_metadata or cfg.creation_metadata
             sbom_json = _build_sbom_from_project_and_wheel(
                 proj_root, wheel_metadata, cfg, reg, eff_creation
             )

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -240,63 +240,95 @@ def embed_sbom_in_wheel(
     )
     if not sbom_bytes.strip():
         raise ValueError("SBOM content cannot be empty")
-    sbom_hash = _calculate_record_hash(sbom_bytes)
-    sbom_size = len(sbom_bytes)
 
     with zipfile.ZipFile(wheel_obj, "r") as original_zf:
         dist_info = _find_dist_info_prefix(original_zf, wheel_obj)
-        target_name = (
-            sbom_filename
-            if sbom_filename is not None
-            else _derive_wheel_sbom_filename(original_zf, dist_info)
-        )
-        _validate_sbom_filename(target_name)
-        sbom_arcname = f"{dist_info}sboms/{target_name}"
-        record_arcname = f"{dist_info}RECORD"
-        sboms_prefix = f"{dist_info}sboms/"
-        stale_arcnames = frozenset(
-            name
-            for name in original_zf.namelist()
-            if name.startswith(sboms_prefix)
-            and name.endswith(_SPDX3_JSON_EXT)
-            and name != sbom_arcname
-            and _looks_like_pitloom_sbom(original_zf.read(name))
-        )
-
-        record_info = None
-        for info in original_zf.infolist():
-            if info.filename == record_arcname:
-                record_info = info
-                break
-
-        old_record_text = (
-            original_zf.read(record_arcname).decode("utf-8") if record_info else ""
-        )
-        new_record_text = _update_record_lines(
-            old_record_text,
-            sbom_arcname,
-            sbom_hash,
-            sbom_size,
-            dist_info,
-            stale_arcnames,
-        )
-        new_record_bytes = new_record_text.encode("utf-8")
-
-        timestamp, timestamp_floored = _resolve_zip_timestamp(
-            record_info.date_time if record_info else None
-        )
+        plan = _plan_embed(original_zf, dist_info, sbom_filename, sbom_bytes)
         _rewrite_wheel_archive(
             wheel_obj,
             original_zf,
-            sbom_arcname,
+            plan.sbom_arcname,
             sbom_bytes,
-            record_arcname,
-            new_record_bytes,
-            timestamp,
-            stale_arcnames,
+            plan.record_arcname,
+            plan.new_record_bytes,
+            plan.timestamp,
+            plan.stale_arcnames,
         )
 
-    return wheel_obj, sbom_arcname, tuple(sorted(stale_arcnames)), timestamp_floored
+    return (
+        wheel_obj,
+        plan.sbom_arcname,
+        tuple(sorted(plan.stale_arcnames)),
+        plan.timestamp_floored,
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class _EmbedPlan:
+    """Everything :func:`embed_sbom_in_wheel` needs to rewrite the archive."""
+
+    sbom_arcname: str
+    record_arcname: str
+    new_record_bytes: bytes
+    stale_arcnames: frozenset[str]
+    timestamp: tuple[int, int, int, int, int, int]
+    timestamp_floored: bool
+
+
+def _plan_embed(
+    original_zf: zipfile.ZipFile,
+    dist_info: str,
+    sbom_filename: str | None,
+    sbom_bytes: bytes,
+) -> _EmbedPlan:
+    """Resolve the target arcname, updated RECORD, and ZIP timestamp for an embed."""
+    target_name = (
+        sbom_filename
+        if sbom_filename is not None
+        else _derive_wheel_sbom_filename(original_zf, dist_info)
+    )
+    _validate_sbom_filename(target_name)
+    sbom_arcname = f"{dist_info}sboms/{target_name}"
+    record_arcname = f"{dist_info}RECORD"
+    sboms_prefix = f"{dist_info}sboms/"
+    stale_arcnames = frozenset(
+        name
+        for name in original_zf.namelist()
+        if name.startswith(sboms_prefix)
+        and name.endswith(_SPDX3_JSON_EXT)
+        and name != sbom_arcname
+        and _looks_like_pitloom_sbom(original_zf.read(name))
+    )
+
+    record_info = None
+    for info in original_zf.infolist():
+        if info.filename == record_arcname:
+            record_info = info
+            break
+
+    old_record_text = (
+        original_zf.read(record_arcname).decode("utf-8") if record_info else ""
+    )
+    new_record_text = _update_record_lines(
+        old_record_text,
+        sbom_arcname,
+        _calculate_record_hash(sbom_bytes),
+        len(sbom_bytes),
+        dist_info,
+        stale_arcnames,
+    )
+
+    timestamp, timestamp_floored = _resolve_zip_timestamp(
+        record_info.date_time if record_info else None
+    )
+    return _EmbedPlan(
+        sbom_arcname=sbom_arcname,
+        record_arcname=record_arcname,
+        new_record_bytes=new_record_text.encode("utf-8"),
+        stale_arcnames=stale_arcnames,
+        timestamp=timestamp,
+        timestamp_floored=timestamp_floored,
+    )
 
 
 _INVALID_FILENAME_CHARS = frozenset({"/", "\\", "\x00"})
@@ -432,7 +464,23 @@ def _build_sbom_from_project_and_wheel(
     return exporter.to_json(pretty=False)
 
 
-# pylint: disable=too-many-arguments,too-many-locals,too-many-positional-arguments
+@dataclasses.dataclass(frozen=True)
+class ConfigOverrides:
+    """Per-run overrides layered onto a project's ``[tool.pitloom]`` config.
+
+    Each field defaults to ``None`` (defer to the project's own config, or
+    its own built-in default when there is no project) -- see
+    :func:`_apply_config_overrides`.
+    """
+
+    provenance: ProvenanceConfig | None = None
+    enrich: bool | None = None
+    extract_file_header: bool | None = None
+    content_type: bool | None = None
+    content_type_method: str | None = None
+    offline: bool | None = None
+
+
 def embed_wheel_sbom(
     wheel_path: Path | str,
     *,
@@ -442,12 +490,7 @@ def embed_wheel_sbom(
     sbom_basename: str | None = None,
     creation_metadata: CreationMetadata | None = None,
     registry: str | Path | IdRegistry | None = None,
-    provenance: ProvenanceConfig | None = None,
-    enrich: bool | None = None,
-    extract_file_header: bool | None = None,
-    content_type: bool | None = None,
-    content_type_method: str | None = None,
-    offline: bool | None = None,
+    overrides: ConfigOverrides | None = None,
 ) -> tuple[Path, str, str, tuple[str, ...], bool]:
     """Generate and embed a PEP 770 SBOM into a built Python wheel.
 
@@ -459,13 +502,9 @@ def embed_wheel_sbom(
         sbom_basename: Custom basename for the embedded SBOM file.
         creation_metadata: Optional creation metadata overrides.
         registry: ID registry or path.
-        provenance: Metadata provenance config.
-        enrich: Override enrichment setting.
-        extract_file_header: Override SPDX header extraction.
-        content_type: Override content type detection.
-        content_type_method: Content type detection method
-            ('auto'/'magika'/'extension').
-        offline: Offline mode flag.
+        overrides: Per-run overrides for provenance/enrich/content-type/offline
+            settings, layered onto the project's ``[tool.pitloom]`` config.
+            Defaults to no overrides.
 
     Returns:
         Tuple of (modified_wheel_path, embedded_arcname, sbom_json_string,
@@ -474,41 +513,22 @@ def embed_wheel_sbom(
     """
     wheel_obj = Path(wheel_path).resolve()
     wheel_metadata, _ = read_wheel(wheel_obj)
+    eff_overrides = overrides if overrides is not None else ConfigOverrides()
 
-    if sbom_path is not None:
-        sbom_json = Path(sbom_path).read_text(encoding="utf-8")
-        eff_basename = sbom_basename
-    else:
-        proj_root = _resolve_project_root(project_dir)
-        if proj_root is not None:
-            _, cfg, _ = read_project(proj_root)
-            cfg = _apply_config_overrides(
-                cfg,
-                provenance=provenance,
-                enrich=enrich,
-                extract_file_header=extract_file_header,
-                content_type=content_type,
-                content_type_method=content_type_method,
-                offline=offline,
-            )
-            eff_registry = registry if registry is not None else cfg.ids_file
-            reg = resolve_registry(proj_root, eff_registry)
-            eff_creation = creation_metadata or cfg.creation_metadata
-            sbom_json = _build_sbom_from_project_and_wheel(
-                proj_root, wheel_metadata, cfg, reg, eff_creation
-            )
-            eff_basename = sbom_basename or cfg.sbom_basename
-        else:
-            sbom_json = _build_sbom_standalone_wheel(
-                wheel_metadata, creation_metadata, registry, provenance, offline
-            )
-            eff_basename = sbom_basename
-
-    if eff_basename:
-        eff_clean = eff_basename.removesuffix(_SPDX3_JSON_EXT)
-        target_filename = f"{eff_clean}{_SPDX3_JSON_EXT}"
-    else:
-        target_filename = None
+    sbom_json, eff_basename = _generate_embed_sbom_json(
+        wheel_metadata,
+        project_dir=project_dir,
+        sbom_path=sbom_path,
+        sbom_basename=sbom_basename,
+        creation_metadata=creation_metadata,
+        registry=registry,
+        overrides=eff_overrides,
+    )
+    target_filename = (
+        f"{eff_basename.removesuffix(_SPDX3_JSON_EXT)}{_SPDX3_JSON_EXT}"
+        if eff_basename
+        else None
+    )
 
     res_path, arcname, removed_arcnames, timestamp_floored = embed_sbom_in_wheel(
         wheel_obj, sbom_json, sbom_filename=target_filename
@@ -518,6 +538,46 @@ def embed_wheel_sbom(
         Path(output_path).write_text(sbom_json, encoding="utf-8")
 
     return res_path, arcname, sbom_json, removed_arcnames, timestamp_floored
+
+
+def _generate_embed_sbom_json(
+    wheel_metadata: ProjectMetadata,
+    *,
+    project_dir: Path | str | None,
+    sbom_path: Path | str | None,
+    sbom_basename: str | None,
+    creation_metadata: CreationMetadata | None,
+    registry: str | Path | IdRegistry | None,
+    overrides: ConfigOverrides,
+) -> tuple[str, str | None]:
+    """Resolve the SBOM JSON to embed and its effective basename.
+
+    A pre-generated ``sbom_path`` wins outright; otherwise a source project
+    (if found) drives a Build SBOM, falling back to a standalone Analyzed
+    SBOM from wheel contents alone -- see :func:`embed_wheel_sbom`.
+    """
+    if sbom_path is not None:
+        return Path(sbom_path).read_text(encoding="utf-8"), sbom_basename
+
+    proj_root = _resolve_project_root(project_dir)
+    if proj_root is None:
+        sbom_json = _build_sbom_standalone_wheel(
+            wheel_metadata,
+            creation_metadata,
+            registry,
+            overrides.provenance,
+            overrides.offline,
+        )
+        return sbom_json, sbom_basename
+
+    _, cfg, _ = read_project(proj_root)
+    cfg = _apply_config_overrides(cfg, overrides)
+    eff_registry = registry if registry is not None else cfg.ids_file
+    reg = resolve_registry(proj_root, eff_registry)
+    sbom_json = _build_sbom_from_project_and_wheel(
+        proj_root, wheel_metadata, cfg, reg, creation_metadata or cfg.creation_metadata
+    )
+    return sbom_json, sbom_basename or cfg.sbom_basename
 
 
 def _resolve_project_root(project_dir: Path | str | None) -> Path | None:
@@ -534,39 +594,33 @@ def _resolve_project_root(project_dir: Path | str | None) -> Path | None:
 
 
 def _apply_config_overrides(
-    cfg: PitloomConfig,
-    *,
-    provenance: ProvenanceConfig | None,
-    enrich: bool | None,
-    extract_file_header: bool | None,
-    content_type: bool | None,
-    content_type_method: str | None,
-    offline: bool | None,
+    cfg: PitloomConfig, overrides: ConfigOverrides
 ) -> PitloomConfig:
-    """Apply CLI overrides to PitloomConfig."""
+    """Apply per-run overrides to a PitloomConfig."""
     changes: dict[str, Any] = {}
-    if provenance is not None:
-        changes["provenance_format"] = provenance.format
-        changes["provenance_schema"] = provenance.schema
-        changes["provenance_detail"] = provenance.detail
+    if overrides.provenance is not None:
+        changes["provenance_format"] = overrides.provenance.format
+        changes["provenance_schema"] = overrides.provenance.schema
+        changes["provenance_detail"] = overrides.provenance.detail
         changes["provenance_preserve_source_metadata"] = (
-            provenance.preserve_source_metadata
+            overrides.provenance.preserve_source_metadata
         )
-    if enrich is not None:
-        changes["enrich_local"] = enrich
-    if extract_file_header is not None:
-        changes["extract_file_header"] = extract_file_header
-    if content_type is not None:
-        changes["content_type_enabled"] = content_type
-    if content_type_method is not None:
-        if content_type_method not in VALID_CONTENT_TYPE_METHODS:
+    if overrides.enrich is not None:
+        changes["enrich_local"] = overrides.enrich
+    if overrides.extract_file_header is not None:
+        changes["extract_file_header"] = overrides.extract_file_header
+    if overrides.content_type is not None:
+        changes["content_type_enabled"] = overrides.content_type
+    if overrides.content_type_method is not None:
+        if overrides.content_type_method not in VALID_CONTENT_TYPE_METHODS:
             raise ValueError(
                 "content_type_method must be one of "
-                f"{sorted(VALID_CONTENT_TYPE_METHODS)}, got {content_type_method!r}"
+                f"{sorted(VALID_CONTENT_TYPE_METHODS)}, got "
+                f"{overrides.content_type_method!r}"
             )
-        changes["content_type_method"] = content_type_method
-    if offline is not None:
-        changes["offline"] = offline
+        changes["content_type_method"] = overrides.content_type_method
+    if overrides.offline is not None:
+        changes["offline"] = overrides.offline
     return dataclasses.replace(cfg, **changes)
 
 

--- a/src/pitloom/ids.py
+++ b/src/pitloom/ids.py
@@ -518,26 +518,34 @@ def _iter_files(paths: list[Path], project_root: Path) -> Iterator[Path]:
             yield file_path
 
 
-def resolve_registry(project_dir: Path, ids_file: str | None) -> IdRegistry | None:
+def resolve_registry(
+    project_dir: Path,
+    ids_file: str | Path | IdRegistry | None = None,
+) -> IdRegistry | None:
     """Resolve the registry a project build should consult.
 
-    Shared by the Hatchling build hook and the CLI project-assembly path
-    (see :func:`~pitloom.assemble.generate_project_sbom`) so both use the exact same
-    resolution rule as ``pitloom.loom``: an explicit ``[tool.pitloom]
-    ids-file`` (``ids_file``) is loaded relative to *project_dir*; otherwise
-    ``loom-ids.json`` is auto-discovered by walking up from
-    *project_dir*. Any load failure is logged and degrades to "no registry"
-    -- a missing or broken registry must never fail a build.
+    Shared by the Hatchling build hook, Python API, and CLI project-assembly
+    paths so all use the exact same resolution rule:
+    - An :class:`IdRegistry` instance is returned as-is.
+    - A ``str`` or :class:`pathlib.Path` is loaded (relative to *project_dir* if
+      relative, or directly if absolute).
+    - ``None`` auto-discovers ``loom-ids.json`` by walking up from *project_dir*.
+
+    Any load failure is logged and degrades to "no registry" (``None``) --
+    a missing or broken registry must never fail a build.
 
     Args:
         project_dir: Project root directory.
-        ids_file: ``[tool.pitloom] ids-file`` value, or ``None``.
+        ids_file: File path, config string, :class:`IdRegistry`, or ``None``.
 
     Returns:
         The loaded :class:`IdRegistry`, or ``None`` if none is configured/found.
     """
+    if isinstance(ids_file, IdRegistry):
+        return ids_file
     if ids_file is not None:
-        registry_path = project_dir / ids_file
+        path = Path(ids_file)
+        registry_path = path if path.is_absolute() else project_dir / path
         try:
             return IdRegistry.load(registry_path)
         except (FileNotFoundError, ValueError, OSError) as exc:

--- a/src/pitloom/loom.py
+++ b/src/pitloom/loom.py
@@ -23,7 +23,7 @@ from pitloom.core.models import generate_spdx_id
 from pitloom.core.provenance import ProvenanceConfig
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 from pitloom.extract._extract_utils import sanitize_provenance_text
-from pitloom.ids import IdRegistry
+from pitloom.ids import IdRegistry, resolve_registry
 
 #: loom.py is a standalone SDK invoked from ad hoc scripts/notebooks, not
 #: through a pyproject.toml-based [tool.pitloom.provenance] config -- so
@@ -133,15 +133,7 @@ def _resolve_registry(
     logged and degrades to "no registry" rather than raising -- a missing or
     broken registry must never break a training/preprocessing run.
     """
-    if isinstance(registry, IdRegistry):
-        return registry
-    if registry is not None:
-        try:
-            return IdRegistry.load(Path(registry))
-        except (FileNotFoundError, ValueError, OSError) as exc:
-            log.warning("loom: could not load registry %s: %s", registry, exc)
-            return None
-    return IdRegistry.find()
+    return resolve_registry(Path.cwd(), registry)
 
 
 def _hash_and_registry_lookup(

--- a/src/pitloom/plugins/hatch.py
+++ b/src/pitloom/plugins/hatch.py
@@ -84,17 +84,18 @@ def _check_hatchling_sbom_support() -> None:
 def _resolve_build_datetime(pitloom_config: PitloomConfig) -> str:
     """Resolve the ``builtTime`` stamped on the main package.
 
-    Priority: the standard reproducible-builds ``SOURCE_DATE_EPOCH``
-    environment variable, then a pinned ``[tool.pitloom.creation]``
-    ``creation-datetime``, then the current UTC time.  With either of the
+    Priority: a pinned ``[tool.pitloom.creation]`` ``creation-datetime``
+    (a deliberate, explicit pin -- more specific than an ambient env var,
+    so it wins), then the standard reproducible-builds ``SOURCE_DATE_EPOCH``
+    environment variable, then the current UTC time.  With either of the
     first two, repeated builds of unchanged sources produce byte-identical
     SBOMs (and therefore byte-identical wheels).
     """
+    if pitloom_config.creation_datetime:
+        return pitloom_config.creation_datetime
     epoch_dt = resolve_source_date_epoch()
     if epoch_dt is not None:
         return to_spdx3_datetime(epoch_dt).isoformat()
-    if pitloom_config.creation_datetime:
-        return pitloom_config.creation_datetime
     return to_spdx3_datetime(datetime.now(timezone.utc)).isoformat()
 
 

--- a/src/pitloom/plugins/hatch.py
+++ b/src/pitloom/plugins/hatch.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import os
 import tempfile
@@ -111,15 +112,13 @@ def _build_creation_metadata(pitloom_config: PitloomConfig) -> CreationMetadata:
     and ``tools`` -> ``[Pitloom]`` -- matching the CLI.
     """
     comment = pitloom_config.creation_comment
-    return CreationMetadata(
-        creators=pitloom_config.creators,
-        tools=pitloom_config.tools,
+    return dataclasses.replace(
+        pitloom_config.creation_metadata,
         creation_comment=(
             comment
             if comment is not None
             else "Generated via Pitloom Hatchling build hook (PEP 770)"
         ),
-        creation_datetime=pitloom_config.creation_datetime,
         build_datetime=_resolve_build_datetime(pitloom_config),
     )
 

--- a/src/pitloom/plugins/hatch.py
+++ b/src/pitloom/plugins/hatch.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-import os
 import tempfile
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError
@@ -27,7 +26,7 @@ from pitloom.assemble.spdx3.creation_info import to_spdx3_datetime
 from pitloom.assemble.spdx3.document import build as assemble_spdx3
 from pitloom.assemble.spdx3.fragments import merge_fragments
 from pitloom.core.config import PitloomConfig, read_pitloom_config
-from pitloom.core.creation import CreationMetadata
+from pitloom.core.creation import CreationMetadata, resolve_source_date_epoch
 from pitloom.core.document import DocumentModel
 from pitloom.core.models import get_wheel_files
 from pitloom.enrich import run_enrichers_for_models
@@ -91,13 +90,9 @@ def _resolve_build_datetime(pitloom_config: PitloomConfig) -> str:
     first two, repeated builds of unchanged sources produce byte-identical
     SBOMs (and therefore byte-identical wheels).
     """
-    source_date_epoch = os.environ.get("SOURCE_DATE_EPOCH")
-    if source_date_epoch:
-        try:
-            stamp = datetime.fromtimestamp(int(source_date_epoch), tz=timezone.utc)
-            return to_spdx3_datetime(stamp).isoformat()
-        except (ValueError, OverflowError, OSError) as exc:
-            log.warning("Ignoring invalid SOURCE_DATE_EPOCH: %s", exc)
+    epoch_dt = resolve_source_date_epoch()
+    if epoch_dt is not None:
+        return to_spdx3_datetime(epoch_dt).isoformat()
     if pitloom_config.creation_datetime:
         return pitloom_config.creation_datetime
     return to_spdx3_datetime(datetime.now(timezone.utc)).isoformat()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,7 @@ import pytest
 
 from pitloom.core.config import (
     VALID_CONTENT_TYPE_METHODS,
+    PitloomConfig,
     _read_content_type_settings,
     _read_enrich_settings,
     _read_extract_file_header,
@@ -18,6 +19,7 @@ from pitloom.core.config import (
     _read_pitloom_config,
 )
 from pitloom.core.content_type_config import ContentTypeOverride
+from pitloom.core.creation import Creator, Tool
 
 # ---------------------------------------------------------------------------
 # _read_extract_file_header
@@ -282,14 +284,11 @@ def test_valid_content_type_methods_is_public() -> None:
 
 def test_pitloom_config_helper_properties() -> None:
     """Test PitloomConfig properties convert scalar fields to model objects."""
-    from pitloom.core.config import PitloomConfig
-    from pitloom.core.creation import Creator, Tool
-
     cfg = PitloomConfig(
         provenance_format="annotation",
         provenance_schema="spdx3",
         provenance_detail="full",
-        provenance_preserve_source_metadata=True,
+        provenance_preserve_source_metadata="always",
         content_type_enabled=True,
         content_type_method="magika",
         enrich_local=True,
@@ -303,7 +302,7 @@ def test_pitloom_config_helper_properties() -> None:
     assert prov.format == "annotation"
     assert prov.schema == "spdx3"
     assert prov.detail == "full"
-    assert prov.preserve_source_metadata is True
+    assert prov.preserve_source_metadata == "always"
 
     ct = cfg.content_type
     assert ct.enabled is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -278,3 +278,43 @@ def test_new_style_config_unaffected_by_moved_keys_guard() -> None:
 
 def test_valid_content_type_methods_is_public() -> None:
     assert VALID_CONTENT_TYPE_METHODS == frozenset({"auto", "magika", "extension"})
+
+
+def test_pitloom_config_helper_properties() -> None:
+    """Test PitloomConfig properties convert scalar fields to model objects."""
+    from pitloom.core.config import PitloomConfig
+    from pitloom.core.creation import Creator, Tool
+
+    cfg = PitloomConfig(
+        provenance_format="annotation",
+        provenance_schema="spdx3",
+        provenance_detail="full",
+        provenance_preserve_source_metadata=True,
+        content_type_enabled=True,
+        content_type_method="magika",
+        enrich_local=True,
+        creators=[Creator(name="Alice", type="person")],
+        tools=[Tool(name="Pitloom")],
+        creation_datetime="2026-08-14T00:00:00Z",
+        creation_comment="Test comment",
+    )
+
+    prov = cfg.provenance
+    assert prov.format == "annotation"
+    assert prov.schema == "spdx3"
+    assert prov.detail == "full"
+    assert prov.preserve_source_metadata is True
+
+    ct = cfg.content_type
+    assert ct.enabled is True
+    assert ct.method == "magika"
+
+    enrich = cfg.enrich
+    assert enrich.local is True
+
+    creation = cfg.creation_metadata
+    assert len(creation.creators) == 1
+    assert creation.creators[0].name == "Alice"
+    assert creation.tools is not None and len(creation.tools) == 1
+    assert creation.creation_datetime == "2026-08-14T00:00:00Z"
+    assert creation.creation_comment == "Test comment"

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -1,0 +1,49 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Direct unit tests for pitloom.core.creation."""
+
+# pylint: disable=missing-function-docstring
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from pitloom.core.creation import resolve_source_date_epoch
+
+
+def test_resolve_source_date_epoch_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+    assert resolve_source_date_epoch() is None
+
+
+def test_resolve_source_date_epoch_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "1700000000")
+    assert resolve_source_date_epoch() == datetime(
+        2023, 11, 14, 22, 13, 20, tzinfo=timezone.utc
+    )
+
+
+def test_resolve_source_date_epoch_invalid_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "not-a-number")
+    assert resolve_source_date_epoch() is None
+
+
+def test_resolve_source_date_epoch_overflow_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "99999999999999999999999999999999999")
+    assert resolve_source_date_epoch() is None
+
+
+def test_resolve_source_date_epoch_empty_string_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "")
+    assert resolve_source_date_epoch() is None

--- a/tests/test_creation_info.py
+++ b/tests/test_creation_info.py
@@ -217,14 +217,15 @@ def test_build_creation_info_source_date_epoch_used(
     assert spdx_ci.created == datetime(2023, 11, 14, 22, 13, 20, tzinfo=timezone.utc)
 
 
-def test_build_creation_info_source_date_epoch_overrides_explicit_datetime(
+def test_build_creation_info_explicit_datetime_overrides_source_date_epoch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """SOURCE_DATE_EPOCH wins over a pinned creation_datetime, matching the
-    Hatchling build hook's build_datetime priority -- a build environment's
-    reproducibility setting isn't silently defeated by a stale config pin.
+    """A pinned creation_datetime wins over SOURCE_DATE_EPOCH, matching the
+    Hatchling build hook's build_datetime priority -- an explicit, deliberate
+    per-SBOM pin is more specific than the ambient, workspace-wide
+    SOURCE_DATE_EPOCH signal, so it wins.
     """
     monkeypatch.setenv("SOURCE_DATE_EPOCH", "1700000000")
     metadata = CreationMetadata(creation_datetime="2026-03-01T00:00:00Z")
     spdx_ci, _agents, _tools = build_creation_info(metadata, _DOC_NAME, _DOC_UUID)
-    assert spdx_ci.created == datetime(2023, 11, 14, 22, 13, 20, tzinfo=timezone.utc)
+    assert spdx_ci.created == datetime(2026, 3, 1, tzinfo=timezone.utc)

--- a/tests/test_creation_info.py
+++ b/tests/test_creation_info.py
@@ -204,3 +204,27 @@ def test_build_creation_info_explicit_datetime_used() -> None:
     metadata = CreationMetadata(creation_datetime="2026-03-01T00:00:00Z")
     spdx_ci, _agents, _tools = build_creation_info(metadata, _DOC_NAME, _DOC_UUID)
     assert spdx_ci.created == datetime(2026, 3, 1, tzinfo=timezone.utc)
+
+
+def test_build_creation_info_source_date_epoch_used(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SOURCE_DATE_EPOCH (reproducible-builds.org) sets `created` when unpinned."""
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "1700000000")
+    spdx_ci, _agents, _tools = build_creation_info(
+        CreationMetadata(), _DOC_NAME, _DOC_UUID
+    )
+    assert spdx_ci.created == datetime(2023, 11, 14, 22, 13, 20, tzinfo=timezone.utc)
+
+
+def test_build_creation_info_source_date_epoch_overrides_explicit_datetime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SOURCE_DATE_EPOCH wins over a pinned creation_datetime, matching the
+    Hatchling build hook's build_datetime priority -- a build environment's
+    reproducibility setting isn't silently defeated by a stale config pin.
+    """
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "1700000000")
+    metadata = CreationMetadata(creation_datetime="2026-03-01T00:00:00Z")
+    spdx_ci, _agents, _tools = build_creation_info(metadata, _DOC_NAME, _DOC_UUID)
+    assert spdx_ci.created == datetime(2023, 11, 14, 22, 13, 20, tzinfo=timezone.utc)

--- a/tests/test_deps_enrichment.py
+++ b/tests/test_deps_enrichment.py
@@ -23,7 +23,7 @@ import time
 from collections.abc import Iterator
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from spdx_python_model.bindings import v3_0_1 as spdx3
@@ -96,7 +96,7 @@ class _FakeMetadata:
         return item in self._fields
 
     def __getitem__(self, key: str) -> str:
-        return self._fields.get(key)  # type: ignore[return-value]
+        return cast(str, self._fields.get(key))
 
     def __iter__(self) -> Iterator[str]:
         return iter(self._fields)

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import os
+import stat
 import subprocess
 import sys
 import tempfile
@@ -21,7 +23,23 @@ import pytest
 from installer.sources import WheelFile
 
 from pitloom import __main__
-from pitloom.embed import embed_sbom_in_wheel, embed_wheel_sbom
+from pitloom.core.config import PitloomConfig
+from pitloom.core.project import ProjectMetadata
+from pitloom.core.provenance import ProvenanceConfig
+from pitloom.embed import (
+    _apply_config_overrides,
+    _build_sbom_standalone_wheel,
+    _derive_wheel_sbom_filename,
+    _find_dist_info_prefix,
+    _resolve_project_root,
+    _resolve_zip_timestamp,
+    _rewrite_wheel_archive,
+    _update_record_lines,
+    _validate_sbom_filename,
+    embed_sbom_in_wheel,
+    embed_wheel_sbom,
+)
+from pitloom.ids import IdRegistry
 
 _SAMPLE_SPDX3_JSON = json.dumps(
     {
@@ -330,10 +348,8 @@ def test_cli_wheel_embed_flag(
         wf.validate_record()
 
 
-def test_validate_sbom_filename_edge_cases(tmp_path: Path) -> None:
+def test_validate_sbom_filename_edge_cases() -> None:
     """Test _validate_sbom_filename rejects null bytes, traversal, and whitespace."""
-    from pitloom.embed import _validate_sbom_filename
-
     for bad in ("", "   ", "\x00", "a/b", "a\\b", "..", "."):
         with pytest.raises(ValueError, match="Invalid SBOM filename"):
             _validate_sbom_filename(bad)
@@ -406,9 +422,6 @@ def test_embed_sbom_empty_content_raises(tmp_path: Path) -> None:
 
 def test_embed_sbom_preserves_file_permissions(tmp_path: Path) -> None:
     """Test embed_sbom_in_wheel preserves original filesystem permissions."""
-    import os
-    import stat
-
     wheel_path = _make_dummy_wheel(tmp_path, "perm_pkg", "1.0.0")
     target_mode = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH  # 0o644
     os.chmod(wheel_path, target_mode)
@@ -423,8 +436,6 @@ def test_cli_and_api_produce_identical_artifacts(
     tmp_path: Path,
 ) -> None:
     """Verify CLI and Python API produce bit-for-bit identical wheels and SBOMs."""
-    import zipfile
-
     monkeypatch.setenv("SOURCE_DATE_EPOCH", "1700000000")
     monkeypatch.chdir(tmp_path)
 
@@ -476,8 +487,6 @@ type = "person"
 
 def test_find_dist_info_prefix_edge_cases(tmp_path: Path) -> None:
     """Test _find_dist_info_prefix with single, matching, and ambiguous dist-infos."""
-    from pitloom.embed import _find_dist_info_prefix
-
     # 1. No dist-info
     p1 = tmp_path / "nodist-1.0.0-py3-none-any.whl"
     with zipfile.ZipFile(p1, "w") as zf:
@@ -506,8 +515,6 @@ def test_find_dist_info_prefix_edge_cases(tmp_path: Path) -> None:
 
 def test_resolve_zip_timestamp_branches(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test _resolve_zip_timestamp under various invalid/fallback conditions."""
-    from pitloom.embed import _resolve_zip_timestamp
-
     # Invalid string in SOURCE_DATE_EPOCH
     monkeypatch.setenv("SOURCE_DATE_EPOCH", "not-a-number")
     ts = _resolve_zip_timestamp(fallback=(1990, 5, 1, 12, 0, 0))
@@ -530,8 +537,6 @@ def test_resolve_zip_timestamp_branches(monkeypatch: pytest.MonkeyPatch) -> None
 
 def test_update_record_lines_empty_rows() -> None:
     """Test _update_record_lines skips empty rows in RECORD string."""
-    from pitloom.embed import _update_record_lines
-
     raw_record = "pkg/__init__.py,sha256=abc,10\n\n\npkg-1.0.dist-info/RECORD,,\n"
     updated = _update_record_lines(
         raw_record,
@@ -573,8 +578,6 @@ def test_embed_sbom_without_existing_record(tmp_path: Path) -> None:
 
 def test_derive_wheel_sbom_filename_fallbacks(tmp_path: Path) -> None:
     """Test _derive_wheel_sbom_filename metadata missing/empty header fallbacks."""
-    from pitloom.embed import _derive_wheel_sbom_filename
-
     # 1. No METADATA in archive -> fall back to dist-info name prefix
     p1 = tmp_path / "nometa-1.0.0-py3-none-any.whl"
     with zipfile.ZipFile(p1, "w") as zf:
@@ -647,8 +650,6 @@ def test_rewrite_wheel_archive_temp_file_cleanup_on_error(
 
 def test_resolve_project_root_non_existent(tmp_path: Path) -> None:
     """Test _resolve_project_root when non-existent path or empty directory."""
-    from pitloom.embed import _resolve_project_root
-
     # Non-existent explicit project_dir falls back to checking cwd
     res = _resolve_project_root(tmp_path / "does_not_exist")
     assert res is None or res.exists()
@@ -656,16 +657,12 @@ def test_resolve_project_root_non_existent(tmp_path: Path) -> None:
 
 def test_apply_config_overrides_full() -> None:
     """Test _apply_config_overrides applies all CLI override parameters."""
-    from pitloom.core.config import PitloomConfig
-    from pitloom.core.provenance import ProvenanceConfig
-    from pitloom.embed import _apply_config_overrides
-
     cfg = PitloomConfig()
     prov = ProvenanceConfig(
         format="fields",
         schema="https://example.com/schema",
         detail="full",
-        preserve_source_metadata=True,
+        preserve_source_metadata="always",
     )
     overridden = _apply_config_overrides(
         cfg,
@@ -679,7 +676,7 @@ def test_apply_config_overrides_full() -> None:
     assert overridden.provenance_format == "fields"
     assert overridden.provenance_schema == "https://example.com/schema"
     assert overridden.provenance_detail == "full"
-    assert overridden.provenance_preserve_source_metadata is True
+    assert overridden.provenance_preserve_source_metadata == "always"
     assert overridden.enrich_local is True
     assert overridden.extract_file_header is False
     assert overridden.content_type.enabled is True
@@ -700,10 +697,6 @@ def test_apply_config_overrides_full() -> None:
 
 def test_build_sbom_standalone_wheel_registry_options(tmp_path: Path) -> None:
     """Test _build_sbom_standalone_wheel with various registry options."""
-    from pitloom.core.project import ProjectMetadata
-    from pitloom.embed import _build_sbom_standalone_wheel
-    from pitloom.ids import IdRegistry
-
     meta = ProjectMetadata(name="standalonereg", version="1.0.0", files=[])
 
     # 1. IdRegistry instance with namespace
@@ -752,7 +745,6 @@ def test_embed_sbom_drops_stale_sboms_from_archive(tmp_path: Path) -> None:
 
 def test_rewrite_wheel_archive_orig_mode_none(tmp_path: Path) -> None:
     """Test _rewrite_wheel_archive handles non-existent wheel path without error."""
-    from pitloom.embed import _rewrite_wheel_archive
 
     source_wheel = _make_dummy_wheel(tmp_path, "orig_mode_pkg", "1.0.0")
     target_wheel = tmp_path / "new_target.whl"
@@ -768,3 +760,206 @@ def test_rewrite_wheel_archive_orig_mode_none(tmp_path: Path) -> None:
             (2026, 1, 1, 0, 0, 0),
         )
     assert target_wheel.exists()
+
+
+def test_cli_collect_wheel_paths_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test CLI error handling for non-existent and non-whl paths."""
+    not_a_whl = tmp_path / "test.txt"
+    not_a_whl.write_text("hello", encoding="utf-8")
+    non_existent = tmp_path / "missing.whl"
+
+    # 1. Non-existent literal file
+    monkeypatch.setattr(sys, "argv", ["loom", "embed-wheel", str(non_existent)])
+    assert __main__.main() == 1
+    err = capsys.readouterr().err
+    assert "ERROR: wheel file not found" in err
+
+    # 2. Not a .whl file
+    monkeypatch.setattr(sys, "argv", ["loom", "embed-wheel", str(not_a_whl)])
+    assert __main__.main() == 1
+    err = capsys.readouterr().err
+    assert "ERROR: not a .whl file" in err
+
+    # 3. Glob matching no wheels
+    monkeypatch.setattr(
+        sys, "argv", ["loom", "embed-wheel", str(tmp_path / "empty_dir/*.whl")]
+    )
+    assert __main__.main() == 1
+    err = capsys.readouterr().err
+    assert "ERROR: no wheel files matched" in err
+
+
+def test_cli_embed_wheel_multiple_with_output_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test multiple wheels with -o option returns error."""
+    w1 = _make_dummy_wheel(tmp_path, "pkg_one", "1.0.0")
+    w2 = _make_dummy_wheel(tmp_path, "pkg_two", "1.0.0")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["loom", "embed-wheel", str(w1), str(w2), "-o", str(tmp_path / "out.json")],
+    )
+    assert __main__.main() == 1
+    err = capsys.readouterr().err
+    assert "ERROR: --output cannot be used when embedding multiple wheels" in err
+
+
+def test_cli_embed_wheel_project_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test CLI with explicit --project-dir."""
+    wheel_path = _make_dummy_wheel(tmp_path, "projdirpkg", "1.0.0")
+    fixture_dir = (
+        Path(__file__).parent / "fixtures" / "projects" / "sampleproject-hatchling"
+    )
+
+    # 1. Non-existent project directory
+    missing_dir = tmp_path / "no_such_proj_dir"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["loom", "embed-wheel", str(wheel_path), "--project-dir", str(missing_dir)],
+    )
+    assert __main__.main() == 1
+    err = capsys.readouterr().err
+    assert "ERROR: project directory not found" in err
+
+    # 2. Valid project directory
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["loom", "embed-wheel", str(wheel_path), "--project-dir", str(fixture_dir)],
+    )
+    assert __main__.main() == 0
+    out = capsys.readouterr().out
+    assert "pitloom: embedded" in out
+
+
+def test_cli_embed_wheel_pregenerated_sbom(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test CLI embedding a pregenerated SBOM file with --sbom."""
+    wheel_path = _make_dummy_wheel(tmp_path, "pregenpkg", "1.0.0")
+    sbom_file = tmp_path / "custom_sbom.spdx3.json"
+    sbom_file.write_text(_SAMPLE_SPDX3_JSON, encoding="utf-8")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "loom",
+            "embed-wheel",
+            str(wheel_path),
+            "--sbom",
+            str(sbom_file),
+            "--sbom-basename",
+            "embedded_pregen.spdx3.json",
+        ],
+    )
+    assert __main__.main() == 0
+    out = capsys.readouterr().out
+    assert "embedded_pregen.spdx3.json" in out
+
+    with zipfile.ZipFile(wheel_path, "r") as zf:
+        assert (
+            "pregenpkg-1.0.0.dist-info/sboms/embedded_pregen.spdx3.json"
+            in zf.namelist()
+        )
+
+
+def test_cli_wheel_embed_verbose_and_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test `loom wheel --embed` with --verbose and explicit -o."""
+    wheel_path = _make_dummy_wheel(tmp_path, "verbosepkg", "1.0.0")
+    out_file = tmp_path / "standalone.spdx3.json"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "loom",
+            "wheel",
+            str(wheel_path),
+            "--embed",
+            "-v",
+            "-o",
+            str(out_file),
+        ],
+    )
+    assert __main__.main() == 0
+    captured = capsys.readouterr()
+    assert "Output path" in captured.out
+    assert out_file.exists()
+
+
+def test_cli_embed_wheel_error_verbose(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test CLI error logging and traceback on failure with --verbose."""
+    bad_wheel = tmp_path / "corrupt.whl"
+    bad_wheel.write_bytes(b"not a zip file")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["loom", "embed-wheel", str(bad_wheel), "-v"],
+    )
+    assert __main__.main() == 1
+    err = capsys.readouterr().err
+    assert "ERROR: wheel SBOM embedding failed" in err
+
+
+def test_cli_wheel_embed_error_verbose(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test `loom wheel --embed` failure with --verbose."""
+    bad_wheel = tmp_path / "corrupt.whl"
+    bad_wheel.write_bytes(b"not a zip file")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["loom", "wheel", str(bad_wheel), "--embed", "-v"],
+    )
+    assert __main__.main() == 1
+    err = capsys.readouterr().err
+    assert "ERROR: wheel SBOM generation failed" in err
+
+
+def test_cli_embed_wheel_project_dir_without_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test CLI fallback when project directory exists but has no pyproject.toml."""
+    wheel_path = _make_dummy_wheel(tmp_path, "nometa_pkg", "1.0.0")
+    empty_dir = tmp_path / "empty_project_dir"
+    empty_dir.mkdir()
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["loom", "embed-wheel", str(wheel_path), "--project-dir", str(empty_dir)],
+    )
+    assert __main__.main() == 1
+    err = capsys.readouterr().err
+    assert "No pyproject.toml" in err

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -126,7 +126,7 @@ def test_embed_sbom_in_wheel_minimal(tmp_path: Path) -> None:
     """Test embedding an SBOM into a minimal wheel."""
     wheel_path = _make_dummy_wheel(tmp_path, "demo_pkg", "1.0.0")
 
-    res_path, arcname = embed_sbom_in_wheel(wheel_path, _SAMPLE_SPDX3_JSON)
+    res_path, arcname, _ = embed_sbom_in_wheel(wheel_path, _SAMPLE_SPDX3_JSON)
     assert res_path == wheel_path
     assert arcname == "demo_pkg-1.0.0.dist-info/sboms/demo_pkg-1.0.0.spdx3.json"
 
@@ -173,7 +173,7 @@ def test_embed_sbom_in_wheel_custom_filename(tmp_path: Path) -> None:
     """Test embedding with custom sbom_filename."""
     wheel_path = _make_dummy_wheel(tmp_path, "my_app", "2.1.0")
 
-    _, arcname = embed_sbom_in_wheel(
+    _, arcname, _ = embed_sbom_in_wheel(
         wheel_path,
         _SAMPLE_SPDX3_JSON,
         sbom_filename="custom_sbom.spdx3.json",
@@ -239,7 +239,7 @@ def test_embed_wheel_sbom_with_pregenerated_sbom(tmp_path: Path) -> None:
     sbom_file.write_text(_SAMPLE_SPDX3_JSON, encoding="utf-8")
     out_file = tmp_path / "extracted_sbom.json"
 
-    res_path, arcname, sbom_json = embed_wheel_sbom(
+    res_path, arcname, sbom_json, _ = embed_wheel_sbom(
         wheel_path,
         sbom_path=sbom_file,
         output_path=out_file,
@@ -263,7 +263,7 @@ def test_embed_wheel_sbom_with_project_fixture(tmp_path: Path) -> None:
 
     wheel_path = _make_dummy_wheel(tmp_path, "sampleproject_hatchling", "0.1.0")
 
-    res_path, arcname, sbom_json = embed_wheel_sbom(
+    res_path, arcname, sbom_json, _ = embed_wheel_sbom(
         wheel_path,
         project_dir=fixture_dir,
     )
@@ -358,7 +358,7 @@ def test_validate_sbom_filename_edge_cases() -> None:
 def test_embed_wheel_sbom_basename_with_extension_normalized(tmp_path: Path) -> None:
     """Test custom basename already ending with .spdx3.json avoids double extension."""
     wheel_path = _make_dummy_wheel(tmp_path, "extpkg", "1.0.0")
-    _, arcname, _ = embed_wheel_sbom(
+    _, arcname, _, _ = embed_wheel_sbom(
         wheel_path,
         sbom_basename="custom.spdx3.json",
     )
@@ -466,7 +466,7 @@ type = "person"
     assert __main__.main() == 0
 
     # Run via Python API
-    _, arcname_api, sbom_json_api = embed_wheel_sbom(w_api)
+    _, arcname_api, sbom_json_api, _ = embed_wheel_sbom(w_api)
 
     # Compare embedded SBOM contents
     with zipfile.ZipFile(w_cli, "r") as z_cli, zipfile.ZipFile(w_api, "r") as z_api:

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -15,6 +15,7 @@ import sys
 import tempfile
 import zipfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 from installer.sources import WheelFile
@@ -471,3 +472,299 @@ type = "person"
 
     # Compare entire wheel binary bytes
     assert w_cli.read_bytes() == w_api.read_bytes()
+
+
+def test_find_dist_info_prefix_edge_cases(tmp_path: Path) -> None:
+    """Test _find_dist_info_prefix with single, matching, and ambiguous dist-infos."""
+    from pitloom.embed import _find_dist_info_prefix
+
+    # 1. No dist-info
+    p1 = tmp_path / "nodist-1.0.0-py3-none-any.whl"
+    with zipfile.ZipFile(p1, "w") as zf:
+        zf.writestr("nodist/module.py", "# code")
+    with zipfile.ZipFile(p1, "r") as zf:
+        with pytest.raises(ValueError, match="no .dist-info directory found"):
+            _find_dist_info_prefix(zf, p1)
+
+    # 2. Multiple dist-info where one matches stem prefix
+    p2 = tmp_path / "mypkg-1.0.0-py3-none-any.whl"
+    with zipfile.ZipFile(p2, "w") as zf:
+        zf.writestr("mypkg-1.0.0.dist-info/METADATA", "Name: mypkg\nVersion: 1.0.0\n")
+        zf.writestr("other-1.0.0.dist-info/METADATA", "Name: other\nVersion: 1.0.0\n")
+    with zipfile.ZipFile(p2, "r") as zf:
+        assert _find_dist_info_prefix(zf, p2) == "mypkg-1.0.0.dist-info/"
+
+    # 3. Multiple dist-info where none or multiple match stem prefix
+    p3 = tmp_path / "unmatched-1.0.0-py3-none-any.whl"
+    with zipfile.ZipFile(p3, "w") as zf:
+        zf.writestr("pkg1-1.0.0.dist-info/METADATA", "Name: pkg1\n")
+        zf.writestr("pkg2-1.0.0.dist-info/METADATA", "Name: pkg2\n")
+    with zipfile.ZipFile(p3, "r") as zf:
+        with pytest.raises(ValueError, match="multiple .dist-info directories found"):
+            _find_dist_info_prefix(zf, p3)
+
+
+def test_resolve_zip_timestamp_branches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test _resolve_zip_timestamp under various invalid/fallback conditions."""
+    from pitloom.embed import _resolve_zip_timestamp
+
+    # Invalid string in SOURCE_DATE_EPOCH
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "not-a-number")
+    ts = _resolve_zip_timestamp(fallback=(1990, 5, 1, 12, 0, 0))
+    assert ts == (1990, 5, 1, 12, 0, 0)
+
+    # Overflow in SOURCE_DATE_EPOCH
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "99999999999999999999999999999999999")
+    ts_overflow = _resolve_zip_timestamp(fallback=(1995, 1, 1, 0, 0, 0))
+    assert ts_overflow == (1995, 1, 1, 0, 0, 0)
+
+    # Fallback with year < 1980 clamped to 1980
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+    ts_clamped = _resolve_zip_timestamp(fallback=(1970, 1, 1, 0, 0, 0))
+    assert ts_clamped == (1980, 1, 1, 0, 0, 0)
+
+    # Fallback None uses current time
+    ts_now = _resolve_zip_timestamp(fallback=None)
+    assert ts_now[0] >= 2026
+
+
+def test_update_record_lines_empty_rows() -> None:
+    """Test _update_record_lines skips empty rows in RECORD string."""
+    from pitloom.embed import _update_record_lines
+
+    raw_record = "pkg/__init__.py,sha256=abc,10\n\n\npkg-1.0.dist-info/RECORD,,\n"
+    updated = _update_record_lines(
+        raw_record,
+        "pkg-1.0.dist-info/sboms/pkg.spdx3.json",
+        "hash123",
+        100,
+        "pkg-1.0.dist-info/",
+    )
+    assert "pkg-1.0.dist-info/sboms/pkg.spdx3.json,sha256=hash123,100" in updated
+    assert "pkg-1.0.dist-info/RECORD,," in updated
+
+
+def test_embed_sbom_file_not_found(tmp_path: Path) -> None:
+    """Test embed_sbom_in_wheel raises FileNotFoundError for missing wheel."""
+    missing_wheel = tmp_path / "does_not_exist.whl"
+    with pytest.raises(FileNotFoundError, match="Wheel file not found"):
+        embed_sbom_in_wheel(missing_wheel, "{}")
+
+
+def test_embed_sbom_without_existing_record(tmp_path: Path) -> None:
+    """Test embed_sbom_in_wheel handles a wheel archive with no RECORD entry."""
+    wheel_path = tmp_path / "norec-1.0.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel_path, "w") as zf:
+        zf.writestr(
+            "norec-1.0.0.dist-info/METADATA",
+            "Name: norec\nVersion: 1.0.0\n",
+        )
+        zf.writestr("norec/__init__.py", "# empty\n")
+
+    embed_sbom_in_wheel(wheel_path, _SAMPLE_SPDX3_JSON)
+
+    with zipfile.ZipFile(wheel_path, "r") as zf:
+        assert "norec-1.0.0.dist-info/sboms/norec-1.0.0.spdx3.json" in zf.namelist()
+        assert "norec-1.0.0.dist-info/RECORD" in zf.namelist()
+        rec_text = zf.read("norec-1.0.0.dist-info/RECORD").decode("utf-8")
+        assert "norec-1.0.0.dist-info/sboms/norec-1.0.0.spdx3.json" in rec_text
+        assert "norec-1.0.0.dist-info/RECORD,," in rec_text
+
+
+def test_derive_wheel_sbom_filename_fallbacks(tmp_path: Path) -> None:
+    """Test _derive_wheel_sbom_filename metadata missing/empty header fallbacks."""
+    from pitloom.embed import _derive_wheel_sbom_filename
+
+    # 1. No METADATA in archive -> fall back to dist-info name prefix
+    p1 = tmp_path / "nometa-1.0.0-py3-none-any.whl"
+    with zipfile.ZipFile(p1, "w") as zf:
+        zf.writestr("nometa-1.0.0.dist-info/WHEEL", "Wheel-Version: 1.0\n")
+    with zipfile.ZipFile(p1, "r") as zf:
+        fn1 = _derive_wheel_sbom_filename(zf, "nometa-1.0.0.dist-info/")
+        assert fn1 == "nometa-1.0.0.spdx3.json"
+
+    # 2. METADATA with no Name or Version headers -> fall back to dist-info prefix
+    p2 = tmp_path / "emptyheaders-1.0.0-py3-none-any.whl"
+    with zipfile.ZipFile(p2, "w") as zf:
+        zf.writestr(
+            "emptyheaders-1.0.0.dist-info/METADATA",
+            "Summary: A summary\nAuthor: Author\n",
+        )
+    with zipfile.ZipFile(p2, "r") as zf:
+        fn2 = _derive_wheel_sbom_filename(zf, "emptyheaders-1.0.0.dist-info/")
+        assert fn2 == "emptyheaders-1.0.0.spdx3.json"
+
+    # 3. METADATA with blank line after Name (stops header scan)
+    p3 = tmp_path / "blankheader-1.0.0-py3-none-any.whl"
+    with zipfile.ZipFile(p3, "w") as zf:
+        zf.writestr(
+            "blankheader-1.0.0.dist-info/METADATA",
+            "Name: myname\n\nVersion: 2.0.0 in description body\n",
+        )
+    with zipfile.ZipFile(p3, "r") as zf:
+        fn3 = _derive_wheel_sbom_filename(zf, "blankheader-1.0.0.dist-info/")
+        assert fn3 == "blankheader-1.0.0.spdx3.json"
+
+    # 4. Empty prefix fallback
+    with zipfile.ZipFile(p1, "r") as zf:
+        fn4 = _derive_wheel_sbom_filename(zf, ".dist-info/")
+        assert fn4 == "sbom.spdx3.json"
+
+
+def test_rewrite_wheel_archive_chmod_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Test _rewrite_wheel_archive gracefully ignores OSError on os.chmod."""
+    wheel_path = _make_dummy_wheel(tmp_path, "chmodpkg", "1.0.0")
+
+    def _failing_chmod(path: Any, mode: int) -> None:
+        raise OSError("Permission denied simulation")
+
+    monkeypatch.setattr("pitloom.embed.os.chmod", _failing_chmod)
+    # Should complete without error
+    embed_sbom_in_wheel(wheel_path, _SAMPLE_SPDX3_JSON)
+
+
+def test_rewrite_wheel_archive_temp_file_cleanup_on_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Test temporary file is cleaned up if archive write fails midway."""
+    wheel_path = _make_dummy_wheel(tmp_path, "cleanuppkg", "1.0.0")
+
+    def _failing_writestr(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("Disk write simulation failed")
+
+    monkeypatch.setattr("zipfile.ZipFile.writestr", _failing_writestr)
+    with pytest.raises(RuntimeError, match="Disk write simulation failed"):
+        embed_sbom_in_wheel(wheel_path, _SAMPLE_SPDX3_JSON)
+
+    # Verify no .tmp files remain in parent dir
+    tmp_files = list(tmp_path.glob("*.tmp"))
+    assert not tmp_files
+
+
+def test_resolve_project_root_non_existent(tmp_path: Path) -> None:
+    """Test _resolve_project_root when non-existent path or empty directory."""
+    from pitloom.embed import _resolve_project_root
+
+    # Non-existent explicit project_dir falls back to checking cwd
+    res = _resolve_project_root(tmp_path / "does_not_exist")
+    assert res is None or res.exists()
+
+
+def test_apply_config_overrides_full() -> None:
+    """Test _apply_config_overrides applies all CLI override parameters."""
+    from pitloom.core.config import PitloomConfig
+    from pitloom.core.provenance import ProvenanceConfig
+    from pitloom.embed import _apply_config_overrides
+
+    cfg = PitloomConfig()
+    prov = ProvenanceConfig(
+        format="fields",
+        schema="https://example.com/schema",
+        detail="full",
+        preserve_source_metadata=True,
+    )
+    overridden = _apply_config_overrides(
+        cfg,
+        provenance=prov,
+        enrich=True,
+        extract_file_header=False,
+        content_type=True,
+        content_type_method="extension",
+        offline=True,
+    )
+    assert overridden.provenance_format == "fields"
+    assert overridden.provenance_schema == "https://example.com/schema"
+    assert overridden.provenance_detail == "full"
+    assert overridden.provenance_preserve_source_metadata is True
+    assert overridden.enrich_local is True
+    assert overridden.extract_file_header is False
+    assert overridden.content_type.enabled is True
+    assert overridden.content_type.method == "extension"
+    assert overridden.offline is True
+
+    with pytest.raises(ValueError, match="content_type_method must be one of"):
+        _apply_config_overrides(
+            cfg,
+            provenance=None,
+            enrich=None,
+            extract_file_header=None,
+            content_type=None,
+            content_type_method="invalid_method",
+            offline=None,
+        )
+
+
+def test_build_sbom_standalone_wheel_registry_options(tmp_path: Path) -> None:
+    """Test _build_sbom_standalone_wheel with various registry options."""
+    from pitloom.core.project import ProjectMetadata
+    from pitloom.embed import _build_sbom_standalone_wheel
+    from pitloom.ids import IdRegistry
+
+    meta = ProjectMetadata(name="standalonereg", version="1.0.0", files=[])
+
+    # 1. IdRegistry instance with namespace
+    reg = IdRegistry(namespace="https://example.com/spdx")
+    sbom_1 = _build_sbom_standalone_wheel(meta, None, reg, None, False)
+    assert "standalonereg" in sbom_1
+
+    # 2. Path string to registry file
+    reg_file = tmp_path / "custom_ids.json"
+    reg.save(reg_file)
+    sbom_2 = _build_sbom_standalone_wheel(meta, None, str(reg_file), None, True)
+    assert "standalonereg" in sbom_2
+
+
+def test_embed_sbom_drops_stale_sboms_from_archive(tmp_path: Path) -> None:
+    """Test re-embedding drops prior SBOM from archive & RECORD."""
+    wheel_path = _make_dummy_wheel(tmp_path, "stalepkg", "1.0.0")
+
+    # 1. Embed initial SBOM under custom name 'first.spdx3.json'
+    embed_sbom_in_wheel(
+        wheel_path,
+        _SAMPLE_SPDX3_JSON,
+        sbom_filename="first.spdx3.json",
+    )
+    with zipfile.ZipFile(wheel_path, "r") as zf:
+        assert "stalepkg-1.0.0.dist-info/sboms/first.spdx3.json" in zf.namelist()
+
+    # 2. Embed second SBOM under custom name 'second.spdx3.json'
+    embed_sbom_in_wheel(
+        wheel_path,
+        _SAMPLE_SPDX3_JSON,
+        sbom_filename="second.spdx3.json",
+    )
+    with zipfile.ZipFile(wheel_path, "r") as zf:
+        namelist = zf.namelist()
+        assert "stalepkg-1.0.0.dist-info/sboms/second.spdx3.json" in namelist
+        assert "stalepkg-1.0.0.dist-info/sboms/first.spdx3.json" not in namelist
+
+        record_text = zf.read("stalepkg-1.0.0.dist-info/RECORD").decode("utf-8")
+        assert "stalepkg-1.0.0.dist-info/sboms/second.spdx3.json" in record_text
+        assert "stalepkg-1.0.0.dist-info/sboms/first.spdx3.json" not in record_text
+
+    with WheelFile.open(wheel_path) as wf:
+        wf.validate_record()
+
+
+def test_rewrite_wheel_archive_orig_mode_none(tmp_path: Path) -> None:
+    """Test _rewrite_wheel_archive handles non-existent wheel path without error."""
+    from pitloom.embed import _rewrite_wheel_archive
+
+    source_wheel = _make_dummy_wheel(tmp_path, "orig_mode_pkg", "1.0.0")
+    target_wheel = tmp_path / "new_target.whl"
+
+    with zipfile.ZipFile(source_wheel, "r") as original_zf:
+        _rewrite_wheel_archive(
+            target_wheel,
+            original_zf,
+            "orig_mode_pkg-1.0.0.dist-info/sboms/sbom.spdx3.json",
+            b"{}",
+            "orig_mode_pkg-1.0.0.dist-info/RECORD",
+            b"",
+            (2026, 1, 1, 0, 0, 0),
+        )
+    assert target_wheel.exists()

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -32,7 +32,6 @@ from pitloom.embed import (
     _build_sbom_standalone_wheel,
     _derive_wheel_sbom_filename,
     _find_dist_info_prefix,
-    _resolve_project_root,
     _resolve_zip_timestamp,
     _rewrite_wheel_archive,
     _update_record_lines,
@@ -467,7 +466,7 @@ type = "person"
     assert __main__.main() == 0
 
     # Run via Python API
-    _, arcname_api, sbom_json_api, _, _ = embed_wheel_sbom(w_api)
+    _, arcname_api, sbom_json_api, _, _ = embed_wheel_sbom(w_api, project_dir=tmp_path)
 
     # Compare embedded SBOM contents
     with zipfile.ZipFile(w_cli, "r") as z_cli, zipfile.ZipFile(w_api, "r") as z_api:
@@ -661,13 +660,6 @@ def test_rewrite_wheel_archive_temp_file_cleanup_on_error(
     assert not tmp_files
 
 
-def test_resolve_project_root_non_existent(tmp_path: Path) -> None:
-    """Test _resolve_project_root when non-existent path or empty directory."""
-    # Non-existent explicit project_dir falls back to checking cwd
-    res = _resolve_project_root(tmp_path / "does_not_exist")
-    assert res is None or res.exists()
-
-
 def test_apply_config_overrides_full() -> None:
     """Test _apply_config_overrides applies all CLI override parameters."""
     cfg = PitloomConfig()
@@ -760,7 +752,7 @@ def test_rewrite_wheel_archive_orig_mode_none(tmp_path: Path) -> None:
     target_wheel = tmp_path / "new_target.whl"
 
     with zipfile.ZipFile(source_wheel, "r") as original_zf:
-        _rewrite_wheel_archive(
+        temp_path = _rewrite_wheel_archive(
             target_wheel,
             original_zf,
             "orig_mode_pkg-1.0.0.dist-info/sboms/sbom.spdx3.json",
@@ -769,7 +761,8 @@ def test_rewrite_wheel_archive_orig_mode_none(tmp_path: Path) -> None:
             b"",
             (2026, 1, 1, 0, 0, 0),
         )
-    assert target_wheel.exists()
+    assert temp_path.exists()
+    temp_path.unlink()
 
 
 def test_cli_collect_wheel_paths_errors(
@@ -973,3 +966,41 @@ def test_cli_embed_wheel_project_dir_without_metadata(
     assert __main__.main() == 1
     err = capsys.readouterr().err
     assert "No pyproject.toml" in err
+
+
+def test_cli_wheel_embed_ignores_cwd_project(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Ensure loom wheel <wheel> --embed ignores cwd pyproject.toml."""
+    wheel_path = _make_dummy_wheel(tmp_path, "flagpkg", "1.0.0")
+
+    # Create a valid pyproject.toml in the cwd with pitloom config.
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "cwdpkg"
+version = "2.0.0"
+
+[tool.pitloom]
+creation-comment = "from-cwd"
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["loom", "wheel", str(wheel_path), "--embed"])
+
+    assert __main__.main() == 0
+
+    captured = capsys.readouterr()
+    assert "pitloom: embedded" in captured.out
+
+    with WheelFile.open(wheel_path) as wf:
+        wf.validate_record()
+
+    # Verify that the generated SBOM did NOT use the cwd's pyproject.toml
+    with zipfile.ZipFile(wheel_path, "r") as zf:
+        sbom_bytes = zf.read("flagpkg-1.0.0.dist-info/sboms/flagpkg-1.0.0.spdx3.json")
+        assert b"from-cwd" not in sbom_bytes

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -317,6 +317,7 @@ def test_cli_wheel_embed_flag(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    """Test `loom wheel <wheel> --embed` CLI command."""
     wheel_path = _make_dummy_wheel(tmp_path, "flagpkg", "1.0.0")
     monkeypatch.setattr(sys, "argv", ["loom", "wheel", str(wheel_path), "--embed"])
     assert __main__.main() == 0
@@ -326,3 +327,91 @@ def test_cli_wheel_embed_flag(
 
     with WheelFile.open(wheel_path) as wf:
         wf.validate_record()
+
+
+def test_validate_sbom_filename_edge_cases(tmp_path: Path) -> None:
+    """Test _validate_sbom_filename rejects null bytes, traversal, and whitespace."""
+    from pitloom.embed import _validate_sbom_filename
+
+    for bad in ("", "   ", "\x00", "a/b", "a\\b", "..", "."):
+        with pytest.raises(ValueError, match="Invalid SBOM filename"):
+            _validate_sbom_filename(bad)
+
+
+def test_embed_wheel_sbom_basename_with_extension_normalized(tmp_path: Path) -> None:
+    """Test custom basename already ending with .spdx3.json avoids double extension."""
+    wheel_path = _make_dummy_wheel(tmp_path, "extpkg", "1.0.0")
+    _, arcname, _ = embed_wheel_sbom(
+        wheel_path,
+        sbom_basename="custom.spdx3.json",
+    )
+    assert arcname.endswith(".dist-info/sboms/custom.spdx3.json")
+    assert not arcname.endswith(".spdx3.json.spdx3.json")
+
+    with WheelFile.open(wheel_path) as wf:
+        wf.validate_record()
+
+
+def test_cli_embed_wheel_absolute_glob(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test `loom embed-wheel <abs_path>/*.whl` with absolute glob patterns."""
+    dist_dir = tmp_path / "abs_dist"
+    w1 = _make_dummy_wheel(dist_dir, "abs_pkg", "1.0.0")
+
+    monkeypatch.setattr(sys, "argv", ["loom", "embed-wheel", str(dist_dir / "*.whl")])
+    assert __main__.main() == 0
+
+    captured = capsys.readouterr()
+    assert "abs_pkg-1.0.0-py3-none-any.whl" in captured.out
+
+    with WheelFile.open(w1) as wf:
+        wf.validate_record()
+
+
+def test_cli_embed_wheel_multiple_with_output_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test `loom embed-wheel` fails when multiple wheels match with -o."""
+    dist_dir = tmp_path / "dist"
+    _make_dummy_wheel(dist_dir, "m1", "1.0.0")
+    _make_dummy_wheel(dist_dir, "m2", "1.0.0")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["loom", "embed-wheel", "dist/*.whl", "-o", "out.spdx3.json"],
+    )
+    assert __main__.main() == 1
+
+    captured = capsys.readouterr()
+    assert "--output cannot be used when embedding multiple wheels" in captured.err
+
+
+def test_embed_sbom_empty_content_raises(tmp_path: Path) -> None:
+    """Test embed_sbom_in_wheel raises ValueError on empty or whitespace SBOM."""
+    wheel_path = _make_dummy_wheel(tmp_path, "empty_sbom", "1.0.0")
+    with pytest.raises(ValueError, match="SBOM content cannot be empty"):
+        embed_sbom_in_wheel(wheel_path, "")
+
+    with pytest.raises(ValueError, match="SBOM content cannot be empty"):
+        embed_sbom_in_wheel(wheel_path, "   \n\t  ")
+
+
+def test_embed_sbom_preserves_file_permissions(tmp_path: Path) -> None:
+    """Test embed_sbom_in_wheel preserves original filesystem permissions."""
+    import os
+    import stat
+
+    wheel_path = _make_dummy_wheel(tmp_path, "perm_pkg", "1.0.0")
+    target_mode = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH  # 0o644
+    os.chmod(wheel_path, target_mode)
+
+    embed_sbom_in_wheel(wheel_path, _SAMPLE_SPDX3_JSON)
+    current_mode = stat.S_IMODE(wheel_path.stat().st_mode)
+    assert current_mode == target_mode

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -126,7 +126,7 @@ def test_embed_sbom_in_wheel_minimal(tmp_path: Path) -> None:
     """Test embedding an SBOM into a minimal wheel."""
     wheel_path = _make_dummy_wheel(tmp_path, "demo_pkg", "1.0.0")
 
-    res_path, arcname, _ = embed_sbom_in_wheel(wheel_path, _SAMPLE_SPDX3_JSON)
+    res_path, arcname, _, _ = embed_sbom_in_wheel(wheel_path, _SAMPLE_SPDX3_JSON)
     assert res_path == wheel_path
     assert arcname == "demo_pkg-1.0.0.dist-info/sboms/demo_pkg-1.0.0.spdx3.json"
 
@@ -173,7 +173,7 @@ def test_embed_sbom_in_wheel_custom_filename(tmp_path: Path) -> None:
     """Test embedding with custom sbom_filename."""
     wheel_path = _make_dummy_wheel(tmp_path, "my_app", "2.1.0")
 
-    _, arcname, _ = embed_sbom_in_wheel(
+    _, arcname, _, _ = embed_sbom_in_wheel(
         wheel_path,
         _SAMPLE_SPDX3_JSON,
         sbom_filename="custom_sbom.spdx3.json",
@@ -239,7 +239,7 @@ def test_embed_wheel_sbom_with_pregenerated_sbom(tmp_path: Path) -> None:
     sbom_file.write_text(_SAMPLE_SPDX3_JSON, encoding="utf-8")
     out_file = tmp_path / "extracted_sbom.json"
 
-    res_path, arcname, sbom_json, _ = embed_wheel_sbom(
+    res_path, arcname, sbom_json, _, _ = embed_wheel_sbom(
         wheel_path,
         sbom_path=sbom_file,
         output_path=out_file,
@@ -263,7 +263,7 @@ def test_embed_wheel_sbom_with_project_fixture(tmp_path: Path) -> None:
 
     wheel_path = _make_dummy_wheel(tmp_path, "sampleproject_hatchling", "0.1.0")
 
-    res_path, arcname, sbom_json, _ = embed_wheel_sbom(
+    res_path, arcname, sbom_json, _, _ = embed_wheel_sbom(
         wheel_path,
         project_dir=fixture_dir,
     )
@@ -358,7 +358,7 @@ def test_validate_sbom_filename_edge_cases() -> None:
 def test_embed_wheel_sbom_basename_with_extension_normalized(tmp_path: Path) -> None:
     """Test custom basename already ending with .spdx3.json avoids double extension."""
     wheel_path = _make_dummy_wheel(tmp_path, "extpkg", "1.0.0")
-    _, arcname, _, _ = embed_wheel_sbom(
+    _, arcname, _, _, _ = embed_wheel_sbom(
         wheel_path,
         sbom_basename="custom.spdx3.json",
     )
@@ -466,7 +466,7 @@ type = "person"
     assert __main__.main() == 0
 
     # Run via Python API
-    _, arcname_api, sbom_json_api, _ = embed_wheel_sbom(w_api)
+    _, arcname_api, sbom_json_api, _, _ = embed_wheel_sbom(w_api)
 
     # Compare embedded SBOM contents
     with zipfile.ZipFile(w_cli, "r") as z_cli, zipfile.ZipFile(w_api, "r") as z_api:
@@ -517,22 +517,34 @@ def test_resolve_zip_timestamp_branches(monkeypatch: pytest.MonkeyPatch) -> None
     """Test _resolve_zip_timestamp under various invalid/fallback conditions."""
     # Invalid string in SOURCE_DATE_EPOCH
     monkeypatch.setenv("SOURCE_DATE_EPOCH", "not-a-number")
-    ts = _resolve_zip_timestamp(fallback=(1990, 5, 1, 12, 0, 0))
+    ts, floored = _resolve_zip_timestamp(fallback=(1990, 5, 1, 12, 0, 0))
     assert ts == (1990, 5, 1, 12, 0, 0)
+    assert floored is False
 
     # Overflow in SOURCE_DATE_EPOCH
     monkeypatch.setenv("SOURCE_DATE_EPOCH", "99999999999999999999999999999999999")
-    ts_overflow = _resolve_zip_timestamp(fallback=(1995, 1, 1, 0, 0, 0))
+    ts_overflow, floored_overflow = _resolve_zip_timestamp(
+        fallback=(1995, 1, 1, 0, 0, 0)
+    )
     assert ts_overflow == (1995, 1, 1, 0, 0, 0)
+    assert floored_overflow is False
 
     # Fallback with year < 1980 clamped to 1980
     monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
-    ts_clamped = _resolve_zip_timestamp(fallback=(1970, 1, 1, 0, 0, 0))
+    ts_clamped, floored_clamped = _resolve_zip_timestamp(fallback=(1970, 1, 1, 0, 0, 0))
     assert ts_clamped == (1980, 1, 1, 0, 0, 0)
+    assert floored_clamped is True
 
     # Fallback None uses current time
-    ts_now = _resolve_zip_timestamp(fallback=None)
+    ts_now, floored_now = _resolve_zip_timestamp(fallback=None)
     assert ts_now[0] >= 2026
+    assert floored_now is False
+
+    # SOURCE_DATE_EPOCH itself before 1980 (e.g. SOURCE_DATE_EPOCH=0) is floored
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "0")
+    ts_epoch_floored, floored_epoch = _resolve_zip_timestamp()
+    assert ts_epoch_floored == (1980, 1, 1, 0, 0, 0)
+    assert floored_epoch is True
 
 
 def test_update_record_lines_empty_rows() -> None:

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -660,6 +660,51 @@ def test_rewrite_wheel_archive_temp_file_cleanup_on_error(
     assert not tmp_files
 
 
+def test_embed_sbom_in_wheel_chmod_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Test that os.chmod raising OSError is gracefully ignored."""
+    wheel_path = _make_dummy_wheel(tmp_path, "chmodpkg", "1.0.0")
+
+    def _failing_chmod(*args: Any, **kwargs: Any) -> None:
+        raise OSError("Simulated permission error on chmod")
+
+    monkeypatch.setattr("os.chmod", _failing_chmod)
+
+    # Should complete without error
+    embed_sbom_in_wheel(wheel_path, _SAMPLE_SPDX3_JSON)
+    assert wheel_path.exists()
+
+
+def test_embed_wheel_sbom_not_found(tmp_path: Path) -> None:
+    """Test that embedding into a non-existent wheel
+    raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        embed_wheel_sbom(tmp_path / "does_not_exist.whl")
+
+
+def test_embed_sbom_in_wheel_replace_error_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Test that temp_path is cleaned up if os.replace fails
+    (e.g., Windows PermissionError)."""
+    wheel_path = _make_dummy_wheel(tmp_path, "replacepkg", "1.0.0")
+
+    def _failing_replace(src: str | Path, dst: str | Path) -> None:
+        raise PermissionError("Simulated file in use error")
+
+    monkeypatch.setattr("os.replace", _failing_replace)
+
+    with pytest.raises(PermissionError, match="Simulated file in use error"):
+        embed_sbom_in_wheel(wheel_path, _SAMPLE_SPDX3_JSON)
+
+    # Verify no .tmp files remain in parent dir
+    tmp_files = list(tmp_path.glob("*.tmp"))
+    assert not tmp_files
+
+
 def test_apply_config_overrides_full() -> None:
     """Test _apply_config_overrides applies all CLI override parameters."""
     cfg = PitloomConfig()

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -27,6 +27,7 @@ from pitloom.core.config import PitloomConfig
 from pitloom.core.project import ProjectMetadata
 from pitloom.core.provenance import ProvenanceConfig
 from pitloom.embed import (
+    ConfigOverrides,
     _apply_config_overrides,
     _build_sbom_standalone_wheel,
     _derive_wheel_sbom_filename,
@@ -678,12 +679,14 @@ def test_apply_config_overrides_full() -> None:
     )
     overridden = _apply_config_overrides(
         cfg,
-        provenance=prov,
-        enrich=True,
-        extract_file_header=False,
-        content_type=True,
-        content_type_method="extension",
-        offline=True,
+        ConfigOverrides(
+            provenance=prov,
+            enrich=True,
+            extract_file_header=False,
+            content_type=True,
+            content_type_method="extension",
+            offline=True,
+        ),
     )
     assert overridden.provenance_format == "fields"
     assert overridden.provenance_schema == "https://example.com/schema"
@@ -698,12 +701,7 @@ def test_apply_config_overrides_full() -> None:
     with pytest.raises(ValueError, match="content_type_method must be one of"):
         _apply_config_overrides(
             cfg,
-            provenance=None,
-            enrich=None,
-            extract_file_header=None,
-            content_type=None,
-            content_type_method="invalid_method",
-            offline=None,
+            ConfigOverrides(content_type_method="invalid_method"),
         )
 
 

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -415,3 +415,59 @@ def test_embed_sbom_preserves_file_permissions(tmp_path: Path) -> None:
     embed_sbom_in_wheel(wheel_path, _SAMPLE_SPDX3_JSON)
     current_mode = stat.S_IMODE(wheel_path.stat().st_mode)
     assert current_mode == target_mode
+
+
+def test_cli_and_api_produce_identical_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Verify CLI and Python API produce bit-for-bit identical wheels and SBOMs."""
+    import zipfile
+
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "1700000000")
+    monkeypatch.chdir(tmp_path)
+
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "identpkg"
+version = "1.0.0"
+
+[tool.pitloom]
+creation-comment = "shared-comment"
+creation-datetime = "2026-08-14T12:00:00Z"
+
+[[tool.pitloom.creator]]
+name = "Test Author"
+type = "person"
+""",
+        encoding="utf-8",
+    )
+
+    dir_cli = tmp_path / "cli"
+    dir_api = tmp_path / "api"
+    w_cli = _make_dummy_wheel(dir_cli, "identpkg", "1.0.0")
+    w_api = _make_dummy_wheel(dir_api, "identpkg", "1.0.0")
+
+    # Run via CLI
+    monkeypatch.setattr(sys, "argv", ["loom", "embed-wheel", str(w_cli)])
+    assert __main__.main() == 0
+
+    # Run via Python API
+    _, arcname_api, sbom_json_api = embed_wheel_sbom(w_api)
+
+    # Compare embedded SBOM contents
+    with zipfile.ZipFile(w_cli, "r") as z_cli, zipfile.ZipFile(w_api, "r") as z_api:
+        assert z_cli.namelist() == z_api.namelist()
+        cli_sbom_bytes = z_cli.read(arcname_api)
+        api_sbom_bytes = z_api.read(arcname_api)
+        assert cli_sbom_bytes == api_sbom_bytes
+        assert cli_sbom_bytes.decode("utf-8") == sbom_json_api
+
+        # Compare RECORD contents
+        cli_record = z_cli.read("identpkg-1.0.0.dist-info/RECORD")
+        api_record = z_api.read("identpkg-1.0.0.dist-info/RECORD")
+        assert cli_record == api_record
+
+    # Compare entire wheel binary bytes
+    assert w_cli.read_bytes() == w_api.read_bytes()

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -1,0 +1,328 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for pitloom.embed: PEP 770 post-build SBOM wheel injection."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+import pytest
+from installer.sources import WheelFile
+
+from pitloom import __main__
+from pitloom.embed import embed_sbom_in_wheel, embed_wheel_sbom
+
+_SAMPLE_SPDX3_JSON = json.dumps(
+    {
+        "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+        "@graph": [
+            {
+                "type": "SpdxDocument",
+                "spdxId": "https://spdx.org/spdxdocs/sample-doc-123",
+                "name": "sample",
+                "specVersion": "3.0.1",
+                "profileConformance": ["core", "software"],
+                "creationInfo": "_:creationInfo1",
+                "rootElement": ["https://spdx.org/spdxdocs/sample-doc-123/package"],
+            },
+            {
+                "type": "CreationInfo",
+                "@id": "_:creationInfo1",
+                "specVersion": "3.0.1",
+                "createdBy": ["https://spdx.org/spdxdocs/sample-doc-123/agent"],
+                "created": "2026-08-14T00:00:00Z",
+            },
+            {
+                "type": "software_Package",
+                "spdxId": "https://spdx.org/spdxdocs/sample-doc-123/package",
+                "name": "demo_pkg",
+                "software_packageVersion": "1.0.0",
+                "software_packageUrl": "pkg:pypi/demo-pkg@1.0.0",
+            },
+            {
+                "type": "SoftwareAgent",
+                "spdxId": "https://spdx.org/spdxdocs/sample-doc-123/agent",
+                "name": "Pitloom",
+            },
+        ],
+    }
+)
+
+
+def _make_dummy_wheel(
+    directory: Path,
+    name: str = "demo_pkg",
+    version: str = "1.0.0",
+) -> Path:
+    """Create a minimal valid wheel with a valid RECORD file."""
+    directory.mkdir(parents=True, exist_ok=True)
+    wheel_filename = f"{name}-{version}-py3-none-any.whl"
+    wheel_path = directory / wheel_filename
+    dist_info = f"{name}-{version}.dist-info"
+
+    init_code = b"__version__ = '1.0.0'\n"
+    metadata_content = (
+        f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n"
+    ).encode()
+    wheel_content = (
+        b"Wheel-Version: 1.0\n"
+        b"Generator: test\n"
+        b"Root-Is-Purelib: true\n"
+        b"Tag: py3-none-any\n"
+    )
+
+    def _rec_entry(arcname: str, payload: bytes) -> str:
+        d = hashlib.sha256(payload).digest()
+        h = base64.urlsafe_b64encode(d).decode("ascii").rstrip("=")
+        return f"{arcname},sha256={h},{len(payload)}"
+
+    records = [
+        _rec_entry(f"{name}/__init__.py", init_code),
+        _rec_entry(f"{dist_info}/METADATA", metadata_content),
+        _rec_entry(f"{dist_info}/WHEEL", wheel_content),
+        f"{dist_info}/RECORD,,",
+    ]
+    record_content = "\n".join(records).encode("utf-8") + b"\n"
+
+    with zipfile.ZipFile(wheel_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(f"{name}/__init__.py", init_code)
+        zf.writestr(f"{dist_info}/METADATA", metadata_content)
+        zf.writestr(f"{dist_info}/WHEEL", wheel_content)
+        zf.writestr(f"{dist_info}/RECORD", record_content)
+
+    return wheel_path
+
+
+def test_embed_sbom_in_wheel_minimal(tmp_path: Path) -> None:
+    """Test embedding an SBOM into a minimal wheel."""
+    wheel_path = _make_dummy_wheel(tmp_path, "demo_pkg", "1.0.0")
+
+    res_path, arcname = embed_sbom_in_wheel(wheel_path, _SAMPLE_SPDX3_JSON)
+    assert res_path == wheel_path
+    assert arcname == "demo_pkg-1.0.0.dist-info/sboms/demo_pkg-1.0.0.spdx3.json"
+
+    with zipfile.ZipFile(wheel_path, "r") as zf:
+        assert arcname in zf.namelist()
+        raw = zf.read(arcname).decode("utf-8")
+        assert raw == _SAMPLE_SPDX3_JSON
+
+    # 1. Authoritative PyPA installer RECORD validation
+    with WheelFile.open(wheel_path) as wf:
+        wf.validate_record()
+
+    # 2. check-wheel-contents validation
+    result = subprocess.run(
+        [sys.executable, "-m", "check_wheel_contents", str(wheel_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"check-wheel-contents failed: {result.stderr}"
+
+    # 3. pip install --dry-run validation
+    with tempfile.TemporaryDirectory() as td:
+        pip_res = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--dry-run",
+                "--target",
+                td,
+                "--no-deps",
+                str(wheel_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert pip_res.returncode == 0, f"pip install failed: {pip_res.stderr}"
+
+
+def test_embed_sbom_in_wheel_custom_filename(tmp_path: Path) -> None:
+    """Test embedding with custom sbom_filename."""
+    wheel_path = _make_dummy_wheel(tmp_path, "my_app", "2.1.0")
+
+    _, arcname = embed_sbom_in_wheel(
+        wheel_path,
+        _SAMPLE_SPDX3_JSON,
+        sbom_filename="custom_sbom.spdx3.json",
+    )
+    assert arcname == "my_app-2.1.0.dist-info/sboms/custom_sbom.spdx3.json"
+
+    with WheelFile.open(wheel_path) as wf:
+        wf.validate_record()
+
+
+def test_embed_sbom_in_wheel_idempotency(tmp_path: Path) -> None:
+    """Test re-embedding updates RECORD cleanly without duplicate entries."""
+    wheel_path = _make_dummy_wheel(tmp_path, "demo_pkg", "1.0.0")
+
+    embed_sbom_in_wheel(wheel_path, _SAMPLE_SPDX3_JSON)
+    updated_sbom = _SAMPLE_SPDX3_JSON.replace("demo_pkg", "demo_pkg_v2")
+    embed_sbom_in_wheel(wheel_path, updated_sbom)
+
+    with zipfile.ZipFile(wheel_path, "r") as zf:
+        sbom_entries = [n for n in zf.namelist() if "/sboms/" in n]
+        assert len(sbom_entries) == 1
+        assert zf.read(sbom_entries[0]).decode("utf-8") == updated_sbom
+
+        record_text = zf.read("demo_pkg-1.0.0.dist-info/RECORD").decode("utf-8")
+        sbom_record_lines = [
+            line for line in record_text.splitlines() if "/sboms/" in line
+        ]
+        assert len(sbom_record_lines) == 1
+
+    with WheelFile.open(wheel_path) as wf:
+        wf.validate_record()
+
+
+def test_embed_sbom_source_date_epoch_reproducibility(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test SOURCE_DATE_EPOCH reproducibility produces byte-identical wheels."""
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "1700000000")
+
+    wheel_1 = _make_dummy_wheel(tmp_path / "w1", "repro", "1.0.0")
+    wheel_2 = _make_dummy_wheel(tmp_path / "w2", "repro", "1.0.0")
+
+    embed_sbom_in_wheel(wheel_1, _SAMPLE_SPDX3_JSON)
+    embed_sbom_in_wheel(wheel_2, _SAMPLE_SPDX3_JSON)
+
+    assert wheel_1.read_bytes() == wheel_2.read_bytes()
+
+
+def test_embed_sbom_missing_dist_info_raises(tmp_path: Path) -> None:
+    """Test ValueError raised if no .dist-info directory is found."""
+    bad_wheel = tmp_path / "bad-1.0.0-py3-none-any.whl"
+    with zipfile.ZipFile(bad_wheel, "w") as zf:
+        zf.writestr("pkg/__init__.py", b"")
+
+    with pytest.raises(ValueError, match="no .dist-info directory found"):
+        embed_sbom_in_wheel(bad_wheel, _SAMPLE_SPDX3_JSON)
+
+
+def test_embed_wheel_sbom_with_pregenerated_sbom(tmp_path: Path) -> None:
+    """Test embed_wheel_sbom with a pre-generated SBOM path."""
+    wheel_path = _make_dummy_wheel(tmp_path, "pregen_pkg", "0.5.0")
+    sbom_file = tmp_path / "custom.spdx3.json"
+    sbom_file.write_text(_SAMPLE_SPDX3_JSON, encoding="utf-8")
+    out_file = tmp_path / "extracted_sbom.json"
+
+    res_path, arcname, sbom_json = embed_wheel_sbom(
+        wheel_path,
+        sbom_path=sbom_file,
+        output_path=out_file,
+    )
+    assert res_path == wheel_path
+    assert arcname.endswith(".dist-info/sboms/pregen_pkg-0.5.0.spdx3.json")
+    assert sbom_json == _SAMPLE_SPDX3_JSON
+    assert out_file.read_text(encoding="utf-8") == _SAMPLE_SPDX3_JSON
+
+    with WheelFile.open(wheel_path) as wf:
+        wf.validate_record()
+
+
+def test_embed_wheel_sbom_with_project_fixture(tmp_path: Path) -> None:
+    """Test embed_wheel_sbom using a project fixture directory."""
+    fixture_dir = (
+        Path(__file__).parent / "fixtures" / "projects" / "sampleproject-hatchling"
+    )
+    if not fixture_dir.exists():
+        pytest.skip("sampleproject-hatchling fixture not found")
+
+    wheel_path = _make_dummy_wheel(tmp_path, "sampleproject_hatchling", "0.1.0")
+
+    res_path, arcname, sbom_json = embed_wheel_sbom(
+        wheel_path,
+        project_dir=fixture_dir,
+    )
+    assert res_path == wheel_path
+    assert arcname.endswith(".dist-info/sboms/sbom.spdx3.json")
+
+    sbom_data = json.loads(sbom_json)
+    assert "@context" in sbom_data
+    assert "@graph" in sbom_data
+
+    with WheelFile.open(wheel_path) as wf:
+        wf.validate_record()
+
+    # 4. spdx3-validate validation
+    sbom_file = tmp_path / "fixture_sbom.spdx3.json"
+    sbom_file.write_text(sbom_json, encoding="utf-8")
+    val_res = subprocess.run(
+        [sys.executable, "-m", "spdx3_validate", "--json", str(sbom_file)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert val_res.returncode == 0, (
+        f"spdx3-validate failed: {val_res.stderr} {val_res.stdout}"
+    )
+
+
+def test_cli_embed_wheel_single(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    wheel_path = _make_dummy_wheel(tmp_path, "clipkg", "1.0.0")
+    monkeypatch.setattr(sys, "argv", ["loom", "embed-wheel", str(wheel_path)])
+    assert __main__.main() == 0
+
+    captured = capsys.readouterr()
+    assert "pitloom: embedded" in captured.out
+    assert "clipkg-1.0.0-py3-none-any.whl" in captured.out
+
+    with WheelFile.open(wheel_path) as wf:
+        wf.validate_record()
+
+
+def test_cli_embed_wheel_glob(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    dist_dir = tmp_path / "dist"
+    w1 = _make_dummy_wheel(dist_dir, "multi_a", "1.0.0")
+    w2 = _make_dummy_wheel(dist_dir, "multi_b", "1.0.0")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["loom", "embed-wheel", "dist/*.whl"])
+    assert __main__.main() == 0
+
+    captured = capsys.readouterr()
+    assert "multi_a-1.0.0-py3-none-any.whl" in captured.out
+    assert "multi_b-1.0.0-py3-none-any.whl" in captured.out
+
+    with WheelFile.open(w1) as wf:
+        wf.validate_record()
+    with WheelFile.open(w2) as wf:
+        wf.validate_record()
+
+
+def test_cli_wheel_embed_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    wheel_path = _make_dummy_wheel(tmp_path, "flagpkg", "1.0.0")
+    monkeypatch.setattr(sys, "argv", ["loom", "wheel", str(wheel_path), "--embed"])
+    assert __main__.main() == 0
+
+    captured = capsys.readouterr()
+    assert "pitloom: embedded" in captured.out
+
+    with WheelFile.open(wheel_path) as wf:
+        wf.validate_record()

--- a/tests/test_extract_file_headers.py
+++ b/tests/test_extract_file_headers.py
@@ -6,6 +6,8 @@
 """Tests for per-file SPDX header tag parsing and content-type detection."""
 
 import sys
+from types import ModuleType
+from typing import cast
 
 import pytest
 
@@ -172,7 +174,7 @@ def test_guess_content_type_falls_back_to_extension_when_magika_unavailable(
 ) -> None:
     """When magika isn't importable, the stdlib filename-extension guess
     is used instead -- default method="auto"."""
-    monkeypatch.setitem(sys.modules, "magika", None)
+    monkeypatch.setitem(sys.modules, "magika", cast(ModuleType, None))
     mime_type, method = guess_content_type(b"whatever bytes", "example.py")
     assert method == "extension_guess"
     assert mime_type == "text/x-python"
@@ -182,7 +184,7 @@ def test_guess_content_type_returns_none_when_neither_resolves(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An unrecognized extension with magika unavailable resolves nothing."""
-    monkeypatch.setitem(sys.modules, "magika", None)
+    monkeypatch.setitem(sys.modules, "magika", cast(ModuleType, None))
     mime_type, method = guess_content_type(b"whatever bytes", "mystery.xyzzy123")
     assert (mime_type, method) == (None, None)
 
@@ -214,7 +216,7 @@ def test_guess_content_type_method_magika_falls_back_when_unavailable(
     when magika isn't importable -- require_magika_available() is the
     thing that turns this into a hard error, not guess_content_type()
     itself."""
-    monkeypatch.setitem(sys.modules, "magika", None)
+    monkeypatch.setitem(sys.modules, "magika", cast(ModuleType, None))
     mime_type, method = guess_content_type(
         b"whatever bytes", "example.py", method="magika"
     )
@@ -235,7 +237,7 @@ def test_require_magika_available_no_op_when_installed() -> None:
 def test_require_magika_available_raises_when_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setitem(sys.modules, "magika", None)
+    monkeypatch.setitem(sys.modules, "magika", cast(ModuleType, None))
     with pytest.raises(RuntimeError, match="content-type-method 'magika'"):
         require_magika_available()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,8 @@
 import sys
 from collections.abc import Callable, Iterator
 from pathlib import Path
+from types import ModuleType
+from typing import cast
 
 import pytest
 from hatchling.builders.wheel import WheelBuilder
@@ -470,7 +472,7 @@ def test_get_wheel_files_content_type_method_magika_missing_raises_before_any_fi
     partway through a scan."""
     tagged_file, plain_file = _make_header_project(tmp_path)
     _patch_recurse(monkeypatch, tagged_file, plain_file)
-    monkeypatch.setitem(sys.modules, "magika", None)
+    monkeypatch.setitem(sys.modules, "magika", cast(ModuleType, None))
 
     recurse_calls: list[str] = []
 
@@ -497,7 +499,7 @@ def test_get_wheel_files_content_type_method_magika_missing_inert_when_detection
     gated by detection being on, same as everything else content-type."""
     tagged_file, plain_file = _make_header_project(tmp_path)
     _patch_recurse(monkeypatch, tagged_file, plain_file)
-    monkeypatch.setitem(sys.modules, "magika", None)
+    monkeypatch.setitem(sys.modules, "magika", cast(ModuleType, None))
 
     _root, files = get_wheel_files(tmp_path, content_type_method="magika")
 

--- a/tests/test_wheel_integration.py
+++ b/tests/test_wheel_integration.py
@@ -11,10 +11,14 @@
 from __future__ import annotations
 
 import json
+import shutil
+import subprocess
+import sys
 import zipfile
 from pathlib import Path
 
 import pytest
+from installer.sources import WheelFile
 
 # Skip the entire module if hatchling is not installed.
 pytest.importorskip(
@@ -24,6 +28,8 @@ pytest.importorskip(
 # Guard import after importorskip.
 # pylint: disable=wrong-import-position
 from hatchling.builders.wheel import WheelBuilder  # noqa: E402
+
+from pitloom.embed import embed_wheel_sbom  # noqa: E402
 
 # pylint: enable=wrong-import-position
 
@@ -198,4 +204,141 @@ def test_sbom_graph_contains_main_package_purl(built_wheel: Path) -> None:
     main_package = next(p for p in packages if p["name"] == "sampleproject_hatchling")
     assert main_package["software_packageUrl"] == (
         "pkg:pypi/sampleproject-hatchling@0.1.0"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3rd-party validation: PyPA installer, check-wheel-contents, pip, spdx3-validate
+# ---------------------------------------------------------------------------
+
+
+def test_wheel_record_passes_pypa_installer_validation(built_wheel: Path) -> None:
+    """PyPA installer strictly validates every file and RECORD hash in the wheel."""
+    with WheelFile.open(built_wheel) as wf:
+        wf.validate_record()
+
+
+def test_wheel_passes_check_wheel_contents(built_wheel: Path) -> None:
+    """check-wheel-contents validates the wheel's layout and files."""
+    res = subprocess.run(
+        [sys.executable, "-m", "check_wheel_contents", str(built_wheel)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert res.returncode == 0, f"check-wheel-contents failed: {res.stderr}"
+
+
+def test_wheel_passes_pip_install_dry_run(built_wheel: Path, tmp_path: Path) -> None:
+    """pip install --dry-run unpacks and validates wheel without issues."""
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--dry-run",
+            "--target",
+            str(tmp_path),
+            "--no-deps",
+            str(built_wheel),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert res.returncode == 0, f"pip install --dry-run failed: {res.stderr}"
+
+
+def test_wheel_sbom_passes_spdx3_validate(built_wheel: Path, tmp_path: Path) -> None:
+    """Embedded SBOM in wheel conforms to SPDX 3.0.1 per spdx3-validate."""
+    with zipfile.ZipFile(built_wheel) as zf:
+        (sbom_entry,) = [n for n in zf.namelist() if "/sboms/" in n]
+        sbom_data = zf.read(sbom_entry)
+
+    sbom_file = tmp_path / "embedded.spdx3.json"
+    sbom_file.write_bytes(sbom_data)
+
+    res = subprocess.run(
+        [sys.executable, "-m", "spdx3_validate", "--json", str(sbom_file)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert res.returncode == 0, f"spdx3-validate failed: {res.stderr} {res.stdout}"
+
+
+def _build_plain_fixture_wheel(tmp_path: Path) -> tuple[Path, Path]:
+    """Build a plain wheel from sampleproject-hatchling without pitloom hook."""
+    proj_dir = tmp_path / "plain_proj"
+    shutil.copytree(FIXTURE_DIR, proj_dir)
+    pyproject_file = proj_dir / "pyproject.toml"
+    content = pyproject_file.read_text(encoding="utf-8").replace(
+        "enabled = true", "enabled = false"
+    )
+    pyproject_file.write_text(content, encoding="utf-8")
+
+    out_dir = tmp_path / "wheel_out"
+    builder = WheelBuilder(str(proj_dir))
+    wheel_filename = next(builder.build(directory=str(out_dir), versions=["standard"]))
+    return proj_dir, Path(wheel_filename)
+
+
+def test_post_build_wheel_embedding_integration(tmp_path: Path) -> None:
+    """Test post-build wheel embedding (non-Hatchling / post-processing path)."""
+    proj_dir, wheel_path = _build_plain_fixture_wheel(tmp_path)
+
+    # Verify no SBOM exists before embedding
+    with zipfile.ZipFile(wheel_path) as zf:
+        assert not [n for n in zf.namelist() if "/sboms/" in n]
+
+    # Post-process: embed PEP 770 SBOM via Pitloom
+    res_path, arcname, sbom_json = embed_wheel_sbom(
+        wheel_path,
+        project_dir=proj_dir,
+    )
+    assert res_path == wheel_path
+    assert arcname.endswith(".dist-info/sboms/sbom.spdx3.json")
+
+    # Authoritative 3rd-party validation suite
+    with WheelFile.open(wheel_path) as wf:
+        wf.validate_record()
+
+    res = subprocess.run(
+        [sys.executable, "-m", "check_wheel_contents", str(wheel_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert res.returncode == 0, f"check-wheel-contents failed: {res.stderr}"
+
+    install_target = tmp_path / "install_target"
+    pip_res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--dry-run",
+            "--target",
+            str(install_target),
+            "--no-deps",
+            str(wheel_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert pip_res.returncode == 0, f"pip install failed: {pip_res.stderr}"
+
+    sbom_file = tmp_path / "post_embedded.spdx3.json"
+    sbom_file.write_text(sbom_json, encoding="utf-8")
+    val_res = subprocess.run(
+        [sys.executable, "-m", "spdx3_validate", "--json", str(sbom_file)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert val_res.returncode == 0, (
+        f"spdx3-validate failed: {val_res.stderr} {val_res.stdout}"
     )

--- a/tests/test_wheel_integration.py
+++ b/tests/test_wheel_integration.py
@@ -293,7 +293,7 @@ def test_post_build_wheel_embedding_integration(tmp_path: Path) -> None:
         assert not [n for n in zf.namelist() if "/sboms/" in n]
 
     # Post-process: embed PEP 770 SBOM via Pitloom
-    res_path, arcname, sbom_json = embed_wheel_sbom(
+    res_path, arcname, sbom_json, _ = embed_wheel_sbom(
         wheel_path,
         project_dir=proj_dir,
     )

--- a/tests/test_wheel_integration.py
+++ b/tests/test_wheel_integration.py
@@ -293,7 +293,7 @@ def test_post_build_wheel_embedding_integration(tmp_path: Path) -> None:
         assert not [n for n in zf.namelist() if "/sboms/" in n]
 
     # Post-process: embed PEP 770 SBOM via Pitloom
-    res_path, arcname, sbom_json, _ = embed_wheel_sbom(
+    res_path, arcname, sbom_json, _, _ = embed_wheel_sbom(
         wheel_path,
         project_dir=proj_dir,
     )

--- a/working-docs/implementation/wheel-embedding.md
+++ b/working-docs/implementation/wheel-embedding.md
@@ -1,0 +1,94 @@
+---
+Created: 2026-08-14
+Last-Modified: 2026-08-14
+SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+SPDX-FileType: DOCUMENTATION
+SPDX-License-Identifier: CC0-1.0
+---
+
+# Post-build wheel embedding (PEP 770): implementation notes
+
+See [docs/cli.md](../../docs/cli.md) and
+[docs/github-action.md](../../docs/github-action.md) for the user-facing
+command and CI configuration -- this document covers internal design,
+ZIP archive manipulation, RECORD formatting, and verification.
+
+See also [hatchling-build-hook.md](hatchling-build-hook.md) for the
+Hatchling build-hook counterpart.
+
+## Context and motivation
+
+PEP 770 defines the `.dist-info/sboms/` convention for embedding SBOM
+documents into Python wheels (`.whl`). Previously, Pitloom supported
+PEP 770 embedding only via its Hatchling build hook
+(`pitloom.plugins.hatch`).
+
+However, many Python packages use different build backends
+(`flit_core`, `setuptools`, `poetry-core`, `maturin`, `scikit-build-core`),
+or build in environments where Python 3.10+ is unavailable at build time.
+Because a Python wheel is a standard ZIP archive, post-processing built
+wheel files decouples SBOM generation and embedding from the build backend
+and Python build version.
+
+## Architecture
+
+Wheel embedding is implemented in `pitloom.embed`:
+
+```text
+Built .whl archive (ZIP)
+         │
+         ├── 1. Locate .dist-info/ prefix (<name>-<version>.dist-info/)
+         ├── 2. Assemble / read canonical SPDX 3 JSON-LD (JCS RFC 8785)
+         ├── 3. Write to .dist-info/sboms/<name>-<version>.spdx3.json
+         ├── 4. Compute SHA-256 base64url hash without padding (PEP 376)
+         ├── 5. Update .dist-info/RECORD with new file and retain RECORD,,
+         └── 6. Atomically replace .whl (respecting SOURCE_DATE_EPOCH)
+```
+
+### RECORD formatting and hash calculation
+
+Under PEP 376 / PEP 427 / PEP 770, each record row is formatted as:
+
+```text
+<archive_path>,sha256=<base64url_no_padding>,<byte_size>
+```
+
+The SHA-256 digest is encoded in URL-safe base64 with trailing `=`
+padding removed:
+
+```python
+digest = hashlib.sha256(sbom_bytes).digest()
+b64_hash = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+record_entry = f"{sbom_arcname},sha256={b64_hash},{len(sbom_bytes)}"
+```
+
+The RECORD file itself is listed as `<dist_info>/RECORD,,`.
+
+### Determinism, atomic writing, and memory efficiency
+
+- `_resolve_zip_timestamp`: Honours the standard `SOURCE_DATE_EPOCH`
+  environment variable if set; otherwise reuses the existing `RECORD`
+  `date_time` or the current UTC timestamp.
+- Atomic replacement: New entries and existing members are written to
+  a sibling temporary file (`.whl.tmp`) before calling `os.replace` to
+  prevent corrupt archives on process interruption.
+- Chunked streaming: Existing zip entries are streamed chunk-by-chunk
+  via `shutil.copyfileobj(original_zf.open(info), new_zf.open(info, "w"))`
+  rather than loaded into memory, keeping memory consumption minimal even
+  for wheels containing large binary files or model weights.
+
+## Authoritative 3rd-party validation
+
+The implementation is verified across two layers:
+
+1. **Wheel & RECORD verification**:
+   - **PyPA `installer` (`WheelFile.validate_record()`)**: Authoritative
+     reference validator that cryptographically checks every file in the
+     wheel archive against `.dist-info/RECORD`.
+   - **`check-wheel-contents`**: PyPA wheel linter verifying proper layout
+     and directory structure.
+   - **`pip install --dry-run`**: Verifies that standard `pip` unpacks and
+     installs the wheel cleanly.
+2. **SPDX 3 SBOM validation**:
+   - **`spdx3-validate`**: Verifies that the embedded SPDX 3 JSON-LD SBOM
+     conforms to SPDX 3.0.1 ontology and schema.

--- a/working-docs/implementation/wheel-embedding.md
+++ b/working-docs/implementation/wheel-embedding.md
@@ -93,4 +93,4 @@ The implementation is verified across two layers:
    - **`spdx3-validate`**: Verifies that the embedded SPDX 3 JSON-LD SBOM
      conforms to SPDX 3.0.1 ontology and schema (or any SPDX 3 version
      as specified/detected and agreed with the user's intention at the
-     generation time)
+     generation time).

--- a/working-docs/implementation/wheel-embedding.md
+++ b/working-docs/implementation/wheel-embedding.md
@@ -91,4 +91,6 @@ The implementation is verified across two layers:
      installs the wheel cleanly.
 2. **SPDX 3 SBOM validation**:
    - **`spdx3-validate`**: Verifies that the embedded SPDX 3 JSON-LD SBOM
-     conforms to SPDX 3.0.1 ontology and schema.
+     conforms to SPDX 3.0.1 ontology and schema (or any SPDX 3 version
+     as specified/detected and agreed with the user's intention at the
+     generation time)


### PR DESCRIPTION
## Summary

Adds post-build PEP 770 SBOM embedding for Python wheels via 'loom embed-wheel', 'loom wheel --embed', and GitHub Action 'embed-wheel' input

This will enable embedding for any build backend with full RECORD rehashing, streaming, and PyPA installer / check-wheel-contents validation.

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
