### PR TITLE
Split shared email person list into individual Person

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ and this project adheres to
 - Full release notes: <https://github.com/bact/pitloom/releases>
 - Commit history: <https://github.com/bact/pitloom/compare/v0.15.0...v0.16.0>
 
+## [Unreleased]
+
+### Fixed
+
+- Split an author list packed into a single email's display name
+  (e.g. `"A, B, C" <shared@example.com>`) into individual Persons instead
+  of emitting one combined-name Person; the shared address, when it
+  doesn't belong to any listed name, is kept on its own anonymous Person
+  ([#169])
+
+[#169]: https://github.com/bact/pitloom/pull/169
+
 ## [0.16.0] - 2026-08-18
 
 ### Added

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -8,7 +8,7 @@
 See also: :mod:`pitloom.assemble.spdx3.deps_installed` for local metadata parsing,
 :mod:`pitloom.assemble.spdx3.deps_pypi` for the PyPI JSON API fallback,
 :mod:`pitloom.assemble.spdx3.deps_license` for license element construction,
-and :mod:`pitloom.assemble.spdx3.deps_supplier` for supplier/originator resolution.
+and :mod:`pitloom.assemble.spdx3.deps_originator` for originator resolution.
 """
 
 from __future__ import annotations
@@ -26,16 +26,16 @@ from pitloom.assemble.spdx3.deps_installed import (
     _resolve_version,
 )
 from pitloom.assemble.spdx3.deps_license import _add_license_noassertion, _apply_license
+from pitloom.assemble.spdx3.deps_originator import (
+    _apply_originator,
+    _resolve_metadata_url,
+)
 from pitloom.assemble.spdx3.deps_pypi import (
     _extract_pypi_license,
-    _extract_pypi_supplier,
+    _extract_pypi_originator,
     _extract_release_hash,
     _fetch_pypi_release_info,
     _prefetch_pypi_release_infos,
-)
-from pitloom.assemble.spdx3.deps_supplier import (
-    _apply_originator,
-    _resolve_metadata_url,
 )
 from pitloom.assemble.spdx3.provenance import ProvenanceEncoder, emit_provenance
 from pitloom.core.models import build_pypi_purl, build_relationship, generate_spdx_id
@@ -76,7 +76,7 @@ def _enrich_from_pypi(
     offline: bool = False,
     content_type_method: str = "auto",
 ) -> set[str]:
-    """Best-effort PyPI JSON API fallback for supplier, license, and hash."""
+    """Best-effort PyPI JSON API fallback for originator, license, and hash."""
     version = dep_version if dep_version != "unknown" else None
     release_info = (
         release_info_cache.get((dep_name, version))
@@ -101,7 +101,7 @@ def _enrich_from_pypi(
         repo_url = home_page
 
     if "originator" not in already_filled:
-        originators = _extract_pypi_supplier(info)
+        originators = _extract_pypi_originator(info)
         if _apply_originator(
             originators,
             dep_package,

--- a/src/pitloom/assemble/spdx3/deps_installed.py
+++ b/src/pitloom/assemble/spdx3/deps_installed.py
@@ -18,12 +18,12 @@ from packaging.requirements import InvalidRequirement, Requirement
 from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.assemble.spdx3.deps_license import _apply_license
-from pitloom.assemble.spdx3.deps_supplier import (
+from pitloom.assemble.spdx3.deps_originator import (
     _apply_originator,
     _find_license_copyright,
     _parse_project_urls,
+    _resolve_author_or_maintainer,
     _resolve_metadata_url,
-    _resolve_supplier,
 )
 from pitloom.assemble.spdx3.provenance import ProvenanceEncoder
 from pitloom.core.models import build_pypi_purl
@@ -121,7 +121,7 @@ def _enrich_from_installed(
     if version and version != "unknown":
         dep_package.software_packageUrl = build_pypi_purl(dep_name, version)
 
-    originators = _resolve_supplier(pkg_meta)
+    originators = _resolve_author_or_maintainer(pkg_meta)
     if _apply_originator(
         originators,
         dep_package,

--- a/src/pitloom/assemble/spdx3/deps_originator.py
+++ b/src/pitloom/assemble/spdx3/deps_originator.py
@@ -3,7 +3,7 @@
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
-"""Supplier/originator resolution for dependency enrichment.
+"""Originator resolution for dependency enrichment.
 
 See also: :mod:`pitloom.assemble.spdx3.deps`, which calls into this module
 to populate a dependency package's ``originatedBy``.
@@ -39,7 +39,43 @@ _COPYRIGHT_LINE_RE = re.compile(
 _COPYRIGHT_SEARCH_HEAD_CHARS = 500
 
 
-def _extract_suppliers(
+def _split_names(name: str) -> list[str]:
+    """Split a comma-/``and``-separated name list into stripped parts."""
+    return [part.strip() for part in re.split(r",|\band\b", name) if part.strip()]
+
+
+def _resolve_address_entry(
+    parsed_name: str, parsed_email: str, fallback_name: str
+) -> list[tuple[str | None, str | None]]:
+    """Resolve one :func:`email.utils.getaddresses` result into one or more
+    ``(name, email)`` tuples.
+
+    A single parsed address's display name can itself be a comma-separated
+    list of names sharing one address -- e.g. ``'"Author One, Author Two,
+    Author Three" <x@example.com>'``, seen in the wild on PyPI for a real
+    package, where the address belongs to a person not even in the name
+    list. The address cannot be fairly attributed to any of the listed
+    names, so it is split into individual name-only tuples plus one extra
+    email-only, name-``None`` tuple that keeps the address on its own
+    anonymous Person rather than discarding or misattributing it.
+    """
+    resolved_name = parsed_name.strip() or fallback_name or None
+    resolved_email = parsed_email.strip() or None
+    name_parts = _split_names(resolved_name) if resolved_name else []
+
+    if len(name_parts) > 1:
+        entries: list[tuple[str | None, str | None]] = [
+            (part, None) for part in name_parts
+        ]
+        if resolved_email:
+            entries.append((None, resolved_email))
+        return entries
+    if resolved_name or resolved_email:
+        return [(resolved_name, resolved_email)]
+    return []
+
+
+def _extract_name_email_pairs(
     name: str, email_raw: str
 ) -> list[tuple[str | None, str | None]]:
     """Return a list of ``(name, email)`` tuples from metadata fields.
@@ -50,41 +86,35 @@ def _extract_suppliers(
     comma-separated list of several such entries; :func:`email.utils.
     getaddresses` handles all three (unlike :func:`email.utils.parseaddr`,
     which mis-parses a multi-entry list as one malformed address and
-    silently returns nothing).
+    silently returns nothing). See :func:`_resolve_address_entry` for how
+    each parsed address is turned into one or more tuples.
 
     If *email_raw* is empty but *name* contains a comma-separated list of
     names, it splits them into individual tuples.
     """
     name = name.strip()
     email_raw = email_raw.strip()
-    results: list[tuple[str | None, str | None]] = []
 
     if email_raw:
-        addresses = getaddresses([email_raw])
-        for parsed_name, parsed_email in addresses:
-            resolved_name = parsed_name.strip() or name or None
-            resolved_email = parsed_email.strip() or None
-            if resolved_name or resolved_email:
-                results.append((resolved_name, resolved_email))
+        results: list[tuple[str | None, str | None]] = []
+        for parsed_name, parsed_email in getaddresses([email_raw]):
+            results.extend(_resolve_address_entry(parsed_name, parsed_email, name))
         return results
 
-    if name:
-        for part in re.split(r",|\band\b", name):
-            part = part.strip()
-            if part:
-                results.append((part, None))
-    return results
+    return [(part, None) for part in _split_names(name)]
 
 
-def _resolve_supplier(pkg_meta: PackageMetadata) -> list[tuple[str | None, str | None]]:
-    """Return a list of ``(name, email)`` tuples for a dependency's supplier from
-    installed metadata, or an empty list. Tries ``Author``/``Author-email`` first,
-    then falls back to ``Maintainer``/``Maintainer-email``."""
+def _resolve_author_or_maintainer(
+    pkg_meta: PackageMetadata,
+) -> list[tuple[str | None, str | None]]:
+    """Return a list of ``(name, email)`` tuples for a dependency's originator
+    from installed metadata, or an empty list. Tries ``Author``/``Author-email``
+    first, then falls back to ``Maintainer``/``Maintainer-email``."""
     for name_field, email_field in (
         ("Author", "Author-email"),
         ("Maintainer", "Maintainer-email"),
     ):
-        results = _extract_suppliers(
+        results = _extract_name_email_pairs(
             pkg_meta[name_field] or "", pkg_meta[email_field] or ""
         )
         if results:

--- a/src/pitloom/assemble/spdx3/deps_pypi.py
+++ b/src/pitloom/assemble/spdx3/deps_pypi.py
@@ -16,7 +16,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from urllib.parse import quote as url_quote
 
-from pitloom.assemble.spdx3.deps_supplier import _extract_suppliers
+from pitloom.assemble.spdx3.deps_originator import _extract_name_email_pairs
 from pitloom.extract._extract_utils import fetch_json
 
 # Best-effort PyPI JSON API fetch timeout -- short enough that a blocked or
@@ -34,15 +34,18 @@ _PYPI_LICENSE_FIELD_MAX_LEN = 200
 _PYPI_MAX_CONCURRENT_FETCHES = 8
 
 
-def _extract_pypi_supplier(info: dict[str, Any]) -> list[tuple[str | None, str | None]]:
-    """Return a list of ``(name, email)`` tuples for a dependency's supplier from a
-    PyPI JSON API ``info`` object, or an empty list. Same author-then-maintainer
-    precedence as :func:`~pitloom.assemble.spdx3.deps_supplier._resolve_supplier`."""
+def _extract_pypi_originator(
+    info: dict[str, Any],
+) -> list[tuple[str | None, str | None]]:
+    """Return a list of ``(name, email)`` tuples for a dependency's originator
+    from a PyPI JSON API ``info`` object, or an empty list. Same
+    author-then-maintainer precedence as
+    :func:`~pitloom.assemble.spdx3.deps_originator._resolve_author_or_maintainer`."""
     for name_key, email_key in (
         ("author", "author_email"),
         ("maintainer", "maintainer_email"),
     ):
-        results = _extract_suppliers(
+        results = _extract_name_email_pairs(
             info.get(name_key) or "", info.get(email_key) or ""
         )
         if results:

--- a/tests/assemble/test_assembly_edge_cases.py
+++ b/tests/assemble/test_assembly_edge_cases.py
@@ -7,7 +7,7 @@
 
 See also:
 - :mod:`tests.assemble.test_deps_enrichment_names_versions`
-- :mod:`tests.assemble.test_deps_enrichment_supplier_license`
+- :mod:`tests.assemble.test_deps_enrichment_originator_license`
 - :mod:`tests.assemble.test_annotation_provenance_core`
 """
 

--- a/tests/assemble/test_assembly_edge_cases.py
+++ b/tests/assemble/test_assembly_edge_cases.py
@@ -31,7 +31,7 @@ from pitloom.assemble.spdx3.deps_installed import (
     _parse_dep_name,
     _resolve_version,
 )
-from pitloom.assemble.spdx3.deps_supplier import (
+from pitloom.assemble.spdx3.deps_originator import (
     _apply_originator,
     _collect_originator_agents,
     _find_license_copyright,
@@ -126,7 +126,7 @@ def test_enrich_from_installed_unknown_version_skips_purl() -> None:
     assert getattr(dep_pkg, "software_packageUrl", None) is None
 
 
-def test_deps_supplier_candidate_copyright_and_find_license() -> None:
+def test_deps_originator_candidate_copyright_and_find_license() -> None:
     """_read_candidate_copyright and _find_license_copyright handle errors."""
 
     class MockDecodeErrFile:
@@ -150,7 +150,7 @@ def test_deps_supplier_candidate_copyright_and_find_license() -> None:
     mock_pkg_meta = MagicMock()
     mock_pkg_meta.get_all.return_value = ["LICENSE"]
     with patch(
-        "pitloom.assemble.spdx3.deps_supplier.get_pkg_distribution",
+        "pitloom.assemble.spdx3.deps_originator.get_pkg_distribution",
         side_effect=PackageNotFoundError("not found"),
     ):
         assert _find_license_copyright("nonexistent", mock_pkg_meta) is None
@@ -298,18 +298,34 @@ def test_deps_pypi_fetch_release_info_mocked() -> None:
         assert _fetch_pypi_release_info("badpkg", None) is None
 
 
-def test_deps_supplier_edge_branches() -> None:
-    """_extract_suppliers, _parse_project_urls, and remote authors edge branches."""
-    from pitloom.assemble.spdx3.deps_supplier import (
-        _extract_suppliers,
+def test_deps_originator_edge_branches() -> None:
+    """_extract_name_email_pairs, _parse_project_urls, remote authors edge branches."""
+    from pitloom.assemble.spdx3.deps_originator import (
+        _extract_name_email_pairs,
         _get_or_create_originator_agent,
         _parse_project_urls,
         _resolve_remote_authors_file,
     )
 
-    # _extract_suppliers with empty name/email or commas with spaces
-    assert _extract_suppliers("", "  ") == []
-    assert len(_extract_suppliers("Alice, , and Bob", "")) == 2
+    # _extract_name_email_pairs with empty name/email or commas with spaces
+    assert _extract_name_email_pairs("", "  ") == []
+    assert len(_extract_name_email_pairs("Alice, , and Bob", "")) == 2
+
+    # A single address's display name can itself be a comma-separated list
+    # of names sharing one address (seen in the wild on PyPI for a real
+    # package, where the address belongs to a person not even in the name
+    # list). The shared address can't be fairly attributed to any one
+    # listed name, so it splits into name-only tuples plus one extra
+    # email-only tuple that keeps the address on its own anonymous Person.
+    assert _extract_name_email_pairs(
+        "",
+        '"Author One, Author Two, Author Three" <x@example.com>',
+    ) == [
+        ("Author One", None),
+        ("Author Two", None),
+        ("Author Three", None),
+        (None, "x@example.com"),
+    ]
 
     # _parse_project_urls with malformed entry without comma
     mock_pkg = MagicMock()
@@ -358,7 +374,7 @@ def test_deps_supplier_edge_branches() -> None:
     mock_pkg_with_lic = MagicMock()
     mock_pkg_with_lic.get_all.return_value = ["LICENSE"]
     with patch(
-        "pitloom.assemble.spdx3.deps_supplier.get_pkg_distribution",
+        "pitloom.assemble.spdx3.deps_originator.get_pkg_distribution",
         return_value=mock_dist,
     ):
         assert _find_license_copyright("mypkg", mock_pkg_with_lic) is None
@@ -367,7 +383,7 @@ def test_deps_supplier_edge_branches() -> None:
     exporter = Spdx3JsonExporter()
     creation_info = _make_ci()
     with patch(
-        "pitloom.assemble.spdx3.deps_supplier._resolve_remote_authors_file",
+        "pitloom.assemble.spdx3.deps_originator._resolve_remote_authors_file",
         return_value=("https://raw.../AUTHORS", "text/plain", "Author text"),
     ):
         aid, attr_text = _get_or_create_originator_agent(
@@ -390,7 +406,7 @@ def test_deps_supplier_edge_branches() -> None:
     )
     dep_pkg.software_attributionText = ["Initial attribution"]
     with patch(
-        "pitloom.assemble.spdx3.deps_supplier._get_or_create_originator_agent",
+        "pitloom.assemble.spdx3.deps_originator._get_or_create_originator_agent",
         return_value=("http://spdx.org/spdxdocs/aid", "Second attribution"),
     ):
         _collect_originator_agents(

--- a/tests/assemble/test_deps_enrichment_names_versions.py
+++ b/tests/assemble/test_deps_enrichment_names_versions.py
@@ -6,7 +6,7 @@
 """Regression tests for dependency name/version parsing and PURL/installed
 enrichment in SPDX 3 SBOMs.
 
-See also: test_deps_enrichment_supplier_license.py,
+See also: test_deps_enrichment_originator_license.py,
 test_deps_enrichment_pypi_fallback.py, test_deps_enrichment_prefetch.py --
 this module's siblings, split from the original test_deps_enrichment.py.
 

--- a/tests/assemble/test_deps_enrichment_originator_license.py
+++ b/tests/assemble/test_deps_enrichment_originator_license.py
@@ -3,7 +3,7 @@
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
-"""Regression tests for dependency supplier/license resolution and the PyPI
+"""Regression tests for dependency originator/license resolution and the PyPI
 JSON API extraction helpers used by ``pitloom.assemble.spdx3.deps``.
 
 See also: test_deps_enrichment_names_versions.py,

--- a/tests/assemble/test_deps_enrichment_prefetch.py
+++ b/tests/assemble/test_deps_enrichment_prefetch.py
@@ -28,7 +28,7 @@ import pytest
 from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.assemble.spdx3 import deps_installed as deps_mod
-from pitloom.assemble.spdx3 import deps_pypi, deps_supplier
+from pitloom.assemble.spdx3 import deps_originator, deps_pypi
 from pitloom.assemble.spdx3.deps import add_dependencies
 from pitloom.assemble.spdx3.deps_pypi import (
     _extract_release_hash,
@@ -167,9 +167,9 @@ def test_fetch_pypi_release_info_live_network() -> None:
     assert len(digest) == 64  # hex sha256
 
 
-def test_extract_suppliers_parses_comma_separated_names() -> None:
+def test_extract_name_email_pairs_parses_comma_separated_names() -> None:
     meta = _FakeMetadata({"Author": "Alice, Bob and Charlie"})
-    assert deps_supplier._resolve_supplier(meta) == [
+    assert deps_originator._resolve_author_or_maintainer(meta) == [
         ("Alice", None),
         ("Bob", None),
         ("Charlie", None),
@@ -192,7 +192,7 @@ def test_apply_originator_creates_others_external_ref() -> None:
         ("Alice", None),
         ("Others (See OTHER_AUTHORS.md)", None),
     ]
-    deps_supplier._apply_originator(
+    deps_originator._apply_originator(
         originators,
         dep_package,
         ci,
@@ -246,7 +246,7 @@ def test_resolve_remote_authors_file_offline_and_errors() -> None:
     real (and previously unmocked) network call.
     """
     # Test offline returns immediately without trying to fetch
-    locator, ctype, content = deps_supplier._resolve_remote_authors_file(
+    locator, ctype, content = deps_originator._resolve_remote_authors_file(
         "https://github.com/foo/pkg",
         "AUTHORS",
         offline=True,
@@ -259,7 +259,7 @@ def test_resolve_remote_authors_file_offline_and_errors() -> None:
     # Test the URLError/OSError fallback path returns a locator-only result,
     # without making a real network call.
     with patch("urllib.request.urlopen", side_effect=URLError("simulated failure")):
-        locator, ctype, content = deps_supplier._resolve_remote_authors_file(
+        locator, ctype, content = deps_originator._resolve_remote_authors_file(
             "https://github.com/foo/pkg-offline-fallback",
             "AUTHORS",
             offline=False,
@@ -271,7 +271,7 @@ def test_resolve_remote_authors_file_offline_and_errors() -> None:
 
     # Test lru_cache behavior (call twice, check it returns identical)
     # without hitting the network again on the second call.
-    locator2, ctype2, content2 = deps_supplier._resolve_remote_authors_file(
+    locator2, ctype2, content2 = deps_originator._resolve_remote_authors_file(
         "https://github.com/foo/pkg-offline-fallback",
         "AUTHORS",
         offline=False,
@@ -293,7 +293,7 @@ def test_resolve_remote_authors_file_success_and_branches(
     mock_urlopen.return_value.__enter__.return_value = mock_response
 
     # Test github.com with successful fetch
-    locator, _ctype, content = deps_supplier._resolve_remote_authors_file(
+    locator, _ctype, content = deps_originator._resolve_remote_authors_file(
         "https://github.com/foo/pkg",
         "AUTHORS",
         offline=False,
@@ -303,7 +303,7 @@ def test_resolve_remote_authors_file_success_and_branches(
     assert content == "Author1\nAuthor2"
 
     # Test gitlab.com
-    locator, _ctype, content = deps_supplier._resolve_remote_authors_file(
+    locator, _ctype, content = deps_originator._resolve_remote_authors_file(
         "https://gitlab.com/foo/pkg",
         "AUTHORS",
         offline=True,
@@ -312,7 +312,7 @@ def test_resolve_remote_authors_file_success_and_branches(
     assert locator == "https://gitlab.com/foo/pkg/-/blob/HEAD/AUTHORS"
 
     # Test unknown host
-    locator, _ctype, content = deps_supplier._resolve_remote_authors_file(
+    locator, _ctype, content = deps_originator._resolve_remote_authors_file(
         "https://example.com/foo/pkg",
         "AUTHORS",
         offline=True,
@@ -321,7 +321,7 @@ def test_resolve_remote_authors_file_success_and_branches(
     assert locator == "https://example.com/foo/pkg"
 
     # Test short path
-    locator, _ctype, content = deps_supplier._resolve_remote_authors_file(
+    locator, _ctype, content = deps_originator._resolve_remote_authors_file(
         "https://github.com/foo",
         "AUTHORS",
         offline=True,

--- a/tests/assemble/test_deps_enrichment_prefetch.py
+++ b/tests/assemble/test_deps_enrichment_prefetch.py
@@ -8,7 +8,7 @@ PyPI JSON API sanity check, and supplier/originator/remote-authors
 handling in ``pitloom.assemble.spdx3.deps``.
 
 See also: test_deps_enrichment_names_versions.py,
-test_deps_enrichment_supplier_license.py,
+test_deps_enrichment_originator_license.py,
 test_deps_enrichment_pypi_fallback.py -- this module's siblings, split from
 the original test_deps_enrichment.py.
 """

--- a/tests/assemble/test_deps_enrichment_pypi_fallback.py
+++ b/tests/assemble/test_deps_enrichment_pypi_fallback.py
@@ -7,7 +7,7 @@
 ``pitloom.assemble.spdx3.deps.add_dependencies``.
 
 See also: test_deps_enrichment_names_versions.py,
-test_deps_enrichment_supplier_license.py, test_deps_enrichment_prefetch.py --
+test_deps_enrichment_originator_license.py, test_deps_enrichment_prefetch.py --
 this module's siblings, split from the original test_deps_enrichment.py.
 
 Covers the PyPI JSON API fallback (used when installed metadata doesn't

--- a/tests/assemble/test_deps_enrichment_pypi_fallback.py
+++ b/tests/assemble/test_deps_enrichment_pypi_fallback.py
@@ -29,7 +29,7 @@ from pitloom.assemble.spdx3 import deps_installed as deps_mod
 from pitloom.assemble.spdx3 import deps_pypi
 from pitloom.assemble.spdx3.deps import add_dependencies
 from pitloom.assemble.spdx3.deps_license import _add_license_noassertion
-from pitloom.assemble.spdx3.deps_supplier import _resolve_metadata_url
+from pitloom.assemble.spdx3.deps_originator import _resolve_metadata_url
 from pitloom.core.models import _clear_doc_counters, compute_doc_uuid, generate_spdx_id
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 

--- a/tests/assemble/test_deps_enrichment_supplier_license.py
+++ b/tests/assemble/test_deps_enrichment_supplier_license.py
@@ -24,16 +24,16 @@ import pytest
 from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.assemble.spdx3 import deps_installed as deps_mod
-from pitloom.assemble.spdx3 import deps_supplier
+from pitloom.assemble.spdx3 import deps_originator
 from pitloom.assemble.spdx3.deps import _enrich_from_installed
+from pitloom.assemble.spdx3.deps_originator import (
+    _find_license_copyright,
+    _resolve_author_or_maintainer,
+)
 from pitloom.assemble.spdx3.deps_pypi import (
     _extract_pypi_license,
-    _extract_pypi_supplier,
+    _extract_pypi_originator,
     _extract_release_hash,
-)
-from pitloom.assemble.spdx3.deps_supplier import (
-    _find_license_copyright,
-    _resolve_supplier,
 )
 from pitloom.core.models import _clear_doc_counters, compute_doc_uuid, generate_spdx_id
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
@@ -41,20 +41,22 @@ from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
 from .conftest import _FakeMetadata, _make_ci
 
 # ---------------------------------------------------------------------------
-# _resolve_supplier -- single address, Maintainer fallback, multi-address list
+# _resolve_author_or_maintainer -- single address, Maintainer fallback, multi-address
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_supplier_from_author_email() -> None:
+def test_resolve_author_or_maintainer_from_author_email() -> None:
     meta = _FakeMetadata({"Author-email": "Trail of Bits <opensource@trailofbits.com>"})
-    assert _resolve_supplier(meta) == [("Trail of Bits", "opensource@trailofbits.com")]
+    assert _resolve_author_or_maintainer(meta) == [
+        ("Trail of Bits", "opensource@trailofbits.com")
+    ]
 
 
-def test_resolve_supplier_falls_back_to_maintainer() -> None:
+def test_resolve_author_or_maintainer_falls_back_to_maintainer() -> None:
     meta = _FakeMetadata(
         {"Maintainer-email": "Taneli Hukkinen <hukkin@users.noreply.github.com>"}
     )
-    assert _resolve_supplier(meta) == [
+    assert _resolve_author_or_maintainer(meta) == [
         (
             "Taneli Hukkinen",
             "hukkin@users.noreply.github.com",
@@ -62,7 +64,7 @@ def test_resolve_supplier_falls_back_to_maintainer() -> None:
     ]
 
 
-def test_resolve_supplier_handles_multiple_maintainer_addresses() -> None:
+def test_resolve_author_or_maintainer_handles_multiple_maintainer_addresses() -> None:
     """Regression: a comma-separated multi-maintainer ``Maintainer-email``
     (common in real PyPI metadata, e.g. pipdeptree's three maintainers)
     made ``email.utils.parseaddr`` -- which expects a single address --
@@ -79,20 +81,20 @@ def test_resolve_supplier_handles_multiple_maintainer_addresses() -> None:
             )
         }
     )
-    assert _resolve_supplier(meta) == [
+    assert _resolve_author_or_maintainer(meta) == [
         ("Bernát Gábor", "gaborjbernat@gmail.com"),
         ("Kemal Zebari", "kemalzebra@gmail.com"),
         ("Vineet Naik", "naikvin@gmail.com"),
     ]
 
 
-def test_resolve_supplier_plain_name_no_email() -> None:
+def test_resolve_author_or_maintainer_plain_name_no_email() -> None:
     meta = _FakeMetadata({"Author": "Some Org"})
-    assert _resolve_supplier(meta) == [("Some Org", None)]
+    assert _resolve_author_or_maintainer(meta) == [("Some Org", None)]
 
 
-def test_resolve_supplier_absent_returns_none() -> None:
-    assert _resolve_supplier(_FakeMetadata({})) == []
+def test_resolve_author_or_maintainer_absent_returns_none() -> None:
+    assert _resolve_author_or_maintainer(_FakeMetadata({})) == []
 
 
 def test_enrich_from_installed_sets_originated_by(
@@ -209,7 +211,7 @@ def test_find_license_copyright_ignores_same_named_file_outside_dist_info(
         "Copyright (c) 2026 Real Author\n",
     )
     fake_dist = _FakeDistribution([vendored_license, real_license])
-    monkeypatch.setattr(deps_supplier, "get_pkg_distribution", lambda name: fake_dist)
+    monkeypatch.setattr(deps_originator, "get_pkg_distribution", lambda name: fake_dist)
 
     meta = _FakeMetadata({}, license_files=["LICENSE"])
     assert _find_license_copyright("mypkg", meta) == "Copyright (c) 2026 Real Author"
@@ -223,7 +225,7 @@ def test_find_license_copyright_matches_dist_info_root_not_only_licenses_subdir(
         "Copyright (c) 2026 Root Dist-Info Author\n",
     )
     fake_dist = _FakeDistribution([license_file])
-    monkeypatch.setattr(deps_supplier, "get_pkg_distribution", lambda name: fake_dist)
+    monkeypatch.setattr(deps_originator, "get_pkg_distribution", lambda name: fake_dist)
 
     meta = _FakeMetadata({}, license_files=["LICENSE.txt"])
     assert (
@@ -237,25 +239,25 @@ def test_find_license_copyright_matches_dist_info_root_not_only_licenses_subdir(
 # ---------------------------------------------------------------------------
 
 
-def test_extract_pypi_supplier_from_author() -> None:
+def test_extract_pypi_originator_from_author() -> None:
     info = {"author": "Trail of Bits", "author_email": "opensource@trailofbits.com"}
-    assert _extract_pypi_supplier(info) == [
+    assert _extract_pypi_originator(info) == [
         ("Trail of Bits", "opensource@trailofbits.com")
     ]
 
 
-def test_extract_pypi_supplier_falls_back_to_maintainer() -> None:
+def test_extract_pypi_originator_falls_back_to_maintainer() -> None:
     info = {
         "maintainer": "Taneli Hukkinen",
         "maintainer_email": "hukkin@users.noreply.github.com",
     }
-    assert _extract_pypi_supplier(info) == [
+    assert _extract_pypi_originator(info) == [
         ("Taneli Hukkinen", "hukkin@users.noreply.github.com")
     ]
 
 
-def test_extract_pypi_supplier_absent_returns_none() -> None:
-    assert _extract_pypi_supplier({}) == []
+def test_extract_pypi_originator_absent_returns_none() -> None:
+    assert _extract_pypi_originator({}) == []
 
 
 def test_extract_pypi_license_prefers_license_expression() -> None:

--- a/working-docs/design/complexity-and-file-size-roadmap.md
+++ b/working-docs/design/complexity-and-file-size-roadmap.md
@@ -58,7 +58,7 @@ helper functions:
 | `_iter_files` | `src/pitloom/_ids_types.py` | 10 | 22 | $\le 10$ | $\le 15$ | Fixed |
 | `_read_tar_sdist` | `src/pitloom/extract/_sdist.py` | 11 | 22 | $\le 10$ | $\le 15$ | Fixed |
 | `_resolve_cfg_version` | `src/pitloom/extract/_setuptools_cfg.py` | 11 | 22 | $\le 8$ | $\le 10$ | Fixed |
-| `_apply_originator` / `_find_license_copyright` | `src/pitloom/assemble/spdx3/deps_supplier.py` | 10 | 22 | $\le 10$ | $\le 15$ | Fixed |
+| `_apply_originator` / `_find_license_copyright` | `src/pitloom/assemble/spdx3/deps_originator.py` | 10 | 22 | $\le 10$ | $\le 15$ | Fixed |
 | `read_pyproject` | `src/pitloom/extract/_pyproject.py` | 11 | 22 | $\le 10$ | $\le 15$ | Fixed |
 | `read_onnx` | `src/pitloom/extract/_onnx.py` | 14 | 21 | $\le 10$ | $\le 15$ | Fixed |
 | `metadata_from_hatchling` | `src/pitloom/extract/hatchling.py` | 12 | 21 | $\le 10$ | $\le 15$ | Fixed |
@@ -87,7 +87,7 @@ individually large enough to trip review attention:
 
 None of these have crossed the 800-line hard cap, so nothing is currently
 broken -- but per AGENTS.md, a file should be split *before* crossing the
-soft limit, not after. `_setuptools_cfg.py` and `deps_supplier.py`
+soft limit, not after. `_setuptools_cfg.py` and `deps_originator.py`
 (407 lines, under the old high-water mark but still growing) are the
 best next candidates: both were split once already (see the table below)
 and have regrown past a third of their original decomposed size.
@@ -107,7 +107,7 @@ that gap -- not yet implemented.
 | `src/pitloom/assemble/spdx3/fragments.py` (758) | `_fragments_unify.py` (279), `fragments.py` (366) | 366 |
 | `src/pitloom/assemble/spdx3/provenance.py` (634) | `_provenance_encoders.py` (275), `provenance.py` (374) | 374 |
 | `src/pitloom/assemble/spdx3/ai.py` (593) | `_ai_package.py` (226), `ai.py` (363) | 363 |
-| `src/pitloom/assemble/spdx3/deps.py` (519) | `deps_installed.py` (168), `deps_license.py` (391), `deps_pypi.py` (307), `deps_supplier.py` (264), `deps.py` (311) | 391 |
+| `src/pitloom/assemble/spdx3/deps.py` (519) | `deps_installed.py` (168), `deps_license.py` (391), `deps_pypi.py` (307), `deps_originator.py` (264), `deps.py` (311) | 391 |
 | `src/pitloom/extract/_setuptools.py` (786) | `_setuptools_cfg.py` (228), `_setuptools_py.py` (190), `_setuptools.py` (158) | 228 |
 | `src/pitloom/extract/_license.py` (420) | `_license_detect.py` (178), `_license.py` (186) | 186 |
 | `src/pitloom/core/models.py` (450) | `_models_wheel.py` (168), `models.py` (186) | 186 |

--- a/working-docs/design/provenance-enrichment-vocabulary.md
+++ b/working-docs/design/provenance-enrichment-vocabulary.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-08-13
-Last-Modified: 2026-08-17
+Last-Modified: 2026-08-18
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -151,7 +151,7 @@ line numbers are approximate.
 | `dynamic_extraction` | Value read from a Python file at build time (e.g. `__version__`/`__about__.py`), not `pyproject.toml` directly | `src/pitloom/extract/_pyproject.py:342`, `:363` |
 | `licenseid_detection` | License matched against a known SPDX id via the `licenseid` library -- detected, not declared | `src/pitloom/extract/_pyproject.py:301`; `src/pitloom/extract/_huggingface_fetch.py:233`, `:327`; `src/pitloom/extract/_license.py:354`, `:417` |
 | `inferred_from_authors` | Copyright text derived from the `authors` list, not read verbatim | `src/pitloom/extract/_setuptools.py:284`, `:432`; `src/pitloom/extract/_poetry.py:169`; `src/pitloom/extract/hatchling.py:143`; `src/pitloom/extract/_pyproject.py:202` |
-| `parsed_author_list` | Multiple individual entities extracted by splitting a single, comma-separated author string | `src/pitloom/assemble/spdx3/deps_supplier.py:347` |
+| `parsed_author_list` | Multiple individual entities extracted by splitting a single, comma-separated author string | `src/pitloom/assemble/spdx3/deps_originator.py:347` |
 | `file_directive` | `pyproject.toml` dynamic field pointed at a file (`{file = "..."}`) | `src/pitloom/extract/_setuptools.py:500` |
 | `attr_directive` | `pyproject.toml` dynamic field pointed at a Python attribute (`{attr = "..."}`) | `src/pitloom/extract/_setuptools.py:519` |
 | `inspect_caller` | Recorded automatically by the `pitloom.loom` SDK via stack inspection | `src/pitloom/_loom_active_run.py:62`, `:67`, `:73` |

--- a/working-docs/implementation/file-map.md
+++ b/working-docs/implementation/file-map.md
@@ -96,7 +96,7 @@ pitloom/
 │       │   │   ├── deps_installed.py # Installed-environment dependency tree mapping
 │       │   │   ├── deps_license.py   # License element assembly
 │       │   │   ├── deps_pypi.py      # PyPI release-info lookups
-│       │   │   ├── deps_originator.py  # Originator resolution
+│       │   │   ├── deps_originator.py # Originator resolution
 │       │   │   ├── deps.py           # Dependency enrichment facade
 │       │   │   ├── document.py       # Facade: build(DocumentModel) -> Spdx3JsonExporter
 │       │   │   ├── fragments.py      # Fragment merging + unification provenance facade

--- a/working-docs/implementation/file-map.md
+++ b/working-docs/implementation/file-map.md
@@ -96,7 +96,7 @@ pitloom/
 │       │   │   ├── deps_installed.py # Installed-environment dependency tree mapping
 │       │   │   ├── deps_license.py   # License element assembly
 │       │   │   ├── deps_pypi.py      # PyPI release-info lookups
-│       │   │   ├── deps_supplier.py  # Supplier/originator resolution
+│       │   │   ├── deps_originator.py  # Originator resolution
 │       │   │   ├── deps.py           # Dependency enrichment facade
 │       │   │   ├── document.py       # Facade: build(DocumentModel) -> Spdx3JsonExporter
 │       │   │   ├── fragments.py      # Fragment merging + unification provenance facade

--- a/working-docs/implementation/provenance/annotation-provenance.md
+++ b/working-docs/implementation/provenance/annotation-provenance.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-07-20
-Last-Modified: 2026-08-17
+Last-Modified: 2026-08-18
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -88,7 +88,7 @@ does not fit `Key: value` must be preserved (see parser rules in §5.1).
 | Main Python package (post-migration: `emit_provenance()` call) | [`src/pitloom/assemble/spdx3/document.py:220`](../../../src/pitloom/assemble/spdx3/document.py) |
 | AI `ai_AIPackage` | [`src/pitloom/assemble/spdx3/ai.py:193`](../../../src/pitloom/assemble/spdx3/ai.py) (`_build_ai_package`) |
 | Dataset package | [`src/pitloom/assemble/spdx3/dataset.py:160`](../../../src/pitloom/assemble/spdx3/dataset.py) |
-| Dependency packages / license text / relationships | [`src/pitloom/assemble/spdx3/deps.py:492,566`](../../../src/pitloom/assemble/spdx3/deps.py), [`deps_license.py:79`](../../../src/pitloom/assemble/spdx3/deps_license.py), [`deps_supplier.py:358`](../../../src/pitloom/assemble/spdx3/deps_supplier.py) |
+| Dependency packages / license text / relationships | [`src/pitloom/assemble/spdx3/deps.py:492,566`](../../../src/pitloom/assemble/spdx3/deps.py), [`deps_license.py:79`](../../../src/pitloom/assemble/spdx3/deps_license.py), [`deps_originator.py:358`](../../../src/pitloom/assemble/spdx3/deps_originator.py) |
 | pipdeptree deps | [`src/pitloom/assemble/spdx3/_document_deployed.py:89,158`](../../../src/pitloom/assemble/spdx3/_document_deployed.py) |
 | Loom SDK fragments | [`src/pitloom/_loom_active_run.py:295,341,367`](../../../src/pitloom/_loom_active_run.py) |
 


### PR DESCRIPTION
## Summary

"A, B, C" <shared@email> author fields now emit one Person per name; a shared email unattributable to any name gets its own anonymous Person.

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
