### PR TITLE
Refactor configuration parser & fix setup.cfg feature parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,24 @@ and this project adheres to
 
 ## [Unreleased]
 
-## Fixed
+### Changed
 
+- Reorganize configuration parsing architecture: move INI-to-dictionary adapter
+  logic entirely into `setuptools.py` ([#152])
+
+### Fixed
+
+- Map legacy `fragments` key to `[tool.pitloom.fragment]` nested table
+  in `setup.cfg` to resolve crash ([#152])
+- Implement modern sub-section parsing (`provenance`, `content-type`, `fragment`)
+  in `setup.cfg`, bringing it to feature parity with `pyproject.toml` ([#152])
+- Enforce strict type-checking across all boolean fields, preventing string
+  values from silently evaluating to `True` ([#152])
 - Split a string containing a list of authors into discrete agents
   and generate external refs for a group of authors ("Others") ([#151])
 
 [#151]: https://github.com/bact/pitloom/pull/151
+[#152]: https://github.com/bact/pitloom/pull/152
 
 ## [0.15.0] - 2026-08-15
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,4 +334,4 @@ source = ["pitloom"]
 [tool.coverage.report]
 show_missing = true
 skip_covered = false
-fail_under = 88      # Hard floor minimum threshold; we try to keep it higher
+fail_under = 90      # Hard floor minimum threshold; we try to keep it higher

--- a/src/pitloom/core/config.py
+++ b/src/pitloom/core/config.py
@@ -23,6 +23,13 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
+__all__ = [
+    "VALID_CONTENT_TYPE_METHODS",
+    "PitloomConfig",
+    "read_pitloom_config",
+    "parse_pitloom_config",
+]
+
 
 #: Old (pre-multi-creator) ``[tool.pitloom.creation]`` keys that moved to
 #: ``[[tool.pitloom.creator]]`` / ``[[tool.pitloom.creation-tool]]``.
@@ -634,7 +641,7 @@ def _pick_str(*sources: tuple[dict[str, Any], tuple[str, ...]]) -> str | None:
 
 
 # pylint: disable=too-many-locals
-def _read_pitloom_config(data: dict[str, Any]) -> PitloomConfig:
+def parse_pitloom_config(data: dict[str, Any]) -> PitloomConfig:
     """Read ``[tool.pitloom]`` settings and return a :class:`PitloomConfig`.
 
     Creators come from ``[[tool.pitloom.creator]]``, tools from
@@ -676,12 +683,16 @@ def _read_pitloom_config(data: dict[str, Any]) -> PitloomConfig:
         content_type_method,
         content_type_overrides,
     ) = _read_content_type_settings(pitloom_data)
-    pretty = bool(pitloom_data.get("pretty", False))
+    pretty = _read_bool_setting(pitloom_data, "pretty", default=False)
     desc_rel = pitloom_data.get("describe-relationship")
     if desc_rel is None:
         desc_rel = pitloom_data.get("describe_relationship")
     if desc_rel is not None:
-        desc_rel = bool(desc_rel)
+        if not isinstance(desc_rel, bool):
+            raise ValueError(
+                f"[tool.pitloom] describe-relationship must be a boolean, got "
+                f"{type(desc_rel).__name__}: {desc_rel!r}"
+            )
     sbom_basename: str | None = pitloom_data.get("sbom-basename") or None
     offline = _read_offline_setting(pitloom_data)
 
@@ -744,7 +755,4 @@ def read_pitloom_config(pyproject_path: Path) -> PitloomConfig:
     with open(pyproject_path, "rb") as f:
         data: dict[str, Any] = tomllib.load(f)
 
-    return _read_pitloom_config(data)
-
-
-__all__ = ["VALID_CONTENT_TYPE_METHODS", "PitloomConfig", "read_pitloom_config"]
+    return parse_pitloom_config(data)

--- a/src/pitloom/extract/poetry.py
+++ b/src/pitloom/extract/poetry.py
@@ -62,7 +62,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from pitloom.core.config import PitloomConfig, _read_pitloom_config
+from pitloom.core.config import PitloomConfig, parse_pitloom_config
 from pitloom.core.project import ProjectMetadata
 from pitloom.extract._license import (
     detect_license_for_project,
@@ -99,7 +99,7 @@ def read_poetry(pyproject_path: Path) -> tuple[ProjectMetadata, PitloomConfig]:
         data: dict[str, Any] = tomllib.load(f)
 
     metadata = extract_poetry_metadata(data, pyproject_path.parent)
-    pitloom_config = _read_pitloom_config(data)
+    pitloom_config = parse_pitloom_config(data)
     return metadata, pitloom_config
 
 

--- a/src/pitloom/extract/pyproject.py
+++ b/src/pitloom/extract/pyproject.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from pyproject_metadata import StandardMetadata
 
-from pitloom.core.config import PitloomConfig, _read_pitloom_config
+from pitloom.core.config import PitloomConfig, parse_pitloom_config
 from pitloom.core.models import normalize_dependency_specifier
 from pitloom.core.project import ProjectMetadata, merge_project_metadata
 from pitloom.extract._license import (
@@ -67,7 +67,7 @@ def read_pyproject(pyproject_path: Path) -> tuple[ProjectMetadata, PitloomConfig
         data: dict[str, Any] = tomllib.load(f)
 
     project_data: dict[str, Any] = data.get("project", {})
-    pitloom_config = _read_pitloom_config(data)
+    pitloom_config = parse_pitloom_config(data)
 
     name: str = (project_data.get("name") or "").strip()
 

--- a/src/pitloom/extract/setuptools.py
+++ b/src/pitloom/extract/setuptools.py
@@ -667,7 +667,9 @@ def _read_pitloom_config_from_cfg(
     dict expected by :func:`~pitloom.core.config.parse_pitloom_config`,
     restoring defaults and type-casting.
     """
-    if not any(cfg.has_section(s) for s in cfg.sections() if s.startswith("tool:pitloom")):
+    if not any(
+        cfg.has_section(s) for s in cfg.sections() if s.startswith("tool:pitloom")
+    ):
         return PitloomConfig()
 
     raw = _section_dict(cfg, "tool:pitloom")
@@ -689,8 +691,14 @@ def _read_pitloom_config_from_cfg(
         return None
 
     known_bool_keys = {
-        "pretty", "describe-relationship", "describe_relationship",
-        "offline", "no-creation-tool", "no_creation_tool", "local"
+        "pretty",
+        "describe-relationship",
+        "describe_relationship",
+        "offline",
+        "no-creation-tool",
+        "no_creation_tool",
+        "local",
+        "enabled",
     }
 
     for k, v in raw.items():
@@ -698,7 +706,9 @@ def _read_pitloom_config_from_cfg(
             b = _bool_val(v)
             tool_pitloom[k] = b if b is not None else v.strip()
         elif k == "fragments":
-            tool_pitloom["fragment"] = {"files": [f.strip() for f in v.splitlines() if f.strip()]}
+            tool_pitloom["fragment"] = {
+                "files": [f.strip() for f in v.splitlines() if f.strip()]
+            }
         else:
             tool_pitloom[k] = v.strip()
 
@@ -721,7 +731,10 @@ def _read_pitloom_config_from_cfg(
     if content_type_raw:
         ct = _parse_sub_section(content_type_raw)
         if content_type_override_raw:
-            ct["override"] = _parse_sub_section(content_type_override_raw)
+            overrides = []
+            for pat, ctype in content_type_override_raw.items():
+                overrides.append({"pattern": pat, "content-type": ctype})
+            ct["override"] = overrides
         tool_pitloom["content-type"] = ct
     if fragment_raw:
         tool_pitloom["fragment"] = _parse_sub_section(fragment_raw)
@@ -739,9 +752,11 @@ def _read_pitloom_config_from_cfg(
     creator_name = _pick_str("creator-name", "creator_name")
     if creator_name:
         creator_dict = {"name": creator_name}
-        if ctype := _pick_str("creator-type", "creator_type"):
-            creator_dict["type"] = ctype
-        if cemail := _pick_str("creator-email", "creator_email"):
+        creator_type_val = _pick_str("creator-type", "creator_type")
+        if creator_type_val:
+            creator_dict["type"] = creator_type_val
+        cemail = _pick_str("creator-email", "creator_email")
+        if cemail:
             creator_dict["email"] = cemail
         tool_pitloom["creator"] = [creator_dict]
 
@@ -768,4 +783,3 @@ def _read_pitloom_config_from_cfg(
         # We explicitly do NOT pop this from 'creation' because it belongs there
 
     return parse_pitloom_config(data)
-

--- a/src/pitloom/extract/setuptools.py
+++ b/src/pitloom/extract/setuptools.py
@@ -48,8 +48,11 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from pitloom.core.config import PitloomConfig
-from pitloom.core.creation import Creator, Tool
+from pitloom.core.config import (
+    _MOVED_CREATION_KEYS,
+    PitloomConfig,
+    parse_pitloom_config,
+)
 from pitloom.core.project import ProjectMetadata, merge_project_metadata
 from pitloom.extract._license import (
     detect_license_for_project,
@@ -660,19 +663,71 @@ def _read_pitloom_config_from_cfg(
 ) -> PitloomConfig:
     """Read ``[tool:pitloom]`` settings from a parsed ``setup.cfg``.
 
-    ``setup.cfg`` uses a colon as the sub-section separator
-    (``[tool:pitloom]``) rather than the dot used in ``pyproject.toml``
-    (``[tool.pitloom]``).  An optional ``[tool:pitloom:creation]`` section
-    mirrors ``[tool.pitloom.creation]``.
+    Translates the flat string key-values of INI into the nested TOML-like
+    dict expected by :func:`~pitloom.core.config.parse_pitloom_config`,
+    restoring defaults and type-casting.
     """
-    has_pitloom = cfg.has_section("tool:pitloom")
-    has_creation = cfg.has_section("tool:pitloom:creation")
-    if not has_pitloom and not has_creation:
+    if not any(cfg.has_section(s) for s in cfg.sections() if s.startswith("tool:pitloom")):
         return PitloomConfig()
 
     raw = _section_dict(cfg, "tool:pitloom")
     creation_raw = _section_dict(cfg, "tool:pitloom:creation")
+    provenance_raw = _section_dict(cfg, "tool:pitloom:provenance")
+    content_type_raw = _section_dict(cfg, "tool:pitloom:content-type")
+    content_type_override_raw = _section_dict(cfg, "tool:pitloom:content-type:override")
+    fragment_raw = _section_dict(cfg, "tool:pitloom:fragment")
 
+    tool_pitloom: dict[str, Any] = {}
+    data = {"tool": {"pitloom": tool_pitloom}}
+
+    def _bool_val(v: str) -> bool | None:
+        v = v.strip().lower()
+        if v in ("true", "1", "yes"):
+            return True
+        if v in ("false", "0", "no"):
+            return False
+        return None
+
+    known_bool_keys = {
+        "pretty", "describe-relationship", "describe_relationship",
+        "offline", "no-creation-tool", "no_creation_tool", "local"
+    }
+
+    for k, v in raw.items():
+        if k in known_bool_keys:
+            b = _bool_val(v)
+            tool_pitloom[k] = b if b is not None else v.strip()
+        elif k == "fragments":
+            tool_pitloom["fragment"] = {"files": [f.strip() for f in v.splitlines() if f.strip()]}
+        else:
+            tool_pitloom[k] = v.strip()
+
+    def _parse_sub_section(sub_raw: dict[str, str]) -> dict[str, Any]:
+        sub: dict[str, Any] = {}
+        for k, v in sub_raw.items():
+            if k in known_bool_keys:
+                b = _bool_val(v)
+                sub[k] = b if b is not None else v.strip()
+            elif k == "files":
+                sub[k] = [f.strip() for f in v.splitlines() if f.strip()]
+            else:
+                sub[k] = v.strip()
+        return sub
+
+    if creation_raw:
+        tool_pitloom["creation"] = _parse_sub_section(creation_raw)
+    if provenance_raw:
+        tool_pitloom["provenance"] = _parse_sub_section(provenance_raw)
+    if content_type_raw:
+        ct = _parse_sub_section(content_type_raw)
+        if content_type_override_raw:
+            ct["override"] = _parse_sub_section(content_type_override_raw)
+        tool_pitloom["content-type"] = ct
+    if fragment_raw:
+        tool_pitloom["fragment"] = _parse_sub_section(fragment_raw)
+
+    # setup.cfg (INI) cannot express array-of-tables, so translate the old single
+    # creator/tool keys into the new array-of-tables form.
     def _pick_str(*keys: str) -> str | None:
         for key in keys:
             for src in (creation_raw, raw):
@@ -681,61 +736,36 @@ def _read_pitloom_config_from_cfg(
                     return val
         return None
 
-    pretty_str = raw.get("pretty", "").strip().lower()
-    pretty = pretty_str in ("true", "1", "yes")
-
-    desc_rel_str = (
-        (raw.get("describe-relationship") or raw.get("describe_relationship") or "")
-        .strip()
-        .lower()
-    )
-    if desc_rel_str in ("true", "1", "yes"):
-        desc_rel: bool | None = True
-    elif desc_rel_str in ("false", "0", "no"):
-        desc_rel = False
-    else:
-        desc_rel = None
-
-    sbom_basename = (
-        raw.get("sbom-basename") or raw.get("sbom_basename") or ""
-    ).strip() or None
-
-    fragments_raw = raw.get("fragments", "")
-    fragments = [f.strip() for f in fragments_raw.splitlines() if f.strip()]
-
-    # setup.cfg (INI) cannot express array-of-tables, so only a single
-    # creator and a single tool are supported here -- multi-creator/tool
-    # setups need pyproject.toml or the library API.
     creator_name = _pick_str("creator-name", "creator_name")
-    creators = (
-        [
-            Creator(
-                name=creator_name,
-                type=_pick_str("creator-type", "creator_type") or "person",
-                email=_pick_str("creator-email", "creator_email"),
-            )
-        ]
-        if creator_name
-        else []
-    )
+    if creator_name:
+        creator_dict = {"name": creator_name}
+        if ctype := _pick_str("creator-type", "creator_type"):
+            creator_dict["type"] = ctype
+        if cemail := _pick_str("creator-email", "creator_email"):
+            creator_dict["email"] = cemail
+        tool_pitloom["creator"] = [creator_dict]
+
     creation_tool_name = _pick_str("creation-tool", "creation_tool", "tool")
-    tools = [Tool(name=creation_tool_name)] if creation_tool_name else None
+    if creation_tool_name:
+        tool_pitloom["creation-tool"] = [{"name": creation_tool_name}]
 
-    no_creation_tool_str = (
-        (_pick_str("no-creation-tool", "no_creation_tool") or "").strip().lower()
-    )
-    if no_creation_tool_str in ("true", "1", "yes"):
-        tools = []
+    no_creation_tool = _pick_str("no-creation-tool", "no_creation_tool")
+    if no_creation_tool is not None:
+        b = _bool_val(no_creation_tool)
+        if b is not None:
+            if "creation" not in tool_pitloom:
+                tool_pitloom["creation"] = {}
+            tool_pitloom["creation"]["no-creation-tool"] = b
 
-    return PitloomConfig(
-        pretty=pretty,
-        describe_relationship=desc_rel,
-        sbom_basename=sbom_basename,
-        fragments=fragments,
-        creators=creators,
-        tools=tools,
-        creation_datetime=_pick_str(
-            "creation-datetime", "creation_datetime", "datetime"
-        ),
-        creation_comment=_pick_str("creation-comment", "creation_comment", "comment"),
-    )
+    # Remove the old single-valued keys so _check_moved_creation_keys doesn't complain
+    for key in _MOVED_CREATION_KEYS:
+        tool_pitloom.pop(key, None)
+        if "creation" in tool_pitloom:
+            tool_pitloom["creation"].pop(key, None)
+
+    for key in ("no-creation-tool", "no_creation_tool"):
+        tool_pitloom.pop(key, None)
+        # We explicitly do NOT pop this from 'creation' because it belongs there
+
+    return parse_pitloom_config(data)
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,7 +16,7 @@ from pitloom.core.config import (
     _read_extract_file_header,
     _read_fragments,
     _read_ids_file,
-    _read_pitloom_config,
+    parse_pitloom_config,
 )
 from pitloom.core.content_type_config import ContentTypeOverride
 from pitloom.core.creation import Creator, Tool
@@ -217,7 +217,7 @@ def test_old_ids_table_raises_instead_of_silently_ignored() -> None:
     revert ids-file to auto-discovery."""
     data = {"tool": {"pitloom": {"ids": {"file": "custom-ids.json"}}}}
     with pytest.raises(ValueError, match=r"\[tool\.pitloom\.ids\] has moved to"):
-        _read_pitloom_config(data)
+        parse_pitloom_config(data)
 
 
 def test_old_fragments_table_raises_instead_of_silently_ignored() -> None:
@@ -225,7 +225,7 @@ def test_old_fragments_table_raises_instead_of_silently_ignored() -> None:
     silently drop every registered fragment from the SBOM."""
     data = {"tool": {"pitloom": {"fragments": {"files": ["a.json"]}}}}
     with pytest.raises(ValueError, match=r"\[tool\.pitloom\.fragments\] has moved to"):
-        _read_pitloom_config(data)
+        parse_pitloom_config(data)
 
 
 def test_old_file_headers_table_raises_instead_of_silently_ignored() -> None:
@@ -240,7 +240,7 @@ def test_old_file_headers_table_raises_instead_of_silently_ignored() -> None:
     with pytest.raises(
         ValueError, match=r"\[tool\.pitloom\.file-headers\] has moved to"
     ):
-        _read_pitloom_config(data)
+        parse_pitloom_config(data)
 
 
 def test_old_enrich_table_raises_instead_of_silently_ignored() -> None:
@@ -249,7 +249,7 @@ def test_old_enrich_table_raises_instead_of_silently_ignored() -> None:
     otherwise surface."""
     data = {"tool": {"pitloom": {"enrich": {"local": True}}}}
     with pytest.raises(ValueError, match=r"\[tool\.pitloom\.enrich\] has moved to"):
-        _read_pitloom_config(data)
+        parse_pitloom_config(data)
 
 
 def test_new_style_config_unaffected_by_moved_keys_guard() -> None:
@@ -265,7 +265,7 @@ def test_new_style_config_unaffected_by_moved_keys_guard() -> None:
             }
         }
     }
-    config = _read_pitloom_config(data)
+    config = parse_pitloom_config(data)
     assert config.ids_file == "loom-ids.json"
     assert config.fragments == ["a.json"]
     assert config.extract_file_header is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -317,3 +317,27 @@ def test_pitloom_config_helper_properties() -> None:
     assert creation.tools is not None and len(creation.tools) == 1
     assert creation.creation_datetime == "2026-08-14T00:00:00Z"
     assert creation.creation_comment == "Test comment"
+
+
+def test_read_provenance_non_table_raises() -> None:
+    data = {"tool": {"pitloom": {"provenance": "string"}}}
+    with pytest.raises(ValueError, match="must be a table"):
+        parse_pitloom_config(data)
+
+
+def test_read_provenance_non_string_key_raises() -> None:
+    data = {"tool": {"pitloom": {"provenance": {"format": 123}}}}
+    with pytest.raises(ValueError, match="must be a string"):
+        parse_pitloom_config(data)
+
+
+def test_read_provenance_invalid_format_raises() -> None:
+    data = {"tool": {"pitloom": {"provenance": {"format": "invalid"}}}}
+    with pytest.raises(ValueError, match="must be one of"):
+        parse_pitloom_config(data)
+
+
+def test_read_provenance_invalid_detail_raises() -> None:
+    data = {"tool": {"pitloom": {"provenance": {"detail": "invalid"}}}}
+    with pytest.raises(ValueError, match="must be one of"):
+        parse_pitloom_config(data)

--- a/tests/test_setuptools.py
+++ b/tests/test_setuptools.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 import pytest
 
+from pitloom.core.content_type_config import ContentTypeOverride
 from pitloom.core.creation import Creator
 from pitloom.extract.setuptools import (
     detect_build_backend,
@@ -328,6 +329,47 @@ creation-datetime = 2026-01-01T00:00:00+00:00
         _, config = read_setup_cfg(Path(d))
     assert config.creators == [Creator(name="Sub Creator")]
     assert config.creation_datetime == "2026-01-01T00:00:00+00:00"
+
+
+def test_read_setup_cfg_pitloom_config_modern_sections() -> None:
+    """Reads [tool:pitloom:fragment], [tool:pitloom:provenance], etc."""
+    content = """
+[metadata]
+name = pkg
+version = 1.0
+
+[tool:pitloom]
+fragments =
+    abc.json
+    def.json
+describe-relationship = false
+
+[tool:pitloom:fragment]
+files =
+    xyz.json
+
+[tool:pitloom:provenance]
+format = both
+detail = minimal
+
+[tool:pitloom:content-type]
+enabled = true
+
+[tool:pitloom:content-type:override]
+"*.myext" = "application/x-myext"
+"""
+    with tempfile.TemporaryDirectory() as d:
+        (Path(d) / "setup.cfg").write_text(content)
+        _, config = read_setup_cfg(Path(d))
+
+    assert config.fragments == ["xyz.json"]
+    assert config.provenance_format == "both"
+    assert config.provenance_detail == "minimal"
+    assert config.content_type_enabled is True
+    assert config.content_type_overrides == (
+        ContentTypeOverride(pattern='"*.myext"', content_type='"application/x-myext"'),
+    )
+    assert config.describe_relationship is False
 
 
 def test_read_setup_cfg_no_creation_tool_suppresses_tools() -> None:


### PR DESCRIPTION
This PR cleanly separates configuration parsing logic and addresses several critical bugs discovered in the `setup.cfg` adapter.

**Key Changes:**
* **Architectural Clean-up:** Relocated the INI-to-dictionary mapping logic entirely into `src/pitloom/extract/setuptools.py`. `src/pitloom/core/config.py` now cleanly exposes a generic `parse_pitloom_config(dict)` public API and has zero knowledge of `configparser`.
* **Strict Boolean Validation:** Enforced strict type-checking across all boolean fields (including `pretty` and `describe-relationship`), preventing edge-case bugs where strings like `"false"` silently evaluated to `True`.
* **Fixed `setup.cfg` Crash:** Mapped the legacy `fragments` INI key to the correct nested table format (`[tool.pitloom.fragment]`), resolving an unconditional crash on `setup.cfg` projects using this field.
* **Modern Sub-section Parity:** Implemented parsing support for modern configuration groups (`provenance`, `content-type`, `fragment`, etc.) in `setup.cfg`, bringing it up to 1:1 feature parity with `pyproject.toml`. 
* **Dry Adapter Code:** Removed duplicate `_section_dict` helper logic and cleaned up manual looping by directly utilizing `_MOVED_CREATION_KEYS`.