### PR TITLE
Make pip-audit blocking

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -43,9 +43,5 @@ jobs:
           pip install ".[ai,content-type]" --group dev
 
       - name: Run pip-audit
-        # Non-blocking for now: the existing dependency tree has known,
-        # untriaged transitive findings (idna, setuptools, soupsieve,
-        # urllib3 as of 2026-08-18). Flip to blocking once those are
-        # resolved or explicitly ignored via `pip-audit --ignore-vuln`.
-        continue-on-error: true
+        # Failed pip-audit = blocking
         run: pip-audit --progress-spinner=off


### PR DESCRIPTION
## Summary

Make pip-audit blocking

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
