### PR TITLE
Optimize pytest-xdist parallelization with loadscope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to
 - Avoid loading full file to memory during AI model (NumPy, PyTorch) and
   archive (sdist) extraction, reducing peak memory usage by over 97% ([#156])
 - Centralize SPDX relationship boilerplate across the codebase ([#157])
+- Optimize pytest-xdist parallelization with `loadscope` to prevent
+  redundant fixture evaluations ([#158])
 
 ### Fixed
 
@@ -53,6 +55,7 @@ and this project adheres to
 [#155]: https://github.com/bact/pitloom/pull/155
 [#156]: https://github.com/bact/pitloom/pull/156
 [#157]: https://github.com/bact/pitloom/pull/157
+[#158]: https://github.com/bact/pitloom/pull/158
 
 ## [0.15.0] - 2026-08-15
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,7 +246,7 @@ max-statements = 100
 max-line-length = 88
 
 [tool.pytest.ini_options]
-addopts = ["--import-mode=importlib", "-n", "auto"]
+addopts = ["--import-mode=importlib", "-n", "auto", "--dist=loadscope"]
 pythonpath = ["src"]
 testpaths = ["tests"]
 markers = [


### PR DESCRIPTION
## Summary

Configure pytest-xdist to use loadscope distribution, grouping tests by module. This guarantees heavy module-scoped fixtures are evaluated exactly once per worker, eliminating redundant setup overhead.


## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
