### PR TITLE
Split a author list string into individual authors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to
 - Full release notes: <https://github.com/bact/pitloom/releases>
 - Commit history: <https://github.com/bact/pitloom/compare/v0.14.1...v0.15.0>
 
+## [Unreleased]
+
+## Fixed
+
+- Split a string containing a list of authors into discrete agents
+  and generate external refs for a group of authors ("Others") ([#151])
+
+[#151]: https://github.com/bact/pitloom/pull/151
+
 ## [0.15.0] - 2026-08-15
 
 This release introduces backend-agnostic support for embedding SBOM

--- a/docs/metadata-provenance.md
+++ b/docs/metadata-provenance.md
@@ -86,6 +86,7 @@ value, not just where it read it from. Values in use today:
 | `dynamic_extraction` | Read from a Python file at build time (e.g. a `__version__` or `__about__.py` variable), not from `pyproject.toml` directly. |
 | `licenseid_detection` | License text matched against a known SPDX license using the [`licenseid`](https://pypi.org/project/licenseid/) library -- detected, not author-declared. |
 | `inferred_from_authors` | Derived from the `authors` list (e.g. a copyright statement), not read verbatim from any single field. |
+| `parsed_author_list` | Extracted multiple individual entities by splitting a single, comma-separated author string. |
 | `file_directive` | A `pyproject.toml` dynamic field pointed at a file (`{file = "..."}`); the value was read from that file. |
 | `attr_directive` | A `pyproject.toml` dynamic field pointed at a Python attribute (`{attr = "..."}`); the value was imported and read from code. |
 | `inspect_caller` | Recorded automatically by the `pitloom.loom` tracking SDK via Python stack inspection -- identifies which script/function called the SDK. |

--- a/src/pitloom/assemble/__init__.py
+++ b/src/pitloom/assemble/__init__.py
@@ -245,6 +245,7 @@ def generate_project_sbom(
         provenance=effective_provenance,
         enrichment_results_by_model=enrichment_results_by_model,
         offline=effective_offline,
+        content_type_method=effective_content_type_method,
     )
 
     if target_path.is_dir():

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -330,12 +330,15 @@ def _resolve_remote_authors_file(
         except ValueError:
             pass
 
-    if host == "github.com":
-        locator = f"{base_url}/blob/{branch}/{filename}"
-        raw_url = f"https://raw.githubusercontent.com/{path_parts[0]}/{path_parts[1]}/{branch}/{filename}"
-    elif host == "gitlab.com":
-        locator = f"{base_url}/-/blob/{branch}/{filename}"
-        raw_url = f"{base_url}/-/raw/{branch}/{filename}"
+    if len(path_parts) >= 2:
+        if host == "github.com":
+            locator = f"{base_url}/blob/{branch}/{filename}"
+            raw_url = f"https://raw.githubusercontent.com/{path_parts[0]}/{path_parts[1]}/{branch}/{filename}"
+        elif host == "gitlab.com":
+            locator = f"{base_url}/-/blob/{branch}/{filename}"
+            raw_url = f"{base_url}/-/raw/{branch}/{filename}"
+        else:
+            return base_url, "text/plain"
     else:
         return base_url, "text/plain"
 
@@ -346,15 +349,15 @@ def _resolve_remote_authors_file(
     try:
         req = urllib.request.Request(raw_url, headers={"User-Agent": "pitloom"})
         with urllib.request.urlopen(req, timeout=5) as res:
-            content = res.read()
+            content = res.read(1024 * 64)
         ctype, _ = guess_content_type(content, filename, method=content_type_method)
         return locator, (ctype or "text/plain")
-    except URLError:
+    except (URLError, http.client.HTTPException, OSError):
         ctype, _ = guess_content_type(b"", filename, method="extension")
         return locator, (ctype or "text/plain")
 
 
-def _get_or_create_supplier_agent(
+def _get_or_create_originator_agent(
     name: str | None,
     email: str | None,
     creation_info: spdx3.CreationInfo,
@@ -367,7 +370,7 @@ def _get_or_create_supplier_agent(
     offline: bool = False,
     content_type_method: str = "auto",
 ) -> str:
-    """Get or create a ``Person`` Agent for a dependency's supplier, deduped
+    """Get or create an Agent for a dependency's originator, deduped
     by ``name``/``email`` so packages sharing an author reuse one Agent."""
     key = f"{name or ''}|{email or ''}"
     is_others = bool(name and "others" in name.lower())
@@ -377,14 +380,17 @@ def _get_or_create_supplier_agent(
     if existing:
         return existing
 
+    agent_type = "Organization" if is_others else "Person"
     kwargs = {
-        "spdxId": generate_spdx_id("Person", doc_name=doc_name, doc_uuid=doc_uuid),
+        "spdxId": generate_spdx_id(agent_type, doc_name=doc_name, doc_uuid=doc_uuid),
         "name": name or email,
         "creationInfo": creation_info,
     }
     if is_others:
         kwargs["comment"] = "Represents a group of additional contributors referenced externally."
-    agent = spdx3.Person(**kwargs)
+        agent = spdx3.Organization(**kwargs)
+    else:
+        agent = spdx3.Person(**kwargs)
     if email:
         agent.externalIdentifier = [
             spdx3.ExternalIdentifier(
@@ -489,8 +495,8 @@ def _resolve_metadata_url(
     return value if value and value != "UNKNOWN" else None
 
 
-def _apply_supplier(
-    suppliers: list[tuple[str | None, str | None]],
+def _apply_originator(
+    originators: list[tuple[str, str | None]],
     dep_package: spdx3.software_Package,
     creation_info: spdx3.CreationInfo,
     doc_name: str,
@@ -504,31 +510,31 @@ def _apply_supplier(
     offline: bool = False,
     content_type_method: str = "auto",
 ) -> bool:
-    """Set ``suppliedBy`` to a list of Agent(s) built from *suppliers*.
+    """Set ``originatedBy`` to a list of Agent(s) built from *originators*.
     Returns whether it was set."""
-    if not suppliers:
+    if not originators:
         return False
         
-    supplier_ids = []
-    for name, email in suppliers:
+    originator_ids = []
+    for name, email in originators:
         if name or email:
-            agent_id = _get_or_create_supplier_agent(
+            agent_id = _get_or_create_originator_agent(
                 name, email, creation_info, doc_name, doc_uuid, exporter, repo_url=repo_url, package_name=dep_package.name, offline=offline, content_type_method=content_type_method
             )
-            supplier_ids.append(agent_id)
+            originator_ids.append(agent_id)
             
-    if not supplier_ids:
+    if not originator_ids:
         return False
         
-    if supplier_ids:
-        dep_package.suppliedBy = supplier_ids[0]
+    if originator_ids:
+        dep_package.originatedBy = originator_ids
     
     if provenance_source:
-        method = "parsed_author_list" if len(suppliers) > 1 else ""
+        method = "parsed_author_list" if len(originators) > 1 else ""
         prov_str = f"{provenance_source} | Method: {method}" if method else provenance_source
         emit_provenance(
             subject=dep_package,
-            provenance={"suppliedBy": prov_str},
+            provenance={"originatedBy": prov_str},
             creation_info=creation_info,
             doc_name=doc_name,
             doc_uuid=doc_uuid,
@@ -629,10 +635,10 @@ def _enrich_from_installed(
     if version and version != "unknown":
         dep_package.software_packageUrl = build_pypi_purl(dep_name, version)
 
-    # suppliedBy -- Person built from Author/Maintainer metadata, when known
-    suppliers = _resolve_supplier(pkg_meta)
-    if _apply_supplier(
-        suppliers,
+    # originatedBy -- Person built from Author/Maintainer metadata, when known
+    originators = _resolve_supplier(pkg_meta)
+    if _apply_originator(
+        originators,
         dep_package,
         creation_info,
         doc_name,
@@ -645,7 +651,7 @@ def _enrich_from_installed(
         offline=offline,
         content_type_method=content_type_method,
     ):
-        filled.add("supplier")
+        filled.add("originator")
 
     # copyrightText -- first copyright line found in a declared License-File
     copyright_text = _find_license_copyright(dep_name, pkg_meta)
@@ -727,10 +733,10 @@ def _enrich_from_pypi(
         home_page = info.get("home_page") or _resolve_metadata_url(info.get("project_url") or "", lower_project_urls, _HOMEPAGE_LABELS)
         repo_url = home_page
 
-    if "supplier" not in already_filled:
-        suppliers = _extract_pypi_supplier(info)
-        if _apply_supplier(
-            suppliers,
+    if "originator" not in already_filled:
+        originators = _extract_pypi_supplier(info)
+        if _apply_originator(
+            originators,
             dep_package,
             creation_info,
             doc_name,
@@ -743,7 +749,7 @@ def _enrich_from_pypi(
             offline=offline,
             content_type_method=content_type_method,
         ):
-            filled.add("supplier")
+            filled.add("originator")
 
     if "license" not in already_filled:
         license_id = _extract_pypi_license(info)

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -143,7 +143,9 @@ def _resolve_version(dep_name: str, dep: str) -> tuple[str, str | None]:
     return "unknown", None
 
 
-def _extract_suppliers(name: str, email_raw: str) -> list[tuple[str | None, str | None]]:
+def _extract_suppliers(
+    name: str, email_raw: str
+) -> list[tuple[str | None, str | None]]:
     """Return a list of ``(name, email)`` tuples from metadata fields.
 
     *email_raw* may carry an RFC 5322 ``"Name <email>"`` form (how PEP 621
@@ -186,7 +188,9 @@ def _resolve_supplier(pkg_meta: PackageMetadata) -> list[tuple[str | None, str |
         ("Author", "Author-email"),
         ("Maintainer", "Maintainer-email"),
     ):
-        results = _extract_suppliers(pkg_meta[name_field] or "", pkg_meta[email_field] or "")
+        results = _extract_suppliers(
+            pkg_meta[name_field] or "", pkg_meta[email_field] or ""
+        )
         if results:
             return results
     return []
@@ -200,7 +204,9 @@ def _extract_pypi_supplier(info: dict[str, Any]) -> list[tuple[str | None, str |
         ("author", "author_email"),
         ("maintainer", "maintainer_email"),
     ):
-        results = _extract_suppliers(info.get(name_key) or "", info.get(email_key) or "")
+        results = _extract_suppliers(
+            info.get(name_key) or "", info.get(email_key) or ""
+        )
         if results:
             return results
     return []
@@ -306,13 +312,15 @@ def _prefetch_pypi_release_infos(
         for future, key in futures.items():
             results[key] = future.result()
     return results
+
+
 @functools.lru_cache(maxsize=256)
 def _resolve_remote_authors_file(
     repo_url: str,
     filename: str,
     offline: bool,
     content_type_method: str,
-) -> tuple[str, str, str | None]:
+) -> tuple[str, str | None, str | None]:
     """Resolve the URL locator and content type for a remote authors file."""
     base_url = repo_url[:-4] if repo_url.endswith(".git") else repo_url
     base_url = base_url.rstrip("/")
@@ -325,18 +333,21 @@ def _resolve_remote_authors_file(
     if len(path_parts) >= 2:
         if host == "github.com":
             locator = f"{base_url}/blob/{branch}/{filename}"
-            raw_url = f"https://raw.githubusercontent.com/{path_parts[0]}/{path_parts[1]}/{branch}/{filename}"
+            raw_url = (
+                f"https://raw.githubusercontent.com/{path_parts[0]}/"
+                f"{path_parts[1]}/{branch}/{filename}"
+            )
         elif host == "gitlab.com":
             locator = f"{base_url}/-/blob/{branch}/{filename}"
             raw_url = f"{base_url}/-/raw/{branch}/{filename}"
         else:
-            return base_url, "text/plain", None
+            return base_url, None, None
     else:
-        return base_url, "text/plain", None
+        return base_url, None, None
 
     if offline or content_type_method == "extension":
         ctype, _ = guess_content_type(b"", filename, method="extension")
-        return locator, (ctype or "text/plain"), None
+        return locator, ctype, None
 
     try:
         if not raw_url.startswith(("http://", "https://")):
@@ -345,12 +356,17 @@ def _resolve_remote_authors_file(
         with urllib.request.urlopen(req, timeout=5) as res:  # nosec B310
             content = res.read(1024 * 64)
         ctype, _ = guess_content_type(content, filename, method=content_type_method)
-        return locator, (ctype or "text/plain"), content.decode("utf-8", errors="replace")
+        return (
+            locator,
+            ctype,
+            content.decode("utf-8", errors="replace"),
+        )
     except (URLError, http.client.HTTPException, OSError, ValueError):
         ctype, _ = guess_content_type(b"", filename, method="extension")
-        return locator, (ctype or "text/plain"), None
+        return locator, ctype, None
 
 
+# pylint: disable=too-many-arguments,too-many-locals
 def _get_or_create_originator_agent(
     name: str | None,
     email: str | None,
@@ -382,7 +398,9 @@ def _get_or_create_originator_agent(
     }
     agent: spdx3.Agent
     if is_others:
-        kwargs["comment"] = "Represents a group of additional contributors referenced externally."
+        kwargs["comment"] = (
+            "Represents a group of additional contributors referenced externally."
+        )
         agent = spdx3.Organization(**kwargs)  # type: ignore[arg-type]
     else:
         agent = spdx3.Person(**kwargs)  # type: ignore[arg-type]
@@ -395,7 +413,6 @@ def _get_or_create_originator_agent(
         ]
     attribution_text = None
     if is_others and repo_url:
-        import re
         match = re.search(r"see\s+([a-zA-Z0-9_.-]+)", str(name), re.IGNORECASE)
         filename = match.group(1) if match else "AUTHORS"
 
@@ -403,18 +420,22 @@ def _get_or_create_originator_agent(
             repo_url, filename, offline, content_type_method
         )
 
-        agent.externalRef = [
-            spdx3.ExternalRef(
-                externalRefType=spdx3.ExternalRefType.documentation,
-                locator=[locator],
-                contentType=ctype,
-                comment=f"Refers to {filename}"
-            )
-        ]
+        ref_kwargs: dict[str, Any] = {
+            "externalRefType": spdx3.ExternalRefType.documentation,
+            "locator": [locator],
+            "comment": f"Refers to {filename}",
+        }
+        if ctype:
+            ref_kwargs["contentType"] = ctype
+
+        agent.externalRef = [spdx3.ExternalRef(**ref_kwargs)]
 
         attribution_text = fetched_text
         if not attribution_text:
-            attribution_text = f"Attribution: This package includes contributions from additional authors detailed in the {filename} file at {repo_url}."
+            attribution_text = (
+                "Attribution: This package includes contributions from additional "
+                f"authors detailed in the {filename} file at {repo_url}."
+            )
 
     exporter.add_agent(agent, key=key)
     return require_spdx_id(agent), attribution_text
@@ -519,7 +540,16 @@ def _apply_originator(
     for name, email in originators:
         if name or email:
             agent_id, attribution_text = _get_or_create_originator_agent(
-                name, email, creation_info, doc_name, doc_uuid, exporter, repo_url=repo_url, package_name=dep_package.name, offline=offline, content_type_method=content_type_method
+                name,
+                email,
+                creation_info,
+                doc_name,
+                doc_uuid,
+                exporter,
+                repo_url=repo_url,
+                package_name=dep_package.name,
+                offline=offline,
+                content_type_method=content_type_method,
             )
             originator_ids.append(agent_id)
             if attribution_text:
@@ -535,11 +565,15 @@ def _apply_originator(
 
     if provenance_source:
         method = "parsed_author_list" if len(originators) > 1 else ""
-        prov_str = f"{provenance_source} | Method: {method}" if method else provenance_source
+        prov_str = (
+            f"{provenance_source} | Method: {method}" if method else provenance_source
+        )
         prov_dict = {"originatedBy": prov_str}
 
         if dep_package.software_attributionText and repo_url:
-            prov_dict["software_attributionText"] = f"Fetched from AUTHORS at {repo_url}"
+            prov_dict["software_attributionText"] = (
+                f"Fetched from AUTHORS at {repo_url}"
+            )
 
         emit_provenance(
             subject=dep_package,
@@ -590,6 +624,7 @@ def _apply_license(
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
+# pylint: disable=too-many-locals
 def _enrich_from_installed(
     dep_name: str,
     dep_package: spdx3.software_Package,
@@ -635,7 +670,9 @@ def _enrich_from_installed(
     if download_url:
         dep_package.software_downloadLocation = download_url
 
-    repo_url = _resolve_metadata_url("", project_urls, ("repository", "source", "source code"))
+    repo_url = _resolve_metadata_url(
+        "", project_urls, ("repository", "source", "source code")
+    )
     if not repo_url:
         repo_url = home_page
 
@@ -737,9 +774,13 @@ def _enrich_from_pypi(
 
     project_urls = info.get("project_urls") or {}
     lower_project_urls = {k.lower(): v for k, v in project_urls.items()}
-    repo_url = _resolve_metadata_url("", lower_project_urls, ("repository", "source", "source code"))
+    repo_url = _resolve_metadata_url(
+        "", lower_project_urls, ("repository", "source", "source code")
+    )
     if not repo_url:
-        home_page = info.get("home_page") or _resolve_metadata_url(info.get("project_url") or "", lower_project_urls, _HOMEPAGE_LABELS)
+        home_page = info.get("home_page") or _resolve_metadata_url(
+            info.get("project_url") or "", lower_project_urls, _HOMEPAGE_LABELS
+        )
         repo_url = home_page
 
     if "originator" not in already_filled:

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -38,6 +38,10 @@ from pitloom.extract._license import (
     normalize_license_expression,
     tag_license_normalization,
 )
+from pitloom.extract._file_headers import guess_content_type
+import urllib.request
+from urllib.error import URLError
+from urllib.parse import urlparse
 
 # Operators used in PEP 508 dependency specifiers, ordered longest-first to
 # avoid splitting on a prefix of a multi-character operator (e.g. "==" before "=").
@@ -137,8 +141,8 @@ def _resolve_version(dep_name: str, dep: str) -> tuple[str, str | None]:
     return "unknown", None
 
 
-def _pick_supplier(name: str, email_raw: str) -> tuple[str | None, str | None] | None:
-    """Return ``(name, email)`` from one name/email metadata pair, or ``None``.
+def _extract_suppliers(name: str, email_raw: str) -> list[tuple[str | None, str | None]]:
+    """Return a list of ``(name, email)`` tuples from metadata fields.
 
     *email_raw* may carry an RFC 5322 ``"Name <email>"`` form (how PEP 621
     ``[project.authors]`` round-trips through core metadata / PyPI's JSON
@@ -146,50 +150,58 @@ def _pick_supplier(name: str, email_raw: str) -> tuple[str | None, str | None] |
     comma-separated list of several such entries; :func:`email.utils.
     getaddresses` handles all three (unlike :func:`email.utils.parseaddr`,
     which mis-parses a multi-entry list as one malformed address and
-    silently returns nothing). Only the first entry is used. *name* alone
-    (no email) is still a usable result.
+    silently returns nothing).
+
+    If *email_raw* is empty but *name* contains a comma-separated list of
+    names, it splits them into individual tuples.
     """
     name = name.strip()
     email_raw = email_raw.strip()
+    results: list[tuple[str | None, str | None]] = []
+
     if email_raw:
         addresses = getaddresses([email_raw])
-        if addresses:
-            parsed_name, parsed_email = addresses[0]
+        for parsed_name, parsed_email in addresses:
             resolved_name = parsed_name.strip() or name or None
             resolved_email = parsed_email.strip() or None
             if resolved_name or resolved_email:
-                return resolved_name, resolved_email
+                results.append((resolved_name, resolved_email))
+        return results
+
     if name:
-        return name, None
-    return None
+        for part in re.split(r",|\band\b", name):
+            part = part.strip()
+            if part:
+                results.append((part, None))
+    return results
 
 
-def _resolve_supplier(pkg_meta: PackageMetadata) -> tuple[str | None, str | None]:
-    """Return ``(name, email)`` for a dependency's supplier from installed
-    metadata, or ``(None, None)``. Tries ``Author``/``Author-email`` first,
+def _resolve_supplier(pkg_meta: PackageMetadata) -> list[tuple[str | None, str | None]]:
+    """Return a list of ``(name, email)`` tuples for a dependency's supplier from
+    installed metadata, or an empty list. Tries ``Author``/``Author-email`` first,
     then falls back to ``Maintainer``/``Maintainer-email``."""
     for name_field, email_field in (
         ("Author", "Author-email"),
         ("Maintainer", "Maintainer-email"),
     ):
-        result = _pick_supplier(pkg_meta[name_field] or "", pkg_meta[email_field] or "")
-        if result:
-            return result
-    return None, None
+        results = _extract_suppliers(pkg_meta[name_field] or "", pkg_meta[email_field] or "")
+        if results:
+            return results
+    return []
 
 
-def _extract_pypi_supplier(info: dict[str, Any]) -> tuple[str | None, str | None]:
-    """Return ``(name, email)`` for a dependency's supplier from a PyPI JSON
-    API ``info`` object, or ``(None, None)``. Same author-then-maintainer
+def _extract_pypi_supplier(info: dict[str, Any]) -> list[tuple[str | None, str | None]]:
+    """Return a list of ``(name, email)`` tuples for a dependency's supplier from a
+    PyPI JSON API ``info`` object, or an empty list. Same author-then-maintainer
     precedence as :func:`_resolve_supplier`."""
     for name_key, email_key in (
         ("author", "author_email"),
         ("maintainer", "maintainer_email"),
     ):
-        result = _pick_supplier(info.get(name_key) or "", info.get(email_key) or "")
-        if result:
-            return result
-    return None, None
+        results = _extract_suppliers(info.get(name_key) or "", info.get(email_key) or "")
+        if results:
+            return results
+    return []
 
 
 def _extract_pypi_license(info: dict[str, Any]) -> str | None:
@@ -292,6 +304,54 @@ def _prefetch_pypi_release_infos(
         for future, key in futures.items():
             results[key] = future.result()
     return results
+def _resolve_remote_authors_file(
+    repo_url: str,
+    filename: str,
+    offline: bool,
+    content_type_method: str,
+) -> tuple[str, str]:
+    """Resolve the URL locator and content type for a remote authors file."""
+    base_url = repo_url[:-4] if repo_url.endswith(".git") else repo_url
+    base_url = base_url.rstrip("/")
+    parsed = urlparse(base_url)
+    host = parsed.netloc.lower()
+    path_parts = [p for p in parsed.path.split("/") if p]
+    
+    branch = "HEAD"
+    if not offline and len(path_parts) >= 2:
+        owner, repo = path_parts[0], path_parts[1]
+        try:
+            if host == "github.com":
+                data = fetch_json(f"https://api.github.com/repos/{owner}/{repo}", timeout=5)
+                branch = data.get("default_branch", "HEAD")
+            elif host == "gitlab.com":
+                data = fetch_json(f"https://gitlab.com/api/v4/projects/{owner}%2F{repo}", timeout=5)
+                branch = data.get("default_branch", "HEAD")
+        except ValueError:
+            pass
+
+    if host == "github.com":
+        locator = f"{base_url}/blob/{branch}/{filename}"
+        raw_url = f"https://raw.githubusercontent.com/{path_parts[0]}/{path_parts[1]}/{branch}/{filename}"
+    elif host == "gitlab.com":
+        locator = f"{base_url}/-/blob/{branch}/{filename}"
+        raw_url = f"{base_url}/-/raw/{branch}/{filename}"
+    else:
+        return base_url, "text/plain"
+
+    if offline or content_type_method == "extension":
+        ctype, _ = guess_content_type(b"", filename, method="extension")
+        return locator, (ctype or "text/plain")
+
+    try:
+        req = urllib.request.Request(raw_url, headers={"User-Agent": "pitloom"})
+        with urllib.request.urlopen(req, timeout=5) as res:
+            content = res.read()
+        ctype, _ = guess_content_type(content, filename, method=content_type_method)
+        return locator, (ctype or "text/plain")
+    except URLError:
+        ctype, _ = guess_content_type(b"", filename, method="extension")
+        return locator, (ctype or "text/plain")
 
 
 def _get_or_create_supplier_agent(
@@ -301,19 +361,30 @@ def _get_or_create_supplier_agent(
     doc_name: str,
     doc_uuid: str,
     exporter: Spdx3JsonExporter,
+    repo_url: str | None = None,
+    package_name: str | None = None,
+    *,
+    offline: bool = False,
+    content_type_method: str = "auto",
 ) -> str:
     """Get or create a ``Person`` Agent for a dependency's supplier, deduped
     by ``name``/``email`` so packages sharing an author reuse one Agent."""
     key = f"{name or ''}|{email or ''}"
+    is_others = bool(name and "others" in name.lower())
+    if is_others:
+        key += f"|{repo_url or package_name or 'unknown'}"
     existing = exporter.find_agent(key)
     if existing:
         return existing
 
-    agent = spdx3.Person(
-        spdxId=generate_spdx_id("Person", doc_name=doc_name, doc_uuid=doc_uuid),
-        name=name or email,
-        creationInfo=creation_info,
-    )
+    kwargs = {
+        "spdxId": generate_spdx_id("Person", doc_name=doc_name, doc_uuid=doc_uuid),
+        "name": name or email,
+        "creationInfo": creation_info,
+    }
+    if is_others:
+        kwargs["comment"] = "Represents a group of additional contributors referenced externally."
+    agent = spdx3.Person(**kwargs)
     if email:
         agent.externalIdentifier = [
             spdx3.ExternalIdentifier(
@@ -321,6 +392,24 @@ def _get_or_create_supplier_agent(
                 identifier=email,
             )
         ]
+    if is_others and repo_url:
+        import re
+        match = re.search(r"see\s+([a-zA-Z0-9_.-]+)", name, re.IGNORECASE)
+        filename = match.group(1) if match else "AUTHORS"
+
+        locator, ctype = _resolve_remote_authors_file(
+            repo_url, filename, offline, content_type_method
+        )
+
+        agent.externalRef = [
+            spdx3.ExternalRef(
+                externalRefType=spdx3.ExternalRefType.documentation,
+                locator=[locator],
+                contentType=ctype,
+                comment=f"Refers to {filename}"
+            )
+        ]
+
     exporter.add_agent(agent, key=key)
     return require_spdx_id(agent)
 
@@ -401,21 +490,52 @@ def _resolve_metadata_url(
 
 
 def _apply_supplier(
-    name: str | None,
-    email: str | None,
+    suppliers: list[tuple[str | None, str | None]],
     dep_package: spdx3.software_Package,
     creation_info: spdx3.CreationInfo,
     doc_name: str,
     doc_uuid: str,
     exporter: Spdx3JsonExporter,
+    repo_url: str | None = None,
+    *,
+    provenance_config: ProvenanceConfig | None = None,
+    encoder: ProvenanceEncoder | None = None,
+    provenance_source: str = "",
+    offline: bool = False,
+    content_type_method: str = "auto",
 ) -> bool:
-    """Set ``suppliedBy`` to a (deduped) Agent built from *name*/*email*, if
-    either is given. Returns whether it was set."""
-    if not (name or email):
+    """Set ``suppliedBy`` to a list of Agent(s) built from *suppliers*.
+    Returns whether it was set."""
+    if not suppliers:
         return False
-    dep_package.suppliedBy = _get_or_create_supplier_agent(
-        name, email, creation_info, doc_name, doc_uuid, exporter
-    )
+        
+    supplier_ids = []
+    for name, email in suppliers:
+        if name or email:
+            agent_id = _get_or_create_supplier_agent(
+                name, email, creation_info, doc_name, doc_uuid, exporter, repo_url=repo_url, package_name=dep_package.name, offline=offline, content_type_method=content_type_method
+            )
+            supplier_ids.append(agent_id)
+            
+    if not supplier_ids:
+        return False
+        
+    if supplier_ids:
+        dep_package.suppliedBy = supplier_ids[0]
+    
+    if provenance_source:
+        method = "parsed_author_list" if len(suppliers) > 1 else ""
+        prov_str = f"{provenance_source} | Method: {method}" if method else provenance_source
+        emit_provenance(
+            subject=dep_package,
+            provenance={"suppliedBy": prov_str},
+            creation_info=creation_info,
+            doc_name=doc_name,
+            doc_uuid=doc_uuid,
+            exporter=exporter,
+            provenance_config=provenance_config,
+            encoder=encoder,
+        )
     return True
 
 
@@ -465,6 +585,8 @@ def _enrich_from_installed(
     *,
     provenance_config: ProvenanceConfig | None = None,
     encoder: ProvenanceEncoder | None = None,
+    offline: bool = False,
+    content_type_method: str = "auto",
 ) -> set[str]:
     """Populate optional fields on a dependency package from installed metadata.
 
@@ -498,21 +620,30 @@ def _enrich_from_installed(
     if download_url:
         dep_package.software_downloadLocation = download_url
 
+    repo_url = _resolve_metadata_url("", project_urls, ("repository", "source", "source code"))
+    if not repo_url:
+        repo_url = home_page
+
     # packageUrl -- PyPI PURL (pkg:pypi/<name>@<version>)
     version = dep_package.software_packageVersion
     if version and version != "unknown":
         dep_package.software_packageUrl = build_pypi_purl(dep_name, version)
 
     # suppliedBy -- Person built from Author/Maintainer metadata, when known
-    supplier_name, supplier_email = _resolve_supplier(pkg_meta)
+    suppliers = _resolve_supplier(pkg_meta)
     if _apply_supplier(
-        supplier_name,
-        supplier_email,
+        suppliers,
         dep_package,
         creation_info,
         doc_name,
         doc_uuid,
         exporter,
+        repo_url=repo_url,
+        provenance_config=provenance_config,
+        encoder=encoder,
+        provenance_source=f"Source: installed metadata | Package: {dep_name}",
+        offline=offline,
+        content_type_method=content_type_method,
     ):
         filled.add("supplier")
 
@@ -560,6 +691,8 @@ def _enrich_from_pypi(
     | None = None,
     provenance_config: ProvenanceConfig | None = None,
     encoder: ProvenanceEncoder | None = None,
+    offline: bool = False,
+    content_type_method: str = "auto",
 ) -> set[str]:
     """Best-effort PyPI JSON API fallback for whatever *already_filled*
     doesn't already cover (supplier, license), plus the published
@@ -587,16 +720,28 @@ def _enrich_from_pypi(
     filled: set[str] = set()
     info = release_info.get("info") or {}
 
+    project_urls = info.get("project_urls") or {}
+    lower_project_urls = {k.lower(): v for k, v in project_urls.items()}
+    repo_url = _resolve_metadata_url("", lower_project_urls, ("repository", "source", "source code"))
+    if not repo_url:
+        home_page = info.get("home_page") or _resolve_metadata_url(info.get("project_url") or "", lower_project_urls, _HOMEPAGE_LABELS)
+        repo_url = home_page
+
     if "supplier" not in already_filled:
-        supplier_name, supplier_email = _extract_pypi_supplier(info)
+        suppliers = _extract_pypi_supplier(info)
         if _apply_supplier(
-            supplier_name,
-            supplier_email,
+            suppliers,
             dep_package,
             creation_info,
             doc_name,
             doc_uuid,
             exporter,
+            repo_url=repo_url,
+            provenance_config=provenance_config,
+            encoder=encoder,
+            provenance_source=f"Source: PyPI JSON API | Package: {dep_name}",
+            offline=offline,
+            content_type_method=content_type_method,
         ):
             filled.add("supplier")
 
@@ -964,6 +1109,7 @@ def _finish_dependency_enrichment(
     | None = None,
     provenance_config: ProvenanceConfig | None = None,
     encoder: ProvenanceEncoder | None = None,
+    content_type_method: str = "auto",
 ) -> None:
     """Apply the shared dependency-package completeness policy to an
     already-created *dep_package*: PURL (name-only when *dep_version* is
@@ -993,6 +1139,8 @@ def _finish_dependency_enrichment(
         exporter,
         provenance_config=provenance_config,
         encoder=encoder,
+        offline=offline,
+        content_type_method=content_type_method,
     )
 
     if not offline:
@@ -1008,6 +1156,8 @@ def _finish_dependency_enrichment(
             release_info_cache=release_info_cache,
             provenance_config=provenance_config,
             encoder=encoder,
+            offline=offline,
+            content_type_method=content_type_method,
         )
 
     if "copyright" not in filled:
@@ -1037,6 +1187,7 @@ def add_dependencies(
     offline: bool = False,
     provenance_config: ProvenanceConfig | None = None,
     encoder: ProvenanceEncoder | None = None,
+    content_type_method: str = "auto",
 ) -> None:
     """Build SPDX ``software_Package`` and ``Relationship`` elements for each
     declared dependency.

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -309,7 +309,7 @@ def _resolve_remote_authors_file(
     filename: str,
     offline: bool,
     content_type_method: str,
-) -> tuple[str, str]:
+) -> tuple[str, str, str | None]:
     """Resolve the URL locator and content type for a remote authors file."""
     base_url = repo_url[:-4] if repo_url.endswith(".git") else repo_url
     base_url = base_url.rstrip("/")
@@ -344,17 +344,19 @@ def _resolve_remote_authors_file(
 
     if offline or content_type_method == "extension":
         ctype, _ = guess_content_type(b"", filename, method="extension")
-        return locator, (ctype or "text/plain")
+        return locator, (ctype or "text/plain"), None
 
     try:
+        if not raw_url.startswith(("http://", "https://")):
+            raise ValueError(f"Disallowed scheme in URL: {raw_url}")
         req = urllib.request.Request(raw_url, headers={"User-Agent": "pitloom"})
-        with urllib.request.urlopen(req, timeout=5) as res:
+        with urllib.request.urlopen(req, timeout=5) as res:  # nosec B310
             content = res.read(1024 * 64)
         ctype, _ = guess_content_type(content, filename, method=content_type_method)
-        return locator, (ctype or "text/plain")
+        return locator, (ctype or "text/plain"), content.decode("utf-8", errors="replace")
     except (URLError, http.client.HTTPException, OSError):
         ctype, _ = guess_content_type(b"", filename, method="extension")
-        return locator, (ctype or "text/plain")
+        return locator, (ctype or "text/plain"), None
 
 
 def _get_or_create_originator_agent(
@@ -369,7 +371,7 @@ def _get_or_create_originator_agent(
     *,
     offline: bool = False,
     content_type_method: str = "auto",
-) -> str:
+) -> tuple[str, str | None]:
     """Get or create an Agent for a dependency's originator, deduped
     by ``name``/``email`` so packages sharing an author reuse one Agent."""
     key = f"{name or ''}|{email or ''}"
@@ -378,7 +380,7 @@ def _get_or_create_originator_agent(
         key += f"|{repo_url or package_name or 'unknown'}"
     existing = exporter.find_agent(key)
     if existing:
-        return existing
+        return existing, None
 
     agent_type = "Organization" if is_others else "Person"
     kwargs = {
@@ -398,12 +400,13 @@ def _get_or_create_originator_agent(
                 identifier=email,
             )
         ]
+    attribution_text = None
     if is_others and repo_url:
         import re
         match = re.search(r"see\s+([a-zA-Z0-9_.-]+)", name, re.IGNORECASE)
         filename = match.group(1) if match else "AUTHORS"
 
-        locator, ctype = _resolve_remote_authors_file(
+        locator, ctype, fetched_text = _resolve_remote_authors_file(
             repo_url, filename, offline, content_type_method
         )
 
@@ -415,9 +418,13 @@ def _get_or_create_originator_agent(
                 comment=f"Refers to {filename}"
             )
         ]
+        
+        attribution_text = fetched_text
+        if not attribution_text:
+            attribution_text = f"Attribution: This software includes contributions from additional authors detailed in the {filename} file at {repo_url}."
 
     exporter.add_agent(agent, key=key)
-    return require_spdx_id(agent)
+    return require_spdx_id(agent), attribution_text
 
 
 def _find_license_copyright(dist_name: str, pkg_meta: PackageMetadata) -> str | None:
@@ -518,10 +525,15 @@ def _apply_originator(
     originator_ids = []
     for name, email in originators:
         if name or email:
-            agent_id = _get_or_create_originator_agent(
+            agent_id, attribution_text = _get_or_create_originator_agent(
                 name, email, creation_info, doc_name, doc_uuid, exporter, repo_url=repo_url, package_name=dep_package.name, offline=offline, content_type_method=content_type_method
             )
             originator_ids.append(agent_id)
+            if attribution_text:
+                if not dep_package.software_attributionText:
+                    dep_package.software_attributionText = [attribution_text]
+                else:
+                    dep_package.software_attributionText.append(attribution_text)
             
     if not originator_ids:
         return False

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -7,7 +7,10 @@
 
 from __future__ import annotations
 
+import functools
+import http.client
 import re
+import urllib.request
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 from email.utils import getaddresses
@@ -16,7 +19,9 @@ from importlib.metadata import distribution as get_pkg_distribution
 from importlib.metadata import metadata as get_pkg_metadata
 from importlib.metadata import version as get_package_version
 from typing import Any
+from urllib.error import URLError
 from urllib.parse import quote as url_quote
+from urllib.parse import urlparse
 
 from packaging.requirements import InvalidRequirement, Requirement
 from spdx_python_model.bindings import v3_0_1 as spdx3
@@ -34,14 +39,11 @@ from pitloom.core.project import PhantomDependency
 from pitloom.core.provenance import ProvenanceConfig
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id, sha256_hash
 from pitloom.extract._extract_utils import fetch_json
+from pitloom.extract._file_headers import guess_content_type
 from pitloom.extract._license import (
     normalize_license_expression,
     tag_license_normalization,
 )
-from pitloom.extract._file_headers import guess_content_type
-import urllib.request
-from urllib.error import URLError
-from urllib.parse import urlparse
 
 # Operators used in PEP 508 dependency specifiers, ordered longest-first to
 # avoid splitting on a prefix of a multi-character operator (e.g. "==" before "=").
@@ -304,6 +306,7 @@ def _prefetch_pypi_release_infos(
         for future, key in futures.items():
             results[key] = future.result()
     return results
+@functools.lru_cache(maxsize=256)
 def _resolve_remote_authors_file(
     repo_url: str,
     filename: str,
@@ -316,19 +319,8 @@ def _resolve_remote_authors_file(
     parsed = urlparse(base_url)
     host = parsed.netloc.lower()
     path_parts = [p for p in parsed.path.split("/") if p]
-    
+
     branch = "HEAD"
-    if not offline and len(path_parts) >= 2:
-        owner, repo = path_parts[0], path_parts[1]
-        try:
-            if host == "github.com":
-                data = fetch_json(f"https://api.github.com/repos/{owner}/{repo}", timeout=5)
-                branch = data.get("default_branch", "HEAD")
-            elif host == "gitlab.com":
-                data = fetch_json(f"https://gitlab.com/api/v4/projects/{owner}%2F{repo}", timeout=5)
-                branch = data.get("default_branch", "HEAD")
-        except ValueError:
-            pass
 
     if len(path_parts) >= 2:
         if host == "github.com":
@@ -338,9 +330,9 @@ def _resolve_remote_authors_file(
             locator = f"{base_url}/-/blob/{branch}/{filename}"
             raw_url = f"{base_url}/-/raw/{branch}/{filename}"
         else:
-            return base_url, "text/plain"
+            return base_url, "text/plain", None
     else:
-        return base_url, "text/plain"
+        return base_url, "text/plain", None
 
     if offline or content_type_method == "extension":
         ctype, _ = guess_content_type(b"", filename, method="extension")
@@ -354,7 +346,7 @@ def _resolve_remote_authors_file(
             content = res.read(1024 * 64)
         ctype, _ = guess_content_type(content, filename, method=content_type_method)
         return locator, (ctype or "text/plain"), content.decode("utf-8", errors="replace")
-    except (URLError, http.client.HTTPException, OSError):
+    except (URLError, http.client.HTTPException, OSError, ValueError):
         ctype, _ = guess_content_type(b"", filename, method="extension")
         return locator, (ctype or "text/plain"), None
 
@@ -388,11 +380,12 @@ def _get_or_create_originator_agent(
         "name": name or email,
         "creationInfo": creation_info,
     }
+    agent: spdx3.Agent
     if is_others:
         kwargs["comment"] = "Represents a group of additional contributors referenced externally."
-        agent = spdx3.Organization(**kwargs)
+        agent = spdx3.Organization(**kwargs)  # type: ignore[arg-type]
     else:
-        agent = spdx3.Person(**kwargs)
+        agent = spdx3.Person(**kwargs)  # type: ignore[arg-type]
     if email:
         agent.externalIdentifier = [
             spdx3.ExternalIdentifier(
@@ -403,7 +396,7 @@ def _get_or_create_originator_agent(
     attribution_text = None
     if is_others and repo_url:
         import re
-        match = re.search(r"see\s+([a-zA-Z0-9_.-]+)", name, re.IGNORECASE)
+        match = re.search(r"see\s+([a-zA-Z0-9_.-]+)", str(name), re.IGNORECASE)
         filename = match.group(1) if match else "AUTHORS"
 
         locator, ctype, fetched_text = _resolve_remote_authors_file(
@@ -418,10 +411,10 @@ def _get_or_create_originator_agent(
                 comment=f"Refers to {filename}"
             )
         ]
-        
+
         attribution_text = fetched_text
         if not attribution_text:
-            attribution_text = f"Attribution: This software includes contributions from additional authors detailed in the {filename} file at {repo_url}."
+            attribution_text = f"Attribution: This package includes contributions from additional authors detailed in the {filename} file at {repo_url}."
 
     exporter.add_agent(agent, key=key)
     return require_spdx_id(agent), attribution_text
@@ -503,7 +496,7 @@ def _resolve_metadata_url(
 
 
 def _apply_originator(
-    originators: list[tuple[str, str | None]],
+    originators: list[tuple[str | None, str | None]],
     dep_package: spdx3.software_Package,
     creation_info: spdx3.CreationInfo,
     doc_name: str,
@@ -521,7 +514,7 @@ def _apply_originator(
     Returns whether it was set."""
     if not originators:
         return False
-        
+
     originator_ids = []
     for name, email in originators:
         if name or email:
@@ -534,19 +527,23 @@ def _apply_originator(
                     dep_package.software_attributionText = [attribution_text]
                 else:
                     dep_package.software_attributionText.append(attribution_text)
-            
+
     if not originator_ids:
         return False
-        
-    if originator_ids:
-        dep_package.originatedBy = originator_ids
-    
+
+    dep_package.originatedBy = originator_ids
+
     if provenance_source:
         method = "parsed_author_list" if len(originators) > 1 else ""
         prov_str = f"{provenance_source} | Method: {method}" if method else provenance_source
+        prov_dict = {"originatedBy": prov_str}
+
+        if dep_package.software_attributionText and repo_url:
+            prov_dict["software_attributionText"] = f"Fetched from AUTHORS at {repo_url}"
+
         emit_provenance(
             subject=dep_package,
-            provenance={"originatedBy": prov_str},
+            provenance=prov_dict,
             creation_info=creation_info,
             doc_name=doc_name,
             doc_uuid=doc_uuid,
@@ -1266,6 +1263,7 @@ def add_dependencies(
             release_info_cache=release_info_cache,
             provenance_config=provenance_config,
             encoder=encoder,
+            content_type_method=content_type_method,
         )
 
         exporter.add_package(dep_package)

--- a/src/pitloom/assemble/spdx3/document.py
+++ b/src/pitloom/assemble/spdx3/document.py
@@ -531,6 +531,7 @@ def build(
         offline=offline,
         provenance_config=prov_cfg,
         encoder=encoder,
+        content_type_method=effective_content_type_method,
     )
 
     # --- Files ---

--- a/src/pitloom/assemble/spdx3/document.py
+++ b/src/pitloom/assemble/spdx3/document.py
@@ -408,6 +408,7 @@ def build(
     provenance: ProvenanceConfig | None = None,
     enrichment_results_by_model: list[list[EnrichmentResult]] | None = None,
     offline: bool = False,
+    content_type_method: str = "auto",
 ) -> Spdx3JsonExporter:
     """Assemble SPDX 3 elements from a :class:`~pitloom.core.document.DocumentModel`.
 
@@ -531,7 +532,7 @@ def build(
         offline=offline,
         provenance_config=prov_cfg,
         encoder=encoder,
-        content_type_method=effective_content_type_method,
+        content_type_method=content_type_method,
     )
 
     # --- Files ---

--- a/tests/test_deps_enrichment.py
+++ b/tests/test_deps_enrichment.py
@@ -1040,5 +1040,8 @@ def test_apply_originator_creates_others_external_ref() -> None:
     assert len(others.externalRef) == 1
     ref = others.externalRef[0]
     assert ref.externalRefType == spdx3.ExternalRefType.documentation
+    
+    assert dep_package.software_attributionText is not None
+    assert "Attribution: This software includes contributions from additional authors" in dep_package.software_attributionText[0]
     assert ref.locator == ["https://github.com/foo/bar/blob/HEAD/OTHER_AUTHORS.md"]
     assert ref.comment == "Refers to OTHER_AUTHORS.md"

--- a/tests/test_deps_enrichment.py
+++ b/tests/test_deps_enrichment.py
@@ -349,17 +349,19 @@ def test_enrich_from_installed_skips_license_when_absent(
 
 def test_resolve_supplier_from_author_email() -> None:
     meta = _FakeMetadata({"Author-email": "Trail of Bits <opensource@trailofbits.com>"})
-    assert _resolve_supplier(meta) == ("Trail of Bits", "opensource@trailofbits.com")
+    assert _resolve_supplier(meta) == [("Trail of Bits", "opensource@trailofbits.com")]
 
 
 def test_resolve_supplier_falls_back_to_maintainer() -> None:
     meta = _FakeMetadata(
         {"Maintainer-email": "Taneli Hukkinen <hukkin@users.noreply.github.com>"}
     )
-    assert _resolve_supplier(meta) == (
-        "Taneli Hukkinen",
-        "hukkin@users.noreply.github.com",
-    )
+    assert _resolve_supplier(meta) == [
+        (
+            "Taneli Hukkinen",
+            "hukkin@users.noreply.github.com",
+        )
+    ]
 
 
 def test_resolve_supplier_handles_multiple_maintainer_addresses() -> None:
@@ -379,16 +381,20 @@ def test_resolve_supplier_handles_multiple_maintainer_addresses() -> None:
             )
         }
     )
-    assert _resolve_supplier(meta) == ("Bernát Gábor", "gaborjbernat@gmail.com")
+    assert _resolve_supplier(meta) == [
+        ("Bernát Gábor", "gaborjbernat@gmail.com"),
+        ("Kemal Zebari", "kemalzebra@gmail.com"),
+        ("Vineet Naik", "naikvin@gmail.com"),
+    ]
 
 
 def test_resolve_supplier_plain_name_no_email() -> None:
     meta = _FakeMetadata({"Author": "Some Org"})
-    assert _resolve_supplier(meta) == ("Some Org", None)
+    assert _resolve_supplier(meta) == [("Some Org", None)]
 
 
 def test_resolve_supplier_absent_returns_none() -> None:
-    assert _resolve_supplier(_FakeMetadata({})) == (None, None)
+    assert _resolve_supplier(_FakeMetadata({})) == []
 
 
 def test_enrich_from_installed_sets_supplied_by(
@@ -535,19 +541,19 @@ def test_find_license_copyright_matches_dist_info_root_not_only_licenses_subdir(
 
 def test_extract_pypi_supplier_from_author() -> None:
     info = {"author": "Trail of Bits", "author_email": "opensource@trailofbits.com"}
-    assert _extract_pypi_supplier(info) == (
-        "Trail of Bits",
-        "opensource@trailofbits.com",
-    )
+    assert _extract_pypi_supplier(info) == [("Trail of Bits", "opensource@trailofbits.com")]
 
 
 def test_extract_pypi_supplier_falls_back_to_maintainer() -> None:
-    info = {"maintainer": "Someone", "maintainer_email": "someone@example.com"}
-    assert _extract_pypi_supplier(info) == ("Someone", "someone@example.com")
+    info = {
+        "maintainer": "Taneli Hukkinen",
+        "maintainer_email": "hukkin@users.noreply.github.com",
+    }
+    assert _extract_pypi_supplier(info) == [("Taneli Hukkinen", "hukkin@users.noreply.github.com")]
 
 
 def test_extract_pypi_supplier_absent_returns_none() -> None:
-    assert _extract_pypi_supplier({}) == (None, None)
+    assert _extract_pypi_supplier({}) == []
 
 
 def test_extract_pypi_license_prefers_license_expression() -> None:
@@ -989,3 +995,48 @@ def test_fetch_pypi_release_info_live_network() -> None:
     digest = _extract_release_hash(release_info)
     assert digest is not None
     assert len(digest) == 64  # hex sha256
+
+
+def test_extract_suppliers_parses_comma_separated_names() -> None:
+    meta = _FakeMetadata({"Author": "Alice, Bob and Charlie"})
+    assert deps_mod._resolve_supplier(meta) == [
+        ("Alice", None),
+        ("Bob", None),
+        ("Charlie", None),
+    ]
+
+
+def test_apply_supplier_creates_others_external_ref() -> None:
+    doc_uuid = compute_doc_uuid("otherstest", "1.0", [])
+    _clear_doc_counters(doc_uuid)
+    exporter = Spdx3JsonExporter()
+    ci = _make_ci()
+    dep_package = spdx3.software_Package(
+        spdxId=generate_spdx_id("Package", doc_name="otherstest", doc_uuid=doc_uuid),
+        name="test",
+        creationInfo=ci,
+    )
+    exporter.add_package(dep_package)
+
+    suppliers = [("Alice", None), ("Others (See OTHER_AUTHORS.md)", None)]
+    deps_mod._apply_supplier(
+        suppliers,
+        dep_package,
+        ci,
+        "otherstest",
+        doc_uuid,
+        exporter,
+        repo_url="https://github.com/foo/bar.git",
+        offline=True,
+    )
+
+    agents = [o for o in exporter.object_set.objects if isinstance(o, spdx3.Person)]
+    assert len(agents) == 2
+    
+    others = next((a for a in agents if "Others" in a.name), None)
+    assert others is not None
+    assert len(others.externalRef) == 1
+    ref = others.externalRef[0]
+    assert ref.externalRefType == spdx3.ExternalRefType.documentation
+    assert ref.locator == ["https://github.com/foo/bar/blob/HEAD/OTHER_AUTHORS.md"]
+    assert ref.comment == "Refers to OTHER_AUTHORS.md"

--- a/tests/test_deps_enrichment.py
+++ b/tests/test_deps_enrichment.py
@@ -25,6 +25,7 @@ from collections.abc import Iterator
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError
 from typing import Any, cast
+from unittest.mock import MagicMock, patch
 
 import pytest
 from spdx_python_model.bindings import v3_0_1 as spdx3
@@ -1096,3 +1097,51 @@ def test_resolve_remote_authors_file_offline_and_errors() -> None:
     assert locator2 == locator
     assert ctype2 == ctype
     assert content2 == content
+
+
+@patch("urllib.request.urlopen")
+def test_resolve_remote_authors_file_success_and_branches(
+    mock_urlopen: MagicMock,
+) -> None:
+    """Test successful URL fetch and other repository branches."""
+    # Mock successful response
+    mock_response = MagicMock()
+    mock_response.read.return_value = b"Author1\nAuthor2"
+    mock_urlopen.return_value.__enter__.return_value = mock_response
+
+    # Test github.com with successful fetch
+    locator, _ctype, content = deps_mod._resolve_remote_authors_file(
+        "https://github.com/foo/pkg",
+        "AUTHORS",
+        offline=False,
+        content_type_method="auto",
+    )
+    assert locator == "https://github.com/foo/pkg/blob/HEAD/AUTHORS"
+    assert content == "Author1\nAuthor2"
+
+    # Test gitlab.com
+    locator, _ctype, content = deps_mod._resolve_remote_authors_file(
+        "https://gitlab.com/foo/pkg",
+        "AUTHORS",
+        offline=True,
+        content_type_method="auto",
+    )
+    assert locator == "https://gitlab.com/foo/pkg/-/blob/HEAD/AUTHORS"
+
+    # Test unknown host
+    locator, _ctype, content = deps_mod._resolve_remote_authors_file(
+        "https://example.com/foo/pkg",
+        "AUTHORS",
+        offline=True,
+        content_type_method="auto",
+    )
+    assert locator == "https://example.com/foo/pkg"
+
+    # Test short path
+    locator, _ctype, content = deps_mod._resolve_remote_authors_file(
+        "https://github.com/foo",
+        "AUTHORS",
+        offline=True,
+        content_type_method="auto",
+    )
+    assert locator == "https://github.com/foo"

--- a/tests/test_deps_enrichment.py
+++ b/tests/test_deps_enrichment.py
@@ -397,7 +397,7 @@ def test_resolve_supplier_absent_returns_none() -> None:
     assert _resolve_supplier(_FakeMetadata({})) == []
 
 
-def test_enrich_from_installed_sets_supplied_by(
+def test_enrich_from_installed_sets_originated_by(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -422,11 +422,11 @@ def test_enrich_from_installed_sets_supplied_by(
 
     _enrich_from_installed("tomli", dep_package, ci, "supptest", doc_uuid, exporter)
 
-    assert dep_package.suppliedBy is not None
+    assert dep_package.originatedBy is not None
     agents = [o for o in exporter.object_set.objects if isinstance(o, spdx3.Person)]
     assert len(agents) == 1
     assert agents[0].name == "Taneli Hukkinen"
-    assert dep_package.suppliedBy == require_spdx_id(agents[0])
+    assert dep_package.originatedBy == [require_spdx_id(agents[0])]
 
 
 def test_enrich_from_installed_dedupes_shared_supplier_agent(
@@ -1006,7 +1006,7 @@ def test_extract_suppliers_parses_comma_separated_names() -> None:
     ]
 
 
-def test_apply_supplier_creates_others_external_ref() -> None:
+def test_apply_originator_creates_others_external_ref() -> None:
     doc_uuid = compute_doc_uuid("otherstest", "1.0", [])
     _clear_doc_counters(doc_uuid)
     exporter = Spdx3JsonExporter()
@@ -1018,9 +1018,9 @@ def test_apply_supplier_creates_others_external_ref() -> None:
     )
     exporter.add_package(dep_package)
 
-    suppliers = [("Alice", None), ("Others (See OTHER_AUTHORS.md)", None)]
-    deps_mod._apply_supplier(
-        suppliers,
+    originators = [("Alice", None), ("Others (See OTHER_AUTHORS.md)", None)]
+    deps_mod._apply_originator(
+        originators,
         dep_package,
         ci,
         "otherstest",
@@ -1030,11 +1030,13 @@ def test_apply_supplier_creates_others_external_ref() -> None:
         offline=True,
     )
 
-    agents = [o for o in exporter.object_set.objects if isinstance(o, spdx3.Person)]
+    agents = [o for o in exporter.object_set.objects if isinstance(o, (spdx3.Person, spdx3.Organization))]
     assert len(agents) == 2
     
-    others = next((a for a in agents if "Others" in a.name), None)
+    others = next((a for a in agents if "Others" in a.name and isinstance(a, spdx3.Organization)), None)
     assert others is not None
+    
+    assert len(dep_package.originatedBy) == 2
     assert len(others.externalRef) == 1
     ref = others.externalRef[0]
     assert ref.externalRefType == spdx3.ExternalRefType.documentation

--- a/tests/test_deps_enrichment.py
+++ b/tests/test_deps_enrichment.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access
 # SPDX-FileContributor: Arthit Suriyawongkul
 # SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 # SPDX-FileType: SOURCE
@@ -541,7 +542,9 @@ def test_find_license_copyright_matches_dist_info_root_not_only_licenses_subdir(
 
 def test_extract_pypi_supplier_from_author() -> None:
     info = {"author": "Trail of Bits", "author_email": "opensource@trailofbits.com"}
-    assert _extract_pypi_supplier(info) == [("Trail of Bits", "opensource@trailofbits.com")]
+    assert _extract_pypi_supplier(info) == [
+        ("Trail of Bits", "opensource@trailofbits.com")
+    ]
 
 
 def test_extract_pypi_supplier_falls_back_to_maintainer() -> None:
@@ -549,7 +552,9 @@ def test_extract_pypi_supplier_falls_back_to_maintainer() -> None:
         "maintainer": "Taneli Hukkinen",
         "maintainer_email": "hukkin@users.noreply.github.com",
     }
-    assert _extract_pypi_supplier(info) == [("Taneli Hukkinen", "hukkin@users.noreply.github.com")]
+    assert _extract_pypi_supplier(info) == [
+        ("Taneli Hukkinen", "hukkin@users.noreply.github.com")
+    ]
 
 
 def test_extract_pypi_supplier_absent_returns_none() -> None:
@@ -1018,7 +1023,10 @@ def test_apply_originator_creates_others_external_ref() -> None:
     )
     exporter.add_package(dep_package)
 
-    originators: list[tuple[str | None, str | None]] = [("Alice", None), ("Others (See OTHER_AUTHORS.md)", None)]
+    originators: list[tuple[str | None, str | None]] = [
+        ("Alice", None),
+        ("Others (See OTHER_AUTHORS.md)", None),
+    ]
     deps_mod._apply_originator(
         originators,
         dep_package,
@@ -1030,10 +1038,21 @@ def test_apply_originator_creates_others_external_ref() -> None:
         offline=True,
     )
 
-    agents = [o for o in exporter.object_set.objects if isinstance(o, (spdx3.Person, spdx3.Organization))]
+    agents = [
+        o
+        for o in exporter.object_set.objects
+        if isinstance(o, (spdx3.Person, spdx3.Organization))
+    ]
     assert len(agents) == 2
 
-    others = next((a for a in agents if a.name and "Others" in a.name and isinstance(a, spdx3.Organization)), None)
+    others = next(
+        (
+            a
+            for a in agents
+            if a.name and "Others" in a.name and isinstance(a, spdx3.Organization)
+        ),
+        None,
+    )
     assert others is not None
     assert len(others.externalRef) == 1
     ref = others.externalRef[0]
@@ -1041,7 +1060,10 @@ def test_apply_originator_creates_others_external_ref() -> None:
     assert ref.externalRefType == spdx3.ExternalRefType.documentation
 
     assert len(dep_package.software_attributionText) > 0
-    assert "Attribution: This package includes contributions from additional authors" in dep_package.software_attributionText[0]
+    assert (
+        "Attribution: This package includes contributions from additional authors"
+        in dep_package.software_attributionText[0]
+    )
     assert ref.locator == ["https://github.com/foo/bar/blob/HEAD/OTHER_AUTHORS.md"]
     assert ref.comment == "Refers to OTHER_AUTHORS.md"
 
@@ -1050,10 +1072,13 @@ def test_resolve_remote_authors_file_offline_and_errors() -> None:
     """Test offline behavior and ValueError handling for remote authors files."""
     # Test offline returns immediately without trying to fetch
     locator, ctype, content = deps_mod._resolve_remote_authors_file(
-        "https://github.com/foo/pkg", "AUTHORS", offline=True, content_type_method="auto"
+        "https://github.com/foo/pkg",
+        "AUTHORS",
+        offline=True,
+        content_type_method="auto",
     )
     assert locator == "https://github.com/foo/pkg/blob/HEAD/AUTHORS"
-    assert ctype == "text/plain"
+    assert ctype is None
     assert content is None
 
     # Test ValueError when scheme is disallowed (ftp)
@@ -1061,7 +1086,7 @@ def test_resolve_remote_authors_file_offline_and_errors() -> None:
         "ftp://github.com/foo/pkg", "AUTHORS", offline=False, content_type_method="auto"
     )
     assert locator == "ftp://github.com/foo/pkg/blob/HEAD/AUTHORS"
-    assert ctype == "text/plain"
+    assert ctype is None
     assert content is None
 
     # Test lru_cache behavior (call twice, check it returns identical)
@@ -1071,4 +1096,3 @@ def test_resolve_remote_authors_file_offline_and_errors() -> None:
     assert locator2 == locator
     assert ctype2 == ctype
     assert content2 == content
-

--- a/tests/test_deps_enrichment.py
+++ b/tests/test_deps_enrichment.py
@@ -422,7 +422,7 @@ def test_enrich_from_installed_sets_originated_by(
 
     _enrich_from_installed("tomli", dep_package, ci, "supptest", doc_uuid, exporter)
 
-    assert dep_package.originatedBy is not None
+    assert len(dep_package.originatedBy) > 0
     agents = [o for o in exporter.object_set.objects if isinstance(o, spdx3.Person)]
     assert len(agents) == 1
     assert agents[0].name == "Taneli Hukkinen"
@@ -1018,7 +1018,7 @@ def test_apply_originator_creates_others_external_ref() -> None:
     )
     exporter.add_package(dep_package)
 
-    originators = [("Alice", None), ("Others (See OTHER_AUTHORS.md)", None)]
+    originators: list[tuple[str | None, str | None]] = [("Alice", None), ("Others (See OTHER_AUTHORS.md)", None)]
     deps_mod._apply_originator(
         originators,
         dep_package,
@@ -1032,16 +1032,43 @@ def test_apply_originator_creates_others_external_ref() -> None:
 
     agents = [o for o in exporter.object_set.objects if isinstance(o, (spdx3.Person, spdx3.Organization))]
     assert len(agents) == 2
-    
-    others = next((a for a in agents if "Others" in a.name and isinstance(a, spdx3.Organization)), None)
+
+    others = next((a for a in agents if a.name and "Others" in a.name and isinstance(a, spdx3.Organization)), None)
     assert others is not None
-    
-    assert len(dep_package.originatedBy) == 2
     assert len(others.externalRef) == 1
     ref = others.externalRef[0]
+    assert isinstance(ref, spdx3.ExternalRef)
     assert ref.externalRefType == spdx3.ExternalRefType.documentation
-    
-    assert dep_package.software_attributionText is not None
-    assert "Attribution: This software includes contributions from additional authors" in dep_package.software_attributionText[0]
+
+    assert len(dep_package.software_attributionText) > 0
+    assert "Attribution: This package includes contributions from additional authors" in dep_package.software_attributionText[0]
     assert ref.locator == ["https://github.com/foo/bar/blob/HEAD/OTHER_AUTHORS.md"]
     assert ref.comment == "Refers to OTHER_AUTHORS.md"
+
+
+def test_resolve_remote_authors_file_offline_and_errors() -> None:
+    """Test offline behavior and ValueError handling for remote authors files."""
+    # Test offline returns immediately without trying to fetch
+    locator, ctype, content = deps_mod._resolve_remote_authors_file(
+        "https://github.com/foo/pkg", "AUTHORS", offline=True, content_type_method="auto"
+    )
+    assert locator == "https://github.com/foo/pkg/blob/HEAD/AUTHORS"
+    assert ctype == "text/plain"
+    assert content is None
+
+    # Test ValueError when scheme is disallowed (ftp)
+    locator, ctype, content = deps_mod._resolve_remote_authors_file(
+        "ftp://github.com/foo/pkg", "AUTHORS", offline=False, content_type_method="auto"
+    )
+    assert locator == "ftp://github.com/foo/pkg/blob/HEAD/AUTHORS"
+    assert ctype == "text/plain"
+    assert content is None
+
+    # Test lru_cache behavior (call twice, check it returns identical)
+    locator2, ctype2, content2 = deps_mod._resolve_remote_authors_file(
+        "ftp://github.com/foo/pkg", "AUTHORS", offline=False, content_type_method="auto"
+    )
+    assert locator2 == locator
+    assert ctype2 == ctype
+    assert content2 == content
+

--- a/working-docs/design/provenance-enrichment-vocabulary.md
+++ b/working-docs/design/provenance-enrichment-vocabulary.md
@@ -145,6 +145,7 @@ keyed `method` in the JSON statement).
 | `dynamic_extraction` | Value read from a Python file at build time (e.g. `__version__`/`__about__.py`), not `pyproject.toml` directly | `src/pitloom/extract/pyproject.py:340`, `:361` |
 | `licenseid_detection` | License matched against a known SPDX id via the `licenseid` library -- detected, not declared | `src/pitloom/extract/pyproject.py:301`; `src/pitloom/extract/_huggingface.py:392`, `:523`; `src/pitloom/extract/_license.py:352`, `:415` |
 | `inferred_from_authors` | Copyright text derived from the `authors` list, not read verbatim | `src/pitloom/extract/setuptools.py:280`, `:427`; `src/pitloom/extract/poetry.py:169`; `src/pitloom/extract/hatchling.py:143`; `src/pitloom/extract/pyproject.py:200` |
+| `parsed_author_list` | Multiple individual entities extracted by splitting a single, comma-separated author string | `src/pitloom/assemble/spdx3/deps.py` |
 | `file_directive` | `pyproject.toml` dynamic field pointed at a file (`{file = "..."}`) | `src/pitloom/extract/setuptools.py:495` |
 | `attr_directive` | `pyproject.toml` dynamic field pointed at a Python attribute (`{attr = "..."}`) | `src/pitloom/extract/setuptools.py:514` |
 | `inspect_caller` | Recorded automatically by the `pitloom.loom` SDK via stack inspection | `src/pitloom/loom.py:52`, `:57`, `:62` |
@@ -357,6 +358,7 @@ involved.
 | `dynamic_extraction` | Read from a Python file at build time (e.g. a `__version__` or `__about__.py` variable), not from `pyproject.toml` directly. |
 | `licenseid_detection` | License text matched against a known SPDX license using the [`licenseid`](https://pypi.org/project/licenseid/) library -- detected, not author-declared. |
 | `inferred_from_authors` | Derived from the `authors` list (e.g. a copyright statement), not read verbatim from any single field. |
+| `parsed_author_list` | Extracted multiple individual entities by splitting a single, comma-separated author string. |
 | `file_directive` | A `pyproject.toml` dynamic field pointed at a file (`{file = "..."}`); the value was read from that file. |
 | `attr_directive` | A `pyproject.toml` dynamic field pointed at a Python attribute (`{attr = "..."}`); the value was imported and read from code. |
 | `inspect_caller` | Recorded automatically by the `pitloom.loom` tracking SDK via Python stack inspection -- identifies which script/function called the SDK. |


### PR DESCRIPTION
## Summary

Split a string containing a list of authors into discrete agents and generate external refs for indirect authors ("Others")

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [ ] Tests pass (`pytest`)
- [ ] Code formatted (`ruff format`)
- [ ] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [ ] `CHANGELOG.md` updated (if user-facing)
- [ ] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [ ] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
