### PR TITLE
Add tests before complexity refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,19 +30,16 @@ and this project adheres to
   with dynamic `args.func` routing ([#153])
 - Split monolithic test files into domain-scoped folders
   (`cli/`, `core/`, `extract/`, `assemble/`) with `conftest.py`
-  ([#153], [#155])
-- Raised fail_under coverage floor to 90% ([#155])
-- Avoid loading full file to memory during AI model (NumPy, PyTorch) and
-  archive (sdist) extraction, reducing peak memory usage by over 97% ([#156])
+  ([#153], [#155], [#161])
+- Raised test coverage to 90% ([#155], [#162])
+- Avoid loading full file to memory during AI model and sdist extraction,
+  reducing peak memory usage by over 97% ([#156])
 - Centralize SPDX relationship boilerplate across the codebase ([#157])
 - Optimize pytest-xdist parallelization with `loadscope` to prevent
   redundant fixture evaluations ([#158])
 - Optimize test workflow by caching the `licenseid` database ([#159])
 - `loom generate` now requires `-o`/`--output` and fails with a clear
   error if it's omitted, instead of guessing a filename. ([#160])
-- Modularize source and test files to strictly comply with file-size limits
-  (all source files $\le 417$ lines, all tests $\le 415$ lines outside mock
-  fixture catalogs) ([#161])
 
 ### Fixed
 
@@ -70,6 +67,7 @@ and this project adheres to
 [#159]: https://github.com/bact/pitloom/pull/159
 [#160]: https://github.com/bact/pitloom/pull/160
 [#161]: https://github.com/bact/pitloom/pull/161
+[#162]: https://github.com/bact/pitloom/pull/162
 
 ## [0.15.0] - 2026-08-15
 

--- a/tests/core/test_generator_model_deployed_tree.py
+++ b/tests/core/test_generator_model_deployed_tree.py
@@ -1,0 +1,193 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for pitloom.assemble.spdx3.document.build_deployed(): the
+pipdeptree-style env_tree walk's dependency-relationship passes -- second
+pass (parent->child dependsOn), third pass (environment-root->top-level
+dependsOn) and their edge cases (a package entry missing a "key", a
+package that is both a dependency and depended upon), plus the
+simpleLicensing profileConformance branch.
+
+See also: tests/core/test_generator_model.py, which covers build_deployed()
+registry-based id reuse -- basic AI-model assembly and usage-file lifecycle
+scoping live there too. tests/core/test_generator_model_enrichment.py for
+license handling on regular (non-deployed) assembler paths.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pitloom.assemble.spdx3.document import build_deployed
+from pitloom.core.creation import CreationMetadata
+from pitloom.core.document import DocumentModel
+from pitloom.core.project import ProjectMetadata
+
+
+def _relationships(graph: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [e for e in graph if e.get("type") == "Relationship"]
+
+
+def _packages(graph: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {e["name"]: e for e in graph if e.get("type") == "software_Package"}
+
+
+def test_build_deployed_links_transitive_dependency_chain() -> None:
+    """A multi-level dependency tree (app -> lib-a -> lib-c, app -> lib-b)
+    exercises the second pass's inner dependency loop in full (lines
+    180-194) and the third pass's "skip, already has a parent" branch
+    (lines 199->197) for every non-root package."""
+    project = ProjectMetadata(name="deployed-environment", version="0.0.0")
+    doc = DocumentModel(project=project, creation_metadata=CreationMetadata())
+    env_tree: list[dict[str, Any]] = [
+        {
+            "package": {
+                "key": "app",
+                "package_name": "app",
+                "installed_version": "1.0",
+            },
+            "dependencies": [{"key": "lib-a"}, {"key": "lib-b"}],
+        },
+        {
+            "package": {
+                "key": "lib-a",
+                "package_name": "lib-a",
+                "installed_version": "2.0",
+            },
+            "dependencies": [{"key": "lib-c"}],
+        },
+        {
+            "package": {
+                "key": "lib-b",
+                "package_name": "lib-b",
+                "installed_version": "3.0",
+            }
+        },
+        {
+            "package": {
+                "key": "lib-c",
+                "package_name": "lib-c",
+                "installed_version": "4.0",
+            }
+        },
+    ]
+
+    exporter = build_deployed(doc, env_tree, offline=True)
+    graph = json.loads(exporter.to_json())["@graph"]
+
+    pkgs = _packages(graph)
+    rels = _relationships(graph)
+    dep_rels = [r for r in rels if r.get("relationshipType") == "dependsOn"]
+
+    def _has(from_name: str, to_name: str) -> bool:
+        from_id = pkgs[from_name]["spdxId"]
+        to_id = pkgs[to_name]["spdxId"]
+        return any(r["from"] == from_id and to_id in r["to"] for r in dep_rels)
+
+    # Second pass: parent -> child edges for every declared dependency.
+    assert _has("app", "lib-a")
+    assert _has("app", "lib-b")
+    assert _has("lib-a", "lib-c")
+
+    # Third pass: only "app" has no parent, so only it gets linked to the
+    # synthetic environment-root main package; lib-a/lib-b/lib-c must not.
+    main_pkg = next(
+        e
+        for e in graph
+        if e.get("type") == "software_Package" and e["name"] == "deployed-environment"
+    )
+    root_edges = [r for r in dep_rels if r["from"] == main_pkg["spdxId"]]
+    assert len(root_edges) == 1
+    assert root_edges[0]["to"] == [pkgs["app"]["spdxId"]]
+
+
+def test_build_deployed_package_without_key_is_skipped_in_relationship_passes() -> None:
+    """A pipdeptree node whose "package" dict has no "key" (only
+    "package_name") still gets a software_Package element in the first
+    pass, but is silently excluded from both the second pass (line 178:
+    no parent_spdx_id to look up) and the third pass (line 201->197: no
+    child_spdx_id to look up either) -- it ends up with no relationship
+    at all rather than crashing."""
+    project = ProjectMetadata(name="deployed-environment", version="0.0.0")
+    doc = DocumentModel(project=project, creation_metadata=CreationMetadata())
+    env_tree: list[dict[str, Any]] = [
+        {
+            "package": {
+                "package_name": "orphan",
+                "installed_version": "9.9",
+            }
+        }
+    ]
+
+    exporter = build_deployed(doc, env_tree, offline=True)
+    graph = json.loads(exporter.to_json())["@graph"]
+
+    pkgs = _packages(graph)
+    assert "orphan" in pkgs
+
+    # Every package (even "orphan") gets a NOASSERTION license
+    # relationship, which is unrelated to the dependency-tree passes under
+    # test here -- restrict to "dependsOn" to check those specifically.
+    dep_rels = [
+        r for r in _relationships(graph) if r.get("relationshipType") == "dependsOn"
+    ]
+    orphan_id = pkgs["orphan"]["spdxId"]
+    assert not any(
+        r["from"] == orphan_id or orphan_id in r.get("to", []) for r in dep_rels
+    )
+
+
+def test_build_deployed_adds_simple_licensing_profile_when_license_found() -> None:
+    """When a dependency's locally-installed metadata resolves a real
+    license (offline path via importlib.metadata, not the network), a
+    simplelicensing_SimpleLicensingText element is created and the
+    document's profileConformance gains the simpleLicensing profile
+    (lines 232-238). "pytest" is used as the dependency name because it
+    is installed in this test environment with a known License-Expression
+    of "MIT"."""
+    project = ProjectMetadata(name="deployed-environment", version="0.0.0")
+    doc = DocumentModel(project=project, creation_metadata=CreationMetadata())
+    env_tree = [
+        {
+            "package": {
+                "key": "pytest",
+                "package_name": "pytest",
+                "installed_version": "unknown",
+            }
+        }
+    ]
+
+    exporter = build_deployed(doc, env_tree, offline=True)
+    graph = json.loads(exporter.to_json())["@graph"]
+
+    licenses = [
+        e for e in graph if e.get("type") == "simplelicensing_SimpleLicensingText"
+    ]
+    assert licenses, "expected a SimpleLicensingText element from pytest's metadata"
+
+    spdx_doc = next(e for e in graph if e.get("type") == "SpdxDocument")
+    assert "simpleLicensing" in spdx_doc["profileConformance"]
+
+
+def test_build_deployed_no_simple_licensing_profile_for_empty_environment() -> None:
+    """Baseline: with no installed packages at all, no
+    simplelicensing_SimpleLicensingText element is ever created (not even
+    a NOASSERTION one, since that path only runs per-dependency), so the
+    simpleLicensing profile must not be added -- the false side of the
+    line 232-238 branch."""
+    project = ProjectMetadata(name="deployed-environment", version="0.0.0")
+    doc = DocumentModel(project=project, creation_metadata=CreationMetadata())
+
+    exporter = build_deployed(doc, [], offline=True)
+    graph = json.loads(exporter.to_json())["@graph"]
+
+    licenses = [
+        e for e in graph if e.get("type") == "simplelicensing_SimpleLicensingText"
+    ]
+    assert not licenses
+
+    spdx_doc = next(e for e in graph if e.get("type") == "SpdxDocument")
+    assert "simpleLicensing" not in spdx_doc["profileConformance"]

--- a/tests/export/test_spdx3_json.py
+++ b/tests/export/test_spdx3_json.py
@@ -1,0 +1,338 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for pitloom.export.spdx3_json: require_spdx_id(), sha256_hash(),
+_annotate_relationships(), and Spdx3JsonExporter's license indexing and
+to_json()/to_file() serialization.
+
+See also: tests/ids_shared.py, which builds a fuller Spdx3JsonExporter
+document for pitloom.ids tests; tests/core/conftest.py, which exercises
+Spdx3JsonExporter indirectly through the full assembler pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from spdx_python_model.bindings import v3_0_1 as spdx3
+
+from pitloom.export.spdx3_json import (
+    Spdx3JsonExporter,
+    _annotate_relationships,
+    require_spdx_id,
+    sha256_hash,
+)
+
+
+def _creation_info() -> spdx3.CreationInfo:
+    """A CreationInfo with a self-referential createdBy, satisfying the
+    model's ``min_count`` requirement without needing a separate Agent
+    element added to the exporter for every test."""
+    ci = spdx3.CreationInfo(
+        specVersion="3.0.1", created=datetime(2026, 1, 1, tzinfo=timezone.utc)
+    )
+    ci.createdBy = ["https://example.org#SoftwareAgent-1"]
+    return ci
+
+
+# --- require_spdx_id ---
+
+
+def test_require_spdx_id_returns_assigned_id() -> None:
+    ci = _creation_info()
+    pkg = spdx3.software_Package(
+        spdxId="https://example.org#Package-1", name="pkg", creationInfo=ci
+    )
+    assert require_spdx_id(pkg) == "https://example.org#Package-1"
+
+
+def test_require_spdx_id_raises_when_unassigned() -> None:
+    ci = _creation_info()
+    pkg = spdx3.software_Package(name="pkg", creationInfo=ci)
+    with pytest.raises(ValueError, match="has no spdxId assigned"):
+        require_spdx_id(pkg)
+
+
+# --- sha256_hash ---
+
+
+def test_sha256_hash_without_comment() -> None:
+    digest = "a" * 64
+    result = sha256_hash(digest)
+    assert result.algorithm == spdx3.HashAlgorithm.sha256
+    assert result.hashValue == digest
+    assert result.comment is None
+
+
+def test_sha256_hash_with_comment() -> None:
+    digest = "b" * 64
+    result = sha256_hash(digest, comment="from wheel RECORD")
+    assert result.comment == "from wheel RECORD"
+
+
+# --- _annotate_relationships ---
+
+
+def test_annotate_relationships_uses_name_field() -> None:
+    graph: list[dict[str, Any]] = [
+        {"spdxId": "urn:x#A", "name": "app"},
+        {"spdxId": "urn:x#B", "name": "lib"},
+        {
+            "spdxId": "urn:x#Rel-1",
+            "relationshipType": "dependsOn",
+            "from": "urn:x#A",
+            "to": ["urn:x#B"],
+        },
+    ]
+    _annotate_relationships(graph)
+    rel = graph[2]
+    assert rel["description"] == "app dependsOn: lib"
+
+
+def test_annotate_relationships_multiple_to_ids_are_joined() -> None:
+    graph: list[dict[str, Any]] = [
+        {"spdxId": "urn:x#A", "name": "app"},
+        {"spdxId": "urn:x#B", "name": "lib-b"},
+        {"spdxId": "urn:x#C", "name": "lib-c"},
+        {
+            "spdxId": "urn:x#Rel-1",
+            "relationshipType": "dependsOn",
+            "from": "urn:x#A",
+            "to": ["urn:x#B", "urn:x#C"],
+        },
+    ]
+    _annotate_relationships(graph)
+    assert graph[3]["description"] == "app dependsOn: lib-b, lib-c"
+
+
+def test_annotate_relationships_falls_back_to_license_expression() -> None:
+    graph: list[dict[str, Any]] = [
+        {"spdxId": "urn:x#A", "name": "app"},
+        {
+            "spdxId": "urn:x#Lic-1",
+            "simplelicensing_licenseExpression": "MIT",
+        },
+        {
+            "spdxId": "urn:x#Rel-1",
+            "relationshipType": "hasConcludedLicense",
+            "from": "urn:x#A",
+            "to": ["urn:x#Lic-1"],
+        },
+    ]
+    _annotate_relationships(graph)
+    assert graph[2]["description"] == "app hasConcludedLicense: MIT"
+
+
+def test_annotate_relationships_falls_back_to_description_field() -> None:
+    graph: list[dict[str, Any]] = [
+        {"spdxId": "urn:x#A", "name": "app"},
+        {"spdxId": "urn:x#B", "description": "a bespoke note"},
+        {
+            "spdxId": "urn:x#Rel-1",
+            "relationshipType": "dependsOn",
+            "from": "urn:x#A",
+            "to": ["urn:x#B"],
+        },
+    ]
+    _annotate_relationships(graph)
+    assert graph[2]["description"] == "app dependsOn: a bespoke note"
+
+
+def test_annotate_relationships_falls_back_to_id_suffix() -> None:
+    """When an element has neither name, license expression, nor
+    description, its @id/spdxId suffix is used; and an id referenced by a
+    relationship but absent from the graph entirely also falls back to its
+    own suffix."""
+    graph: list[dict[str, Any]] = [
+        {"spdxId": "urn:x#A"},
+        {
+            "spdxId": "urn:x#Rel-1",
+            "relationshipType": "dependsOn",
+            "from": "urn:x#A",
+            "to": ["urn:x#Unlisted"],
+        },
+    ]
+    _annotate_relationships(graph)
+    assert graph[1]["description"] == "A dependsOn: Unlisted"
+
+
+def test_annotate_relationships_uses_blank_node_id_field() -> None:
+    """Elements identified by @id (blank nodes) rather than spdxId are
+    still indexed by name."""
+    graph: list[dict[str, Any]] = [
+        {"@id": "_:CreationInfo0"},
+        {
+            "spdxId": "urn:x#Rel-1",
+            "relationshipType": "dependsOn",
+            "from": "_:CreationInfo0",
+            "to": ["urn:x#B"],
+        },
+    ]
+    _annotate_relationships(graph)
+    # No "#" in the blank-node id, so the id_to_name lookup and the
+    # rsplit("#") fallback both resolve to the id unchanged.
+    assert graph[1]["description"] == "_:CreationInfo0 dependsOn: B"
+
+
+def test_annotate_relationships_skips_nodes_without_relationship_type() -> None:
+    graph: list[dict[str, Any]] = [
+        {"spdxId": "urn:x#A", "name": "app"},
+        {"spdxId": "urn:x#B", "name": "lib", "from": "urn:x#A", "to": ["urn:x#B"]},
+    ]
+    _annotate_relationships(graph)
+    assert "description" not in graph[1]
+
+
+def test_annotate_relationships_skips_when_to_is_not_a_list() -> None:
+    """'to' as a bare string (not a list) leaves the node unannotated --
+    the isinstance(to_ids, list) guard rejects it."""
+    graph: list[dict[str, Any]] = [
+        {"spdxId": "urn:x#A", "name": "app"},
+        {
+            "spdxId": "urn:x#Rel-1",
+            "relationshipType": "dependsOn",
+            "from": "urn:x#A",
+            "to": "urn:x#B",
+        },
+    ]
+    _annotate_relationships(graph)
+    assert "description" not in graph[1]
+
+
+def test_annotate_relationships_skips_missing_from_or_to() -> None:
+    graph: list[dict[str, Any]] = [
+        {
+            "spdxId": "urn:x#Rel-1",
+            "relationshipType": "dependsOn",
+            "from": "urn:x#A",
+        },
+        {
+            "spdxId": "urn:x#Rel-2",
+            "relationshipType": "dependsOn",
+            "to": ["urn:x#B"],
+        },
+    ]
+    _annotate_relationships(graph)
+    assert "description" not in graph[0]
+    assert "description" not in graph[1]
+
+
+# --- Spdx3JsonExporter: license indexing ---
+
+
+def test_add_license_indexes_by_license_text() -> None:
+    ci = _creation_info()
+    exporter = Spdx3JsonExporter()
+    license_text = spdx3.simplelicensing_SimpleLicensingText(
+        spdxId="urn:x#Lic-1", creationInfo=ci
+    )
+    license_text.simplelicensing_licenseText = "MIT"
+    exporter.add_license(license_text)
+    assert exporter.find_license("MIT") == "urn:x#Lic-1"
+
+
+def test_add_license_without_license_text_is_not_indexed() -> None:
+    """A SimpleLicensingText with no simplelicensing_licenseText value
+    (falsy) is added to the object set but never registered in the
+    lookup index."""
+    ci = _creation_info()
+    exporter = Spdx3JsonExporter()
+    license_text = spdx3.simplelicensing_SimpleLicensingText(
+        spdxId="urn:x#Lic-1", creationInfo=ci
+    )
+    exporter.add_license(license_text)
+    assert exporter.find_license("MIT") is None
+    assert license_text in exporter.object_set.objects
+
+
+# --- Spdx3JsonExporter: to_json()/to_file() ---
+
+
+def _build_minimal_document(exporter: Spdx3JsonExporter) -> dict[str, str]:
+    """Populate *exporter* with the minimum valid SPDX 3 document graph:
+    creation info, a main package, a dependency package, a dependsOn
+    relationship between them, an SBOM, and the document envelope."""
+    namespace = "https://example.org/spdxdocs/sample"
+    ci = _creation_info()
+    exporter.add_creation_info(ci)
+
+    main_pkg = spdx3.software_Package(
+        spdxId=f"{namespace}#Package-1", name="app", creationInfo=ci
+    )
+    dep_pkg = spdx3.software_Package(
+        spdxId=f"{namespace}#Package-2", name="requests", creationInfo=ci
+    )
+    exporter.add_package(main_pkg)
+    exporter.add_package(dep_pkg)
+
+    relationship = spdx3.Relationship(
+        spdxId=f"{namespace}#Relationship-1",
+        from_=require_spdx_id(main_pkg),
+        to=[require_spdx_id(dep_pkg)],
+        relationshipType=spdx3.RelationshipType.dependsOn,
+        creationInfo=ci,
+    )
+    exporter.add_relationship(relationship)
+
+    sbom = spdx3.software_Sbom(
+        spdxId=f"{namespace}#Sbom-1",
+        creationInfo=ci,
+        rootElement=[require_spdx_id(main_pkg)],
+    )
+    exporter.add_sbom(sbom)
+
+    doc = spdx3.SpdxDocument(
+        spdxId=namespace, creationInfo=ci, rootElement=[require_spdx_id(sbom)]
+    )
+    exporter.add_document(doc)
+
+    return {
+        "main_id": f"{namespace}#Package-1",
+        "dep_id": f"{namespace}#Package-2",
+        "relationship_id": f"{namespace}#Relationship-1",
+    }
+
+
+def test_to_json_without_describe_relationship_omits_description() -> None:
+    exporter = Spdx3JsonExporter()
+    ids = _build_minimal_document(exporter)
+    graph = json.loads(exporter.to_json())["@graph"]
+    rel = next(e for e in graph if e.get("spdxId") == ids["relationship_id"])
+    assert "description" not in rel
+
+
+def test_to_json_with_describe_relationship_adds_description() -> None:
+    exporter = Spdx3JsonExporter()
+    ids = _build_minimal_document(exporter)
+    graph = json.loads(exporter.to_json(describe_relationship=True))["@graph"]
+    rel = next(e for e in graph if e.get("spdxId") == ids["relationship_id"])
+    assert rel["description"] == "app dependsOn: requests"
+
+
+def test_to_file_writes_json_to_path(tmp_path: Path) -> None:
+    exporter = Spdx3JsonExporter()
+    _build_minimal_document(exporter)
+    out_path = tmp_path / "sbom.spdx3.json"
+
+    exporter.to_file(str(out_path))
+
+    written = json.loads(out_path.read_text(encoding="utf-8"))
+    assert "@graph" in written
+    names = {e.get("name") for e in written["@graph"] if "name" in e}
+    assert {"app", "requests"} <= names
+
+
+def test_to_file_pretty_matches_to_json_pretty(tmp_path: Path) -> None:
+    exporter = Spdx3JsonExporter()
+    _build_minimal_document(exporter)
+    out_path = tmp_path / "sbom-pretty.spdx3.json"
+
+    exporter.to_file(str(out_path), pretty=True)
+
+    assert out_path.read_text(encoding="utf-8") == exporter.to_json(pretty=True)

--- a/tests/extract/huggingface/test_huggingface_fetch.py
+++ b/tests/extract/huggingface/test_huggingface_fetch.py
@@ -1,0 +1,270 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Direct unit tests for the low-level pitloom.extract._huggingface_fetch
+helpers -- the raw HF Hub I/O functions and ``_extract_card_description``.
+
+These bypass the full ``read_huggingface()`` pipeline (exercised by the
+sibling ``test_huggingface_*.py`` modules) to reach branches that the
+higher-level facade never exercises: a pinned revision short-circuiting the
+"no pinned revision" warning, the success paths of the raw fetch helpers,
+and the paragraph-collection edge cases in ``_extract_card_description``.
+
+See also: conftest.py and _hf_patches_01.py through _hf_patches_10.py for
+the shared mock-HF-API helpers used by the higher-level tests.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from pitloom.extract._huggingface_fetch import (
+    _detect_license_from_hf_files,
+    _extract_card_description,
+    _list_license_files_in_repo,
+    _load_model_card,
+    _load_model_info,
+    _safe_load_json,
+)
+
+_LOGGER_NAME = "pitloom.extract._huggingface_fetch"
+
+
+class _FakeCardData:
+    """Minimal stand-in for huggingface_hub.ModelCardData."""
+
+    def __init__(self, data: dict[str, Any] | None) -> None:
+        self._data = data
+
+    def to_dict(self) -> dict[str, Any]:
+        return self._data or {}
+
+
+class _FakeCard:
+    """Minimal stand-in for huggingface_hub.ModelCard."""
+
+    def __init__(self, text: str | None, data: _FakeCardData | None) -> None:
+        self.text = text
+        self.data = data
+
+
+class _FakeModelInfo:
+    """Minimal stand-in for huggingface_hub.hf_api.ModelInfo -- only the
+    attributes _load_model_info() actually reads."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.__dict__.update(kwargs)
+
+
+# ---------------------------------------------------------------------------
+# _safe_load_json
+# ---------------------------------------------------------------------------
+
+
+def test_safe_load_json_with_pinned_revision_succeeds_without_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A pinned revision skips the "no pinned revision" warning and the
+    download+parse succeeds, returning the parsed JSON dict."""
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({"model_type": "mistral"}), encoding="utf-8")
+
+    with patch("huggingface_hub.hf_hub_download", return_value=str(config_file)):
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = _safe_load_json("org/model", "config.json", revision="deadbeef")
+
+    assert result == {"model_type": "mistral"}
+    assert not any("pinned revision" in r.message for r in caplog.records)
+
+
+def test_safe_load_json_without_revision_warns_and_succeeds(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """No revision logs a reproducibility warning but still returns the
+    parsed JSON on success."""
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({"a": 1}), encoding="utf-8")
+
+    with patch("huggingface_hub.hf_hub_download", return_value=str(config_file)):
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            result = _safe_load_json("org/model", "config.json")
+
+    assert result == {"a": 1}
+    assert any("pinned revision" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _load_model_card
+# ---------------------------------------------------------------------------
+
+
+def test_load_model_card_success_with_data() -> None:
+    fake_card = _FakeCard("Model card body.", _FakeCardData({"license": "mit"}))
+    with patch("huggingface_hub.ModelCard.load", return_value=fake_card):
+        text, data = _load_model_card("org/model")
+    assert text == "Model card body."
+    assert data == {"license": "mit"}
+
+
+def test_load_model_card_success_falsy_data_and_text() -> None:
+    # card.data is None and card.text is empty -> data becomes {}, text None.
+    fake_card = _FakeCard("", None)
+    with patch("huggingface_hub.ModelCard.load", return_value=fake_card):
+        text, data = _load_model_card("org/model")
+    assert text is None
+    assert data == {}
+
+
+# ---------------------------------------------------------------------------
+# _load_model_info
+# ---------------------------------------------------------------------------
+
+
+def test_load_model_info_all_fields_present() -> None:
+    info = _FakeModelInfo(
+        author="mistralai",
+        sha="deadbeef",
+        created_at=datetime(2023, 9, 20, 13, 3, 50, tzinfo=timezone.utc),
+        last_modified=datetime(2023, 9, 21, 0, 0, 0, tzinfo=timezone.utc),
+        downloads=1234,
+        tags=["license:apache-2.0", "region:us"],
+    )
+    with patch("huggingface_hub.model_info", return_value=info):
+        result = _load_model_info("org/model")
+
+    assert result == {
+        "author": "mistralai",
+        "sha": "deadbeef",
+        "created_at": "2023-09-20T13:03:50+00:00",
+        "last_modified": "2023-09-21T00:00:00+00:00",
+        "downloads": 1234,
+        "tags": ["license:apache-2.0", "region:us"],
+    }
+
+
+def test_load_model_info_falsy_fields_omitted_but_zero_downloads_kept() -> None:
+    # author/created_at/last_modified/tags are falsy -> omitted. downloads
+    # uses an "is not None" check (not truthiness), so 0 is still recorded.
+    info = _FakeModelInfo(
+        author=None,
+        sha="abc",
+        created_at=None,
+        last_modified=None,
+        downloads=0,
+        tags=[],
+    )
+    with patch("huggingface_hub.model_info", return_value=info):
+        result = _load_model_info("org/model")
+
+    assert result == {"sha": "abc", "downloads": 0}
+
+
+# ---------------------------------------------------------------------------
+# _list_license_files_in_repo
+# ---------------------------------------------------------------------------
+
+
+def test_list_license_files_in_repo_filters_and_orders_by_priority() -> None:
+    # _HF_LICENSE_FILENAMES priority: LICENSE, LICENCE, COPYING, NOTICE, ...
+    existing = {"COPYING", "LICENSE.txt", "LICENSE", "NOTICE"}
+    with patch("huggingface_hub.list_repo_files", return_value=existing):
+        result = _list_license_files_in_repo("org/model")
+
+    assert result == ["LICENSE", "COPYING", "NOTICE", "LICENSE.txt"]
+
+
+# ---------------------------------------------------------------------------
+# _detect_license_from_hf_files
+# ---------------------------------------------------------------------------
+
+
+def test_detect_license_from_hf_files_pinned_revision_detects_license(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # A pinned revision skips the reproducibility warning, and a matching
+    # license file yields the detected SPDX ID plus provenance string.
+    license_file = tmp_path / "LICENSE"
+    license_file.write_text("MIT License text...", encoding="utf-8")
+
+    with patch(
+        "pitloom.extract._huggingface_fetch._list_license_files_in_repo",
+        return_value=["LICENSE"],
+    ):
+        with patch("huggingface_hub.hf_hub_download", return_value=str(license_file)):
+            with patch(
+                "pitloom.extract._license.detect_license_from_text",
+                return_value="MIT",
+            ):
+                with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+                    detected_id, provenance = _detect_license_from_hf_files(
+                        "org/model", revision="deadbeef"
+                    )
+
+    assert detected_id == "MIT"
+    assert provenance == (
+        "Source: Hugging Face Hub | File: LICENSE | Method: licenseid_detection"
+    )
+    assert not any("pinned revision" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _extract_card_description
+# ---------------------------------------------------------------------------
+
+
+def test_extract_card_description_typical_card() -> None:
+    card_text = "---\nlicense: mit\n---\n\nA great model for text generation."
+    assert _extract_card_description(card_text) == "A great model for text generation."
+
+
+def test_extract_card_description_no_frontmatter_returns_none() -> None:
+    # Without any "---" delimiter, yaml_done never becomes True, so every
+    # line is skipped by the "not yaml_done" guard and nothing is collected.
+    card_text = "Just plain prose with no YAML frontmatter at all."
+    assert _extract_card_description(card_text) is None
+
+
+def test_extract_card_description_stops_at_blank_line_after_paragraph() -> None:
+    # A blank line before any content is swallowed (continue); a blank line
+    # once a paragraph has started ends collection (break) -- later
+    # paragraphs are never reached.
+    card_text = (
+        "---\nlicense: mit\n---\n\n"
+        "First paragraph line one.\n\n"
+        "Second paragraph that must be ignored."
+    )
+    result = _extract_card_description(card_text)
+    assert result == "First paragraph line one."
+    assert "Second paragraph" not in (result or "")
+
+
+def test_extract_card_description_horizontal_rule_mid_paragraph() -> None:
+    # A "---" appearing in the body (after frontmatter already closed) is
+    # not treated as a new frontmatter delimiter -- it falls straight
+    # through to line 254 and gets appended as literal paragraph text.
+    card_text = (
+        "---\nlicense: mit\n---\n\nFirst line of para.\n---\nSecond continued line."
+    )
+    result = _extract_card_description(card_text)
+    assert result == "First line of para. --- Second continued line."
+
+
+def test_extract_card_description_truncates_at_500_chars() -> None:
+    # A single overlong line (no blank-line break) trips the 500-char
+    # length guard and breaks out of collection immediately.
+    long_line = "word " * 200  # 1000 chars, single line, no blank line follows
+    card_text = f"---\nlicense: mit\n---\n\n{long_line}"
+
+    result = _extract_card_description(card_text)
+
+    assert result is not None
+    assert len(result) == 500

--- a/tests/extract/test_hdf5.py
+++ b/tests/extract/test_hdf5.py
@@ -20,6 +20,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pitloom.core.ai_metadata import AiModelFormat
+from pitloom.extract._hdf5 import (
+    _decode_h5_attr,
+    _extract_input_from_layers,
+    _parse_model_config,
+    _parse_training_config,
+)
 from pitloom.extract.ai_model import read_hdf5
 
 # ---------------------------------------------------------------------------
@@ -243,6 +249,236 @@ def test_read_hdf5_no_keras_attrs(tmp_path: Path) -> None:
     assert meta.format_info.framework is None
     assert meta.format_info.framework_version is None
     assert meta.hyperparameters == {}
+
+
+def test_read_hdf5_unparseable_keras_version_defaults_to_v2(
+    tmp_path: Path,
+) -> None:
+    # A non-numeric keras_version (e.g. corrupted attribute) can't be split
+    # into a major version int -- ValueError is caught, defaulting to v2.
+    model_file = tmp_path / "model.h5"
+    model_file.write_bytes(b"fake")
+    mock_hf = _make_hdf5_file(keras_version="unknown")
+    mock_h5py = MagicMock()
+    mock_h5py.File.return_value = mock_hf
+    with patch.dict("sys.modules", {"h5py": mock_h5py}):
+        meta = read_hdf5(model_file)
+    assert meta.format_info.format_version == "v2"
+
+
+def test_read_hdf5_unparseable_model_config_stores_raw_text(
+    tmp_path: Path,
+) -> None:
+    # model_config present but not valid JSON -> _parse_model_config returns
+    # (None, None); the caller then stashes the raw text for inspection
+    # instead of silently dropping it.
+    model_file = tmp_path / "model.h5"
+    model_file.write_bytes(b"fake")
+    mock_hf = _make_hdf5_file()
+    mock_hf.attrs["model_config"] = "not valid json {{{"
+    mock_h5py = MagicMock()
+    mock_h5py.File.return_value = mock_hf
+    with patch.dict("sys.modules", {"h5py": mock_h5py}):
+        meta = read_hdf5(model_file)
+    assert meta.type_of_model is None
+    assert meta.name is None
+    assert meta.properties.get("model_config_raw") == "not valid json {{{"
+    assert "properties.model_config_raw" in meta.provenance
+
+
+# ---------------------------------------------------------------------------
+# _decode_h5_attr -- direct unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_decode_h5_attr_bytes() -> None:
+    assert _decode_h5_attr(b"2.15.0") == "2.15.0"
+
+
+def test_decode_h5_attr_numpy_like_tobytes() -> None:
+    # numpy.bytes_ (and similar) expose .tobytes() rather than being a
+    # plain `bytes` instance.
+    fake_numpy_bytes = MagicMock()
+    fake_numpy_bytes.tobytes.return_value = b"tensorflow"
+    assert _decode_h5_attr(fake_numpy_bytes) == "tensorflow"
+
+
+def test_decode_h5_attr_plain_str() -> None:
+    assert _decode_h5_attr("already-a-str") == "already-a-str"
+
+
+def test_decode_h5_attr_none() -> None:
+    assert _decode_h5_attr(None) is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_input_from_layers -- direct unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_extract_input_from_layers_non_input_layer_build_config() -> None:
+    # A non-InputLayer entry with a build_config.input_shape is used as a
+    # fallback source for the input shape.
+    layers = [{"class_name": "Dense", "build_config": {"input_shape": [None, 32]}}]
+    inputs, prov = _extract_input_from_layers(layers, "Source: model.h5")
+    assert inputs == [{"shape": [None, 32]}]
+    assert "layers[0].build_config.input_shape" in prov
+
+
+def test_extract_input_from_layers_skips_unmatching_then_matches() -> None:
+    # First layer (Dense, no build_config) yields nothing; loop continues to
+    # the second layer (InputLayer) which does.
+    layers = [
+        {"class_name": "Dense"},
+        {"class_name": "InputLayer", "config": {"batch_shape": [None, 10]}},
+    ]
+    inputs, prov = _extract_input_from_layers(layers, "Source: model.h5")
+    assert inputs == [{"shape": [None, 10]}]
+    assert "InputLayer" in prov
+
+
+def test_extract_input_from_layers_no_match_returns_empty() -> None:
+    layers = [{"class_name": "Dense"}, {"class_name": "Activation"}]
+    inputs, prov = _extract_input_from_layers(layers, "Source: model.h5")
+    assert inputs == []
+    assert prov == ""
+
+
+# ---------------------------------------------------------------------------
+# _parse_model_config -- direct unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_model_config_no_class_name_skips_provenance() -> None:
+    hyperparameters: dict[str, Any] = {}
+    inputs: list[dict[str, Any]] = []
+    properties: dict[str, str] = {}
+    provenance: dict[str, str] = {}
+    raw = _json.dumps({"config": {"name": "my_model"}})
+
+    type_of_model, name = _parse_model_config(
+        raw, "Source: m.h5", hyperparameters, inputs, properties, provenance
+    )
+
+    assert type_of_model is None
+    assert name == "my_model"
+    assert "type_of_model" not in provenance
+
+
+def test_parse_model_config_no_name_skips_name_provenance() -> None:
+    hyperparameters: dict[str, Any] = {}
+    inputs: list[dict[str, Any]] = []
+    properties: dict[str, str] = {}
+    provenance: dict[str, str] = {}
+    raw = _json.dumps({"class_name": "Sequential", "config": {"trainable": True}})
+
+    type_of_model, name = _parse_model_config(
+        raw, "Source: m.h5", hyperparameters, inputs, properties, provenance
+    )
+
+    assert type_of_model == "Sequential"
+    assert name is None
+    assert "name" not in provenance
+
+
+def test_parse_model_config_config_not_a_dict_is_ignored() -> None:
+    # A malformed model_config where "config" isn't a dict must not raise --
+    # the whole `if isinstance(config, dict)` block is skipped.
+    hyperparameters: dict[str, Any] = {}
+    inputs: list[dict[str, Any]] = []
+    properties: dict[str, str] = {}
+    provenance: dict[str, str] = {}
+    raw = _json.dumps({"class_name": "Sequential", "config": "not-a-dict"})
+
+    type_of_model, name = _parse_model_config(
+        raw, "Source: m.h5", hyperparameters, inputs, properties, provenance
+    )
+
+    assert type_of_model == "Sequential"
+    assert name is None
+    assert hyperparameters == {}
+
+
+def test_parse_model_config_top_level_build_config_fallback() -> None:
+    # No layers give a shape (there are none), so the top-level
+    # build_config.input_shape is used as a fallback.
+    hyperparameters: dict[str, Any] = {}
+    inputs: list[dict[str, Any]] = []
+    properties: dict[str, str] = {}
+    provenance: dict[str, str] = {}
+    raw = _json.dumps(
+        {
+            "class_name": "Sequential",
+            "config": {"name": "m"},
+            "build_config": {"input_shape": [None, 4]},
+        }
+    )
+
+    _parse_model_config(
+        raw, "Source: m.h5", hyperparameters, inputs, properties, provenance
+    )
+
+    assert inputs == [{"shape": [None, 4]}]
+    assert provenance["inputs"] == (
+        "Source: m.h5 | Field: model_config.build_config.input_shape"
+    )
+
+
+def test_parse_model_config_invalid_json_returns_none_none() -> None:
+    hyperparameters: dict[str, Any] = {}
+    inputs: list[dict[str, Any]] = []
+    properties: dict[str, str] = {}
+    provenance: dict[str, str] = {}
+
+    type_of_model, name = _parse_model_config(
+        "not valid json",
+        "Source: m.h5",
+        hyperparameters,
+        inputs,
+        properties,
+        provenance,
+    )
+
+    assert type_of_model is None
+    assert name is None
+    assert provenance == {}
+
+
+# ---------------------------------------------------------------------------
+# _parse_training_config -- direct unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_training_config_empty_dict_populates_nothing() -> None:
+    # No optimizer/loss/metrics keys at all -- every guard's false branch.
+    properties: dict[str, str] = {}
+    provenance: dict[str, str] = {}
+
+    _parse_training_config(_json.dumps({}), "Source: m.h5", properties, provenance)
+
+    assert properties == {}
+    assert provenance == {}
+
+
+def test_parse_training_config_optimizer_without_class_name() -> None:
+    # optimizer is a dict but has no (or an empty) class_name.
+    properties: dict[str, str] = {}
+    provenance: dict[str, str] = {}
+    raw = _json.dumps({"optimizer": {}})
+
+    _parse_training_config(raw, "Source: m.h5", properties, provenance)
+
+    assert "optimizer" not in properties
+
+
+def test_parse_training_config_invalid_json_is_ignored() -> None:
+    properties: dict[str, str] = {}
+    provenance: dict[str, str] = {}
+
+    _parse_training_config("not valid json", "Source: m.h5", properties, provenance)
+
+    assert properties == {}
+    assert provenance == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/extract/test_pyproject.py
+++ b/tests/extract/test_pyproject.py
@@ -1,0 +1,419 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for read_pyproject()'s [project]-focused parsing paths and its
+private helpers (dynamic version resolution, license hint resolution,
+readme/author extraction, provenance building).
+
+See also: test_poetry_pyproject.py for the [tool.poetry] fallback/override
+behaviour, and test_hatch_hook_metadata.py for the Hatchling build-hook path.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+from pyproject_metadata import StandardMetadata
+
+from pitloom.extract._pyproject import (
+    _build_provenance,
+    _extract_and_detect_license,
+    _extract_authors,
+    _extract_dynamic_version,
+    _extract_readme,
+    _read_version_from_file,
+    _resolve_license_hint,
+    _try_read_poetry,
+    read_pyproject,
+)
+
+# ---------------------------------------------------------------------------
+# read_pyproject -- no [project] section, no [tool.poetry] fallback
+# ---------------------------------------------------------------------------
+
+
+def test_read_pyproject_no_project_no_poetry_detects_license_from_dir() -> None:
+    """No ``[project]``/``[tool.poetry]``: falls through to an empty
+    ``ProjectMetadata`` whose license is detected independently from the
+    project directory (line 85's ``license_prov`` truthy branch)."""
+    with tempfile.TemporaryDirectory() as d:
+        tmp_path = Path(d)
+        (tmp_path / "pyproject.toml").write_text("[build-system]\n")
+        (tmp_path / "LICENSE").write_text("MIT License", encoding="utf-8")
+        with patch(
+            "pitloom.extract._license.detect_license_from_text",
+            return_value="MIT",
+        ):
+            metadata, _config = read_pyproject(tmp_path / "pyproject.toml")
+    assert metadata.name == ""
+    assert metadata.license_name == "MIT"
+    assert "license" in metadata.provenance
+
+
+def test_read_pyproject_no_project_no_poetry_no_license_found() -> None:
+    """No ``[project]``, no ``[tool.poetry]``, and nothing in the directory
+    that looks like a license: ``license_prov`` stays falsy."""
+    with tempfile.TemporaryDirectory() as d:
+        tmp_path = Path(d)
+        (tmp_path / "pyproject.toml").write_text("[build-system]\n")
+        metadata, _config = read_pyproject(tmp_path / "pyproject.toml")
+    assert metadata.name == ""
+    assert metadata.license_name is None
+
+
+# ---------------------------------------------------------------------------
+# read_pyproject -- dynamic version present but unresolvable
+# ---------------------------------------------------------------------------
+
+
+def test_read_pyproject_dynamic_version_unresolvable() -> None:
+    """``dynamic = ["version"]`` but no Hatchling path/``__about__.py`` found:
+    the dynamic-version block is skipped (line 96->107) and
+    ``pyproject-metadata`` is left to raise (dynamic version) or the field
+    is simply absent from the parsed metadata."""
+    content = """
+[project]
+name = "no-resolvable-version"
+dynamic = ["version"]
+"""
+    with tempfile.TemporaryDirectory() as d:
+        tmp_path = Path(d)
+        (tmp_path / "pyproject.toml").write_text(content)
+        metadata, _config = read_pyproject(tmp_path / "pyproject.toml")
+    assert metadata.name == "no-resolvable-version"
+    assert metadata.version is None
+
+
+# ---------------------------------------------------------------------------
+# read_pyproject -- StandardMetadata.from_pyproject() failure
+# ---------------------------------------------------------------------------
+
+
+def test_read_pyproject_invalid_metadata_raises_value_error() -> None:
+    """A ``[project]`` section that ``pyproject-metadata`` cannot parse (here:
+    an invalid PEP 440 version string) surfaces as ``ValueError``, not the
+    raw underlying exception."""
+    content = """
+[project]
+name = "bad-version-pkg"
+version = "not-a-valid-version!!"
+"""
+    with tempfile.TemporaryDirectory() as d:
+        tmp_path = Path(d)
+        (tmp_path / "pyproject.toml").write_text(content)
+        with pytest.raises(ValueError, match="Failed to parse project metadata"):
+            read_pyproject(tmp_path / "pyproject.toml")
+
+
+# ---------------------------------------------------------------------------
+# _build_provenance -- direct unit tests for branches unreachable/awkward
+# to reach purely through read_pyproject()
+# ---------------------------------------------------------------------------
+
+
+def test_build_provenance_no_version_source_no_version_field() -> None:
+    """Neither a resolved dynamic-version source nor a declared
+    ``project.version`` field: the ``version`` key is omitted entirely
+    (line 185->188)."""
+    prov = _build_provenance({"name": "pkg"}, version_source=None)
+    assert "version" not in prov
+
+
+def test_build_provenance_license_override_without_declared_field() -> None:
+    """``license_prov_override`` is set but ``project.license`` was never
+    declared: the override still lands in ``prov["license"]`` via the
+    fallback branch at the end of the function (line 198)."""
+    prov = _build_provenance(
+        {"name": "pkg"},
+        version_source=None,
+        license_prov_override="Source: LICENSE | Method: licenseid_detection",
+    )
+    assert prov["license"] == "Source: LICENSE | Method: licenseid_detection"
+
+
+# ---------------------------------------------------------------------------
+# _extract_readme -- inline readme text (PEP 621 {text = ...} table)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_readme_inline_text() -> None:
+    """A readme object exposing ``.text`` (no usable ``.file``) returns the
+    inline text directly (lines 238-239)."""
+    fake_readme = SimpleNamespace(file=None, text="Hello from inline readme.")
+    std = SimpleNamespace(readme=fake_readme)
+    result = _extract_readme(cast(StandardMetadata, std), override=None)
+    assert result == "Hello from inline readme."
+
+
+def test_extract_readme_no_file_no_text() -> None:
+    """A readme object with neither a usable ``.file`` nor ``.text``
+    resolves to ``None``."""
+    fake_readme = SimpleNamespace(file=None, text=None)
+    std = SimpleNamespace(readme=fake_readme)
+    result = _extract_readme(cast(StandardMetadata, std), override=None)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_license_hint -- direct unit tests for each license object shape
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_license_hint_text_object() -> None:
+    """A License object exposing ``.text`` (PEP 639 inline license text)."""
+    license_obj = SimpleNamespace(text="Some custom license text.")
+    with tempfile.TemporaryDirectory() as d:
+        hint, base_prov, fallback = _resolve_license_hint(license_obj, Path(d))
+    assert hint == "Some custom license text."
+    assert base_prov.endswith(".text")
+    assert fallback == ("Some custom license text.", None)
+
+
+def test_resolve_license_hint_file_object_reads_content() -> None:
+    """A License object exposing ``.file`` reads the referenced file's
+    content as the detection hint."""
+    with tempfile.TemporaryDirectory() as d:
+        tmp_path = Path(d)
+        (tmp_path / "LICENSE.txt").write_text("MIT License text", encoding="utf-8")
+        license_obj = SimpleNamespace(file="LICENSE.txt")
+        hint, base_prov, fallback = _resolve_license_hint(license_obj, tmp_path)
+    assert hint == "MIT License text"
+    assert base_prov == "Source: LICENSE.txt"
+    assert fallback == ("LICENSE.txt", None)
+
+
+def test_resolve_license_hint_file_object_missing_file() -> None:
+    """A License object whose ``.file`` does not exist on disk: the ``OSError``
+    is caught, ``hint`` is ``None``, and the filename is preserved as
+    fallback."""
+    license_obj = SimpleNamespace(file="does-not-exist.txt")
+    with tempfile.TemporaryDirectory() as d:
+        hint, base_prov, fallback = _resolve_license_hint(license_obj, Path(d))
+    assert hint is None
+    assert base_prov == "Source: pyproject.toml | Field: project.license"
+    assert fallback == ("does-not-exist.txt", None)
+
+
+def test_resolve_license_hint_unrecognised_object() -> None:
+    """A license object with neither ``.text`` nor ``.file`` falls through to
+    the catch-all branch, stringifying the object as the fallback id."""
+    license_obj = object()
+    with tempfile.TemporaryDirectory() as d:
+        hint, base_prov, fallback = _resolve_license_hint(license_obj, Path(d))
+    assert hint is None
+    assert base_prov == "Source: pyproject.toml | Field: project.license"
+    assert fallback == (str(license_obj), None)
+
+
+# ---------------------------------------------------------------------------
+# _extract_and_detect_license -- branches around _resolve_license_hint /
+# detect_license_for_project interplay
+# ---------------------------------------------------------------------------
+
+
+def test_extract_and_detect_license_hint_none_returns_fallback() -> None:
+    """When ``_resolve_license_hint`` cannot produce a hint (missing license
+    file), ``_extract_and_detect_license`` returns its fallback tuple
+    directly (line 296)."""
+    std = SimpleNamespace(license=SimpleNamespace(file="missing-license.txt"))
+    with tempfile.TemporaryDirectory() as d:
+        license_id, prov = _extract_and_detect_license(
+            cast(StandardMetadata, std), Path(d)
+        )
+    assert license_id == "missing-license.txt"
+    assert prov is None
+
+
+def test_extract_and_detect_license_detected_differs_from_hint() -> None:
+    """Free-text license hint that ``licenseid`` detection resolves to a
+    *different* SPDX id: reports the detected id with a
+    ``licenseid_detection`` provenance tag (lines 301-303)."""
+    std = SimpleNamespace(license="Some custom license text that isn't SPDX")
+    with tempfile.TemporaryDirectory() as d:
+        with patch(
+            "pitloom.extract._pyproject.detect_license_for_project",
+            return_value=("Apache-2.0", "Source: detected"),
+        ):
+            license_id, prov = _extract_and_detect_license(
+                cast(StandardMetadata, std), Path(d)
+            )
+    assert license_id == "Apache-2.0"
+    assert prov == (
+        "Source: pyproject.toml | Field: project.license | Method: licenseid_detection"
+    )
+
+
+def test_extract_and_detect_license_detected_equals_hint_uses_fallback_id() -> None:
+    """Detection agrees with the hint (no new information): when the hint
+    came from license *text* (so a non-``None`` ``fallback_id`` exists),
+    the fallback id/provenance pair is returned instead (lines 305-307)."""
+    std = SimpleNamespace(license=SimpleNamespace(text="MIT-like text"))
+    with tempfile.TemporaryDirectory() as d:
+        with patch(
+            "pitloom.extract._pyproject.detect_license_for_project",
+            return_value=("MIT-like text", "Source: irrelevant"),
+        ):
+            license_id, prov = _extract_and_detect_license(
+                cast(StandardMetadata, std), Path(d)
+            )
+    assert license_id == "MIT-like text"
+    assert prov is None
+
+
+def test_extract_and_detect_license_detected_equals_hint_no_fallback_id() -> None:
+    """Detection agrees with the hint and there is no ``fallback_id`` (plain
+    string license hint): falls through to the final
+    ``return detected, prov`` (line 308)."""
+    std = SimpleNamespace(license="Some Custom License Text")
+    with tempfile.TemporaryDirectory() as d:
+        with patch(
+            "pitloom.extract._pyproject.detect_license_for_project",
+            return_value=("Some Custom License Text", "Source: detected-prov"),
+        ):
+            license_id, prov = _extract_and_detect_license(
+                cast(StandardMetadata, std), Path(d)
+            )
+    assert license_id == "Some Custom License Text"
+    assert prov == "Source: detected-prov"
+
+
+# ---------------------------------------------------------------------------
+# _extract_authors -- entries that resolve to nothing get skipped
+# ---------------------------------------------------------------------------
+
+
+def test_extract_authors_skips_empty_entries() -> None:
+    """An ``(name, email)`` pair that is entirely empty is dropped rather
+    than appended as an empty dict (line 318->314)."""
+    std = SimpleNamespace(authors=[("", ""), ("Bob", ""), ("", "carol@example.com")])
+    result = _extract_authors(cast(StandardMetadata, std))
+    assert result == [{"name": "Bob"}, {"email": "carol@example.com"}]
+
+
+# ---------------------------------------------------------------------------
+# _extract_dynamic_version -- Hatchling version-path and fallback candidates
+# ---------------------------------------------------------------------------
+
+
+def test_extract_dynamic_version_hatch_path_missing_file() -> None:
+    """``[tool.hatch.version].path`` is declared but the file does not
+    exist: falls through to the candidate-file scan (line 336->345)."""
+    pyproject_data = {
+        "project": {"name": "pkg"},
+        "tool": {"hatch": {"version": {"path": "src/pkg/__about__.py"}}},
+    }
+    with tempfile.TemporaryDirectory() as d:
+        version, source = _extract_dynamic_version(Path(d), pyproject_data)
+    assert version is None
+    assert source is None
+
+
+def test_extract_dynamic_version_hatch_path_exists_no_version_line() -> None:
+    """The Hatchling version file exists but has no ``__version__`` line:
+    falls through to the candidate-file scan (line 338->345)."""
+    pyproject_data = {
+        "project": {"name": "pkg"},
+        "tool": {"hatch": {"version": {"path": "VERSION.py"}}},
+    }
+    with tempfile.TemporaryDirectory() as d:
+        tmp_path = Path(d)
+        (tmp_path / "VERSION.py").write_text("# no version here\n", encoding="utf-8")
+        version, source = _extract_dynamic_version(tmp_path, pyproject_data)
+    assert version is None
+    assert source is None
+
+
+def test_extract_dynamic_version_candidate_exists_without_version() -> None:
+    """A candidate file (``__about__.py``) exists but has no ``__version__``
+    line: the loop continues past it (line 359->356) and ultimately
+    reports nothing found (line 366)."""
+    pyproject_data = {"project": {"name": "pkg"}}
+    with tempfile.TemporaryDirectory() as d:
+        tmp_path = Path(d)
+        (tmp_path / "__about__.py").write_text("# empty\n", encoding="utf-8")
+        version, source = _extract_dynamic_version(tmp_path, pyproject_data)
+    assert version is None
+    assert source is None
+
+
+def test_extract_dynamic_version_no_hatch_no_candidates() -> None:
+    """Nothing declared and nothing found on disk: plain ``(None, None)``
+    (line 366)."""
+    with tempfile.TemporaryDirectory() as d:
+        version, source = _extract_dynamic_version(Path(d), {"project": {}})
+    assert version is None
+    assert source is None
+
+
+def test_extract_dynamic_version_finds_about_file() -> None:
+    """Sanity check the successful candidate-scan path still works
+    alongside the new failure-path coverage above."""
+    pyproject_data = {"project": {"name": "pkg"}}
+    with tempfile.TemporaryDirectory() as d:
+        tmp_path = Path(d)
+        (tmp_path / "pkg").mkdir()
+        (tmp_path / "pkg" / "__about__.py").write_text(
+            '__version__ = "4.5.6"\n', encoding="utf-8"
+        )
+        version, source = _extract_dynamic_version(tmp_path, pyproject_data)
+    assert version == "4.5.6"
+    assert source is not None
+    assert "dynamic_extraction" in source
+
+
+# ---------------------------------------------------------------------------
+# _read_version_from_file -- error handling
+# ---------------------------------------------------------------------------
+
+
+def test_read_version_from_file_missing_file_returns_none() -> None:
+    """A nonexistent path raises ``FileNotFoundError`` (an ``OSError``
+    subclass), caught and turned into ``None`` (lines 377-379)."""
+    with tempfile.TemporaryDirectory() as d:
+        result = _read_version_from_file(Path(d) / "does-not-exist.py")
+    assert result is None
+
+
+def test_read_version_from_file_directory_path_returns_none() -> None:
+    """Passing a directory (``IsADirectoryError``, also an ``OSError``
+    subclass) is likewise caught and turned into ``None``."""
+    with tempfile.TemporaryDirectory() as d:
+        result = _read_version_from_file(Path(d))
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _try_read_poetry -- extract_poetry_metadata failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_try_read_poetry_value_error_returns_none() -> None:
+    """``extract_poetry_metadata`` raising ``ValueError`` is swallowed and
+    reported as "no poetry metadata available" (lines 391-392)."""
+    data = {"tool": {"poetry": {"name": "pkg"}}}
+    with tempfile.TemporaryDirectory() as d:
+        with patch(
+            "pitloom.extract._pyproject.extract_poetry_metadata",
+            side_effect=ValueError("boom"),
+        ):
+            result = _try_read_poetry(data, Path(d))
+    assert result is None
+
+
+def test_try_read_poetry_key_error_returns_none() -> None:
+    """Same as above, for ``KeyError``."""
+    data = {"tool": {"poetry": {"name": "pkg"}}}
+    with tempfile.TemporaryDirectory() as d:
+        with patch(
+            "pitloom.extract._pyproject.extract_poetry_metadata",
+            side_effect=KeyError("missing"),
+        ):
+            result = _try_read_poetry(data, Path(d))
+    assert result is None

--- a/tests/extract/test_scanner.py
+++ b/tests/extract/test_scanner.py
@@ -1,0 +1,171 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for pitloom.extract.scanner.scan_project_for_ai_models().
+
+The "happy path" (a real model file successfully identified and read) is
+already exercised indirectly by the higher-level project/document assembly
+tests. This module targets the branches those integration tests never hit:
+non-model extensions, magic-byte sniffing that comes back UNKNOWN, the
+ImportError/generic-exception handlers around read_ai_model(), the
+usage-detection debug log, and the file-read failure handler in the
+usage-scanning pass.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pitloom.core.ai_metadata import AiModelFormat, AiModelFormatInfo, AiModelMetadata
+from pitloom.core.project import ProjectFile
+from pitloom.extract.scanner import scan_project_for_ai_models
+
+_LOGGER_NAME = "pitloom.extract.scanner"
+
+
+def _pf(physical_path: str, distribution_path: str | None = None) -> ProjectFile:
+    return ProjectFile(
+        physical_path=physical_path,
+        distribution_path=distribution_path or physical_path,
+        digest_sha256="0" * 64,
+    )
+
+
+def _fake_meta(fmt: AiModelFormat = AiModelFormat.GGUF) -> AiModelMetadata:
+    return AiModelMetadata(format_info=AiModelFormatInfo(model_format=fmt))
+
+
+def test_scan_ignores_files_with_non_model_extensions(tmp_path: Path) -> None:
+    files = [_pf("README.md"), _pf("setup.py")]
+    result = scan_project_for_ai_models(tmp_path, files)
+    assert result == []
+
+
+def test_scan_skips_extension_match_when_format_unknown(tmp_path: Path) -> None:
+    # The extension is a candidate (.bin), but magic-byte sniffing comes
+    # back UNKNOWN (e.g. a generic data file, not actually an AI model).
+    (tmp_path / "weights.bin").write_bytes(b"not really a model")
+    files = [_pf("weights.bin")]
+
+    with patch(
+        "pitloom.extract.scanner.detect_ai_model_format",
+        return_value=AiModelFormat.UNKNOWN,
+    ):
+        result = scan_project_for_ai_models(tmp_path, files)
+
+    assert result == []
+
+
+def test_scan_detects_and_reads_model_successfully(tmp_path: Path) -> None:
+    (tmp_path / "model.gguf").write_bytes(b"fake gguf")
+    files = [_pf("model.gguf", "dist/model.gguf")]
+
+    with patch(
+        "pitloom.extract.scanner.detect_ai_model_format",
+        return_value=AiModelFormat.GGUF,
+    ):
+        with patch("pitloom.extract.scanner.read_ai_model", return_value=_fake_meta()):
+            result = scan_project_for_ai_models(tmp_path, files)
+
+    assert len(result) == 1
+    assert result[0].format_info.file_name == "model.gguf"
+    assert result[0].format_info.file_path_relative == "dist/model.gguf"
+    assert result[0].format_info.physical_path == "model.gguf"
+
+
+def test_scan_logs_warning_and_continues_on_import_error(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # A recognised format whose optional dependency isn't installed must
+    # log a warning (not crash the whole scan) and simply skip that file.
+    (tmp_path / "model.h5").write_bytes(b"fake h5")
+    files = [_pf("model.h5")]
+
+    with patch(
+        "pitloom.extract.scanner.detect_ai_model_format",
+        return_value=AiModelFormat.HDF5,
+    ):
+        with patch(
+            "pitloom.extract.scanner.read_ai_model",
+            side_effect=ImportError("h5py is required"),
+        ):
+            with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+                result = scan_project_for_ai_models(tmp_path, files)
+
+    assert result == []
+    assert any("required library not installed" in r.message for r in caplog.records)
+
+
+def test_scan_logs_warning_and_continues_on_generic_exception(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # A corrupt/unreadable model file must not abort the whole scan.
+    (tmp_path / "model.onnx").write_bytes(b"corrupt")
+    files = [_pf("model.onnx")]
+
+    with patch(
+        "pitloom.extract.scanner.detect_ai_model_format",
+        return_value=AiModelFormat.ONNX,
+    ):
+        with patch(
+            "pitloom.extract.scanner.read_ai_model",
+            side_effect=ValueError("bad protobuf"),
+        ):
+            with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+                result = scan_project_for_ai_models(tmp_path, files)
+
+    assert result == []
+    assert any("failed to extract metadata" in r.message for r in caplog.records)
+
+
+def test_scan_finds_usage_of_model_in_python_source(tmp_path: Path) -> None:
+    (tmp_path / "model.gguf").write_bytes(b"fake gguf")
+    script = tmp_path / "load.py"
+    script.write_text('load("model.gguf")\n', encoding="utf-8")
+    files = [_pf("model.gguf"), _pf("load.py")]
+
+    with patch(
+        "pitloom.extract.scanner.detect_ai_model_format",
+        return_value=AiModelFormat.GGUF,
+    ):
+        with patch("pitloom.extract.scanner.read_ai_model", return_value=_fake_meta()):
+            result = scan_project_for_ai_models(tmp_path, files)
+
+    assert len(result) == 1
+    assert "load.py" in result[0].usage_files
+
+
+def test_scan_no_usage_when_filename_absent_from_source(tmp_path: Path) -> None:
+    (tmp_path / "model.gguf").write_bytes(b"fake gguf")
+    script = tmp_path / "unrelated.py"
+    script.write_text("print('hello')\n", encoding="utf-8")
+    files = [_pf("model.gguf"), _pf("unrelated.py")]
+
+    with patch(
+        "pitloom.extract.scanner.detect_ai_model_format",
+        return_value=AiModelFormat.GGUF,
+    ):
+        with patch("pitloom.extract.scanner.read_ai_model", return_value=_fake_meta()):
+            result = scan_project_for_ai_models(tmp_path, files)
+
+    assert result[0].usage_files == []
+
+
+def test_scan_logs_warning_when_python_source_unreadable(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # A .py file listed but missing/unreadable on disk must not abort the
+    # usage-scanning pass -- it's caught, logged, and scanning continues.
+    files = [_pf("missing.py")]
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        result = scan_project_for_ai_models(tmp_path, files)
+
+    assert result == []
+    assert any("Could not read text from" in r.message for r in caplog.records)

--- a/tests/extract/test_sdist.py
+++ b/tests/extract/test_sdist.py
@@ -13,10 +13,11 @@ import io
 import tarfile
 import zipfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
-from pitloom.extract._sdist import read_sdist
+from pitloom.extract._sdist import _parse_pkg_info, read_sdist
 from pitloom.extract.project import read_project
 
 
@@ -96,3 +97,243 @@ def test_read_project_with_sdist(tmp_path: Path, sample_pkg_info: str) -> None:
 def test_read_sdist_not_found(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError):
         read_sdist(tmp_path / "non_existent.tar.gz")
+
+
+# ---------------------------------------------------------------------------
+# _parse_pkg_info -- field-by-field provenance and edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_parse_pkg_info_minimal_fields_absent() -> None:
+    """A PKG-INFO with only ``Name``: every optional field (version,
+    summary, license, requires-python, urls, author, requires-dist) stays
+    unset and none of their provenance keys are populated."""
+    metadata = _parse_pkg_info("Metadata-Version: 2.1\nName: bare-pkg\n", "src")
+    assert metadata.name == "bare-pkg"
+    assert metadata.version is None
+    assert metadata.description is None
+    assert metadata.license_name is None
+    assert metadata.requires_python is None
+    assert metadata.urls == {}
+    assert metadata.authors == []
+    assert metadata.dependencies == []
+    assert metadata.provenance == {"name": "src"}
+
+
+def test_parse_pkg_info_project_urls_mixed_valid_invalid() -> None:
+    """``Project-URL`` entries without a comma are skipped; valid
+    ``label, url`` entries are kept."""
+    pkg_info = (
+        "Metadata-Version: 2.1\n"
+        "Name: url-pkg\n"
+        "Project-URL: Homepage, https://example.com\n"
+        "Project-URL: no-comma-here\n"
+        "Project-URL: Repository, https://example.com/repo\n"
+    )
+    metadata = _parse_pkg_info(pkg_info, "src")
+    assert metadata.urls == {
+        "Homepage": "https://example.com",
+        "Repository": "https://example.com/repo",
+    }
+    assert metadata.provenance["urls"] == "src"
+
+
+def test_parse_pkg_info_project_urls_all_invalid_leaves_urls_empty() -> None:
+    """When every ``Project-URL`` entry lacks a comma, no ``urls`` end up
+    populated and the ``urls`` provenance key is never set."""
+    pkg_info = "Metadata-Version: 2.1\nName: url-pkg\nProject-URL: no-comma-here\n"
+    metadata = _parse_pkg_info(pkg_info, "src")
+    assert metadata.urls == {}
+    assert "urls" not in metadata.provenance
+
+
+def test_parse_pkg_info_author_unknown_is_skipped() -> None:
+    """``Author: UNKNOWN`` (setuptools' placeholder for an absent author)
+    must not be recorded as a real author."""
+    pkg_info = "Metadata-Version: 2.1\nName: pkg\nAuthor: UNKNOWN\n"
+    metadata = _parse_pkg_info(pkg_info, "src")
+    assert metadata.authors == []
+    assert "authors" not in metadata.provenance
+
+
+# ---------------------------------------------------------------------------
+# _read_tar_sdist -- directory entries, unreadable members, pyproject-only
+# fallback, and the "found nothing" default
+# ---------------------------------------------------------------------------
+
+
+def test_read_tar_sdist_skips_directory_entries(tmp_path: Path) -> None:
+    """Directory entries in the tarball are not hashed or listed as files."""
+    sdist_path = tmp_path / "dirpkg-1.0.tar.gz"
+    with tarfile.open(sdist_path, "w:gz") as tf:
+        dir_info = tarfile.TarInfo(name="dirpkg-1.0/src")
+        dir_info.type = tarfile.DIRTYPE
+        tf.addfile(dir_info)
+
+        pkg_bytes = b"Metadata-Version: 2.1\nName: dirpkg\nVersion: 1.0\n"
+        ti = tarfile.TarInfo(name="dirpkg-1.0/PKG-INFO")
+        ti.size = len(pkg_bytes)
+        tf.addfile(ti, io.BytesIO(pkg_bytes))
+
+    metadata, files = read_sdist(sdist_path)
+    assert metadata.name == "dirpkg"
+    assert len(files) == 1
+    assert files[0].distribution_path == "dirpkg-1.0/PKG-INFO"
+
+
+def test_read_tar_sdist_skips_member_when_extractfile_returns_none(
+    tmp_path: Path,
+) -> None:
+    """A tar member that passes ``isfile()`` but whose ``extractfile()``
+    still returns ``None`` (defensive edge case) is skipped rather than
+    crashing."""
+    sdist_path = tmp_path / "oddpkg-1.0.tar.gz"
+    with tarfile.open(sdist_path, "w:gz") as tf:
+        pkg_bytes = b"Metadata-Version: 2.1\nName: oddpkg\nVersion: 1.0\n"
+        ti = tarfile.TarInfo(name="oddpkg-1.0/PKG-INFO")
+        ti.size = len(pkg_bytes)
+        tf.addfile(ti, io.BytesIO(pkg_bytes))
+
+        src_bytes = b"print('hi')\n"
+        ti2 = tarfile.TarInfo(name="oddpkg-1.0/skip-me.py")
+        ti2.size = len(src_bytes)
+        tf.addfile(ti2, io.BytesIO(src_bytes))
+
+    original_extractfile = tarfile.TarFile.extractfile
+
+    def fake_extractfile(
+        self: tarfile.TarFile, member: str | tarfile.TarInfo
+    ) -> object:
+        name = member if isinstance(member, str) else member.name
+        if name == "oddpkg-1.0/skip-me.py":
+            return None
+        return original_extractfile(self, member)
+
+    with patch.object(tarfile.TarFile, "extractfile", fake_extractfile):
+        metadata, files = read_sdist(sdist_path)
+
+    assert metadata.name == "oddpkg"
+    distribution_paths = [f.distribution_path for f in files]
+    assert "oddpkg-1.0/PKG-INFO" in distribution_paths
+    assert "oddpkg-1.0/skip-me.py" not in distribution_paths
+
+
+def test_read_tar_sdist_pyproject_only_fallback(tmp_path: Path) -> None:
+    """No ``PKG-INFO``: metadata is built from ``pyproject.toml``'s
+    ``[project]`` table instead."""
+    sdist_path = tmp_path / "pyprojpkg-1.0.tar.gz"
+    pyproj_bytes = (
+        b'[project]\nname = "pyprojpkg"\nversion = "1.0"\n'
+        b'description = "Built from pyproject.toml"\n'
+        b'dependencies = ["click>=8.0"]\n'
+    )
+    with tarfile.open(sdist_path, "w:gz") as tf:
+        ti = tarfile.TarInfo(name="pyprojpkg-1.0/pyproject.toml")
+        ti.size = len(pyproj_bytes)
+        tf.addfile(ti, io.BytesIO(pyproj_bytes))
+
+    metadata, files = read_sdist(sdist_path)
+    assert metadata.name == "pyprojpkg"
+    assert metadata.version == "1.0"
+    assert metadata.description == "Built from pyproject.toml"
+    assert metadata.dependencies == ["click>=8.0"]
+    assert len(files) == 1
+
+
+def test_read_tar_sdist_pyproject_malformed_falls_back_to_unknown(
+    tmp_path: Path,
+) -> None:
+    """No ``PKG-INFO`` and an unparsable ``pyproject.toml``: degrades to the
+    ``name="unknown"`` default rather than raising."""
+    sdist_path = tmp_path / "badpkg-1.0.tar.gz"
+    bad_bytes = b"this is not valid toml [[["
+    with tarfile.open(sdist_path, "w:gz") as tf:
+        ti = tarfile.TarInfo(name="badpkg-1.0/pyproject.toml")
+        ti.size = len(bad_bytes)
+        tf.addfile(ti, io.BytesIO(bad_bytes))
+
+    metadata, files = read_sdist(sdist_path)
+    assert metadata.name == "unknown"
+    assert len(files) == 1
+
+
+def test_read_tar_sdist_neither_pkg_info_nor_pyproject(tmp_path: Path) -> None:
+    """Neither ``PKG-INFO`` nor ``pyproject.toml`` present: metadata stays
+    at its ``name="unknown"`` default, but files are still listed."""
+    sdist_path = tmp_path / "plainpkg-1.0.tar.gz"
+    with tarfile.open(sdist_path, "w:gz") as tf:
+        src_bytes = b"print('hello')\n"
+        ti = tarfile.TarInfo(name="plainpkg-1.0/src/main.py")
+        ti.size = len(src_bytes)
+        tf.addfile(ti, io.BytesIO(src_bytes))
+
+    metadata, files = read_sdist(sdist_path)
+    assert metadata.name == "unknown"
+    assert len(files) == 1
+
+
+# ---------------------------------------------------------------------------
+# _read_zip_sdist -- directory entries, pyproject-only fallback, and the
+# "found nothing" default
+# ---------------------------------------------------------------------------
+
+
+def test_read_zip_sdist_skips_directory_entries(tmp_path: Path) -> None:
+    """Directory entries in the zip archive are not hashed or listed."""
+    sdist_path = tmp_path / "dirpkg-1.0.zip"
+    with zipfile.ZipFile(sdist_path, "w") as zf:
+        zf.writestr("dirpkg-1.0/src/", "")
+        zf.writestr(
+            "dirpkg-1.0/PKG-INFO",
+            "Metadata-Version: 2.1\nName: dirpkg\nVersion: 1.0\n",
+        )
+
+    metadata, files = read_sdist(sdist_path)
+    assert metadata.name == "dirpkg"
+    assert len(files) == 1
+    assert files[0].distribution_path == "dirpkg-1.0/PKG-INFO"
+
+
+def test_read_zip_sdist_pyproject_only_fallback(tmp_path: Path) -> None:
+    """No ``PKG-INFO`` in the zip: metadata is built from
+    ``pyproject.toml``'s ``[project]`` table."""
+    sdist_path = tmp_path / "pyprojpkg-1.0.zip"
+    with zipfile.ZipFile(sdist_path, "w") as zf:
+        zf.writestr(
+            "pyprojpkg-1.0/pyproject.toml",
+            '[project]\nname = "pyprojpkg"\nversion = "2.0"\n'
+            'description = "Zip-sourced"\n',
+        )
+
+    metadata, files = read_sdist(sdist_path)
+    assert metadata.name == "pyprojpkg"
+    assert metadata.version == "2.0"
+    assert metadata.description == "Zip-sourced"
+    assert len(files) == 1
+
+
+def test_read_zip_sdist_pyproject_malformed_falls_back_to_unknown(
+    tmp_path: Path,
+) -> None:
+    """No ``PKG-INFO`` and an unparsable ``pyproject.toml`` in the zip:
+    degrades to the ``name="unknown"`` default rather than raising."""
+    sdist_path = tmp_path / "badpkg-1.0.zip"
+    with zipfile.ZipFile(sdist_path, "w") as zf:
+        zf.writestr("badpkg-1.0/pyproject.toml", "not [[[ valid toml")
+
+    metadata, files = read_sdist(sdist_path)
+    assert metadata.name == "unknown"
+    assert len(files) == 1
+
+
+def test_read_zip_sdist_neither_pkg_info_nor_pyproject(tmp_path: Path) -> None:
+    """Neither ``PKG-INFO`` nor ``pyproject.toml`` present in the zip:
+    metadata stays at its ``name="unknown"`` default, but files are still
+    listed."""
+    sdist_path = tmp_path / "plainpkg-1.0.zip"
+    with zipfile.ZipFile(sdist_path, "w") as zf:
+        zf.writestr("plainpkg-1.0/src/main.py", "print('hello')\n")
+
+    metadata, files = read_sdist(sdist_path)
+    assert metadata.name == "unknown"
+    assert len(files) == 1

--- a/tests/extract/test_wheel.py
+++ b/tests/extract/test_wheel.py
@@ -67,3 +67,142 @@ def test_read_wheel_no_metadata_file_has_no_provenance(tmp_path: Path) -> None:
 
     assert metadata.name == "unknown"
     assert not metadata.provenance
+
+
+def test_read_wheel_skips_directory_entries(tmp_path: Path) -> None:
+    """Directory entries in the archive (filenames ending in "/") are
+    skipped by the file-collection loop -- they must not appear in
+    project_files nor be hashed."""
+    wheel_path = tmp_path / "pkg-1.0.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel_path, "w") as zf:
+        zf.writestr("pkg-1.0.0.dist-info/METADATA", "Name: pkg\nVersion: 1.0.0\n")
+        zf.writestr("pkg/subdir/", "")  # directory entry
+        zf.writestr("pkg/__init__.py", "")
+
+    _, project_files = read_wheel(wheel_path)
+
+    distribution_paths = {pf.distribution_path for pf in project_files}
+    assert "pkg/subdir/" not in distribution_paths
+    assert "pkg/__init__.py" in distribution_paths
+
+
+def test_read_wheel_summary_and_requires_python(tmp_path: Path) -> None:
+    """Summary populates description and Requires-Python populates
+    requires_python -- neither is provenance-tracked."""
+    metadata_body = (
+        "Metadata-Version: 2.1\n"
+        "Name: pkg\n"
+        "Version: 1.0.0\n"
+        "Summary: A short description.\n"
+        "Requires-Python: >=3.10\n"
+    )
+    wheel_path = _make_wheel(tmp_path, "pkg", metadata_body)
+
+    metadata, _ = read_wheel(wheel_path)
+
+    assert metadata.description == "A short description."
+    assert metadata.requires_python == ">=3.10"
+    assert "description" not in metadata.provenance
+    assert "requires_python" not in metadata.provenance
+
+
+def test_read_wheel_license_field_fallback_when_no_expression(
+    tmp_path: Path,
+) -> None:
+    """When License-Expression is absent, the legacy License field is used
+    instead (the elif branch)."""
+    metadata_body = (
+        "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0.0\nLicense: MIT License\n"
+    )
+    wheel_path = _make_wheel(tmp_path, "pkg", metadata_body)
+
+    metadata, _ = read_wheel(wheel_path)
+
+    assert metadata.license_name == "MIT License"
+    assert metadata.provenance["license"] == (
+        f"Source: wheel METADATA | File: {wheel_path.name}"
+    )
+
+
+def test_read_wheel_authors_name_and_email(tmp_path: Path) -> None:
+    """Author and Author-email both populate a single authors dict entry."""
+    metadata_body = (
+        "Metadata-Version: 2.1\n"
+        "Name: pkg\n"
+        "Version: 1.0.0\n"
+        "Author: Jane Doe\n"
+        "Author-email: jane@example.com\n"
+    )
+    wheel_path = _make_wheel(tmp_path, "pkg", metadata_body)
+
+    metadata, _ = read_wheel(wheel_path)
+
+    assert metadata.authors == [{"name": "Jane Doe", "email": "jane@example.com"}]
+
+
+def test_read_wheel_authors_email_only(tmp_path: Path) -> None:
+    """Author-email alone (no Author name) still produces an authors entry
+    with just the email key."""
+    metadata_body = (
+        "Metadata-Version: 2.1\n"
+        "Name: pkg\n"
+        "Version: 1.0.0\n"
+        "Author-email: jane@example.com\n"
+    )
+    wheel_path = _make_wheel(tmp_path, "pkg", metadata_body)
+
+    metadata, _ = read_wheel(wheel_path)
+
+    assert metadata.authors == [{"email": "jane@example.com"}]
+
+
+def test_read_wheel_no_authors_when_absent(tmp_path: Path) -> None:
+    """Neither Author nor Author-email present -> authors stays empty."""
+    metadata_body = "Metadata-Version: 2.1\nName: pkg\nVersion: 1.0.0\n"
+    wheel_path = _make_wheel(tmp_path, "pkg", metadata_body)
+
+    metadata, _ = read_wheel(wheel_path)
+
+    assert metadata.authors == []
+
+
+def test_read_wheel_urls_homepage_download_and_project_url(
+    tmp_path: Path,
+) -> None:
+    """Home-page and Download-URL populate fixed URL keys; Project-URL
+    entries are split on the first comma into label/url pairs."""
+    metadata_body = (
+        "Metadata-Version: 2.1\n"
+        "Name: pkg\n"
+        "Version: 1.0.0\n"
+        "Home-page: https://example.com/home\n"
+        "Download-URL: https://example.com/download\n"
+        "Project-URL: Repository, https://example.com/repo\n"
+        "Project-URL: Bug Tracker, https://example.com/issues\n"
+    )
+    wheel_path = _make_wheel(tmp_path, "pkg", metadata_body)
+
+    metadata, _ = read_wheel(wheel_path)
+
+    assert metadata.urls == {
+        "Homepage": "https://example.com/home",
+        "Download": "https://example.com/download",
+        "Repository": "https://example.com/repo",
+        "Bug Tracker": "https://example.com/issues",
+    }
+
+
+def test_read_wheel_project_url_without_comma_is_ignored(tmp_path: Path) -> None:
+    """A Project-URL entry with no comma cannot be split into label/url and
+    is silently skipped."""
+    metadata_body = (
+        "Metadata-Version: 2.1\n"
+        "Name: pkg\n"
+        "Version: 1.0.0\n"
+        "Project-URL: https://example.com/no-label\n"
+    )
+    wheel_path = _make_wheel(tmp_path, "pkg", metadata_body)
+
+    metadata, _ = read_wheel(wheel_path)
+
+    assert metadata.urls == {}


### PR DESCRIPTION
## Summary

Prepare tests to avoid behavior drift during refactor

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
