### PR TITLE
Use smart default name for GitHub Action

### DIFF
--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -124,6 +124,37 @@ jobs:
           spdx3-validate --json "${{ steps.pitloom.outputs.sbom-path }}"
         continue-on-error: true
 
+      - name: Run Pitloom action with default output (project mode)
+        # No "output:" given -- exercises the action's own default-naming
+        # resolution (SBOM_OUTPUT_PATH= stdout parsing), not the generic
+        # "sbom.spdx3.json" the action used to force.
+        id: pitloom-default
+        uses: ./
+        with:
+          project-path: "."
+          install: "false"
+          upload-artifact: "false"
+
+      - name: Assert default output filename is packagename-version, not generic
+        run: |
+          set -euo pipefail
+
+          SBOM_PATH="${{ steps.pitloom-default.outputs.sbom-path }}"
+          echo "Default SBOM path: ${SBOM_PATH}"
+
+          if [ ! -s "${SBOM_PATH}" ]; then
+            echo "::error title=Missing SBOM::${SBOM_PATH} was not created."
+            exit 1
+          fi
+          case "${SBOM_PATH}" in
+            pitloom-*.spdx3.json) ;;
+            *)
+              echo "::error title=Unexpected default filename::" \
+                "expected pitloom-<version>.spdx3.json, got ${SBOM_PATH}"
+              exit 1
+              ;;
+          esac
+
       - name: Build a wheel
         run: |
           python -m build --wheel --no-isolation --outdir dist/
@@ -138,6 +169,38 @@ jobs:
           pretty: "true"
           install: "false"
           upload-artifact: "false"
+
+      - name: Run Pitloom action with embed-wheel and default output
+        # No "output:" given -- exercises the action's arcname-parsing +
+        # wheel-zip-extraction fallback, not the generic "sbom.spdx3.json"
+        # the action used to force.
+        id: pitloom-embed-default
+        uses: ./
+        with:
+          embed-wheel: "dist/*.whl"
+          project-path: "."
+          install: "false"
+          upload-artifact: "false"
+
+      - name: Assert embed-wheel default output filename is packagename-version
+        run: |
+          set -euo pipefail
+
+          SBOM_PATH="${{ steps.pitloom-embed-default.outputs.sbom-path }}"
+          echo "Default embed-wheel SBOM path: ${SBOM_PATH}"
+
+          if [ ! -s "${SBOM_PATH}" ]; then
+            echo "::error title=Missing SBOM::${SBOM_PATH} was not created."
+            exit 1
+          fi
+          case "${SBOM_PATH}" in
+            pitloom-*.spdx3.json) ;;
+            *)
+              echo "::error title=Unexpected default filename::" \
+                "expected pitloom-<version>.spdx3.json, got ${SBOM_PATH}"
+              exit 1
+              ;;
+          esac
 
       - name: Validate embedded wheel and SBOM with authoritative tools
         run: |

--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Run Pitloom action with default output (project mode)
         # No "output:" given -- exercises the action's own default-naming
-        # resolution (SBOM_OUTPUT_PATH= stdout parsing), not the generic
+        # resolution (PITLOOM_SBOM_OUTPUT_PATH= stdout parsing), not the generic
         # "sbom.spdx3.json" the action used to force.
         id: pitloom-default
         uses: ./

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ and this project adheres to
 - Full release notes: <https://github.com/bact/pitloom/releases>
 - Commit history: <https://github.com/bact/pitloom/compare/v0.16.0...v0.16.1>
 
+## [Unreleased]
+
+### Added
+
+- `loom project`/`loom model`/`loom env`/`loom wheel`/`loom embed-wheel`
+  print `PITLOOM_SBOM_OUTPUT_PATH=<path>` to stdout after writing an SBOM,
+  letting callers (e.g. the GitHub Action) discover the resolved output
+  path without re-deriving the default-naming logic themselves ([#171])
+
+### Fixed
+
+- The GitHub Action no longer forces a generic `sbom.spdx3.json` output
+  filename when `output` is left unset; it now defers to `loom`'s own
+  default-naming logic (`packagename-version.spdx3.json`, falling back to
+  `packagename.spdx3.json`, then `sbom.spdx3.json` as a last resort) ([#171])
+
+[#171]: https://github.com/bact/pitloom/pull/171
+
 ## [0.16.1] - 2026-08-18
 
 ### Fixed

--- a/action.yml
+++ b/action.yml
@@ -280,7 +280,7 @@ runs:
             # (see pitloom.cli.commands.utils._print_sbom_output_path).
             sbom_path=$(
               printf '%s\n' "${loom_stdout}" \
-                | sed -n 's/^SBOM_OUTPUT_PATH=//p' | head -n1
+                | sed -n 's/^PITLOOM_SBOM_OUTPUT_PATH=//p' | head -n1
             )
           fi
           echo "sbom-path=${sbom_path}" >> "${GITHUB_OUTPUT}"

--- a/action.yml
+++ b/action.yml
@@ -32,9 +32,16 @@ inputs:
     required: false
     default: ""
   output:
-    description: "SBOM output file path."
+    description: >-
+      SBOM output file path. Empty (default) lets "loom" apply its own
+      default naming for the resolved mode: project mode uses
+      packagename-version.spdx3.json (falling back to packagename.spdx3.json,
+      then sbom.spdx3.json as a last resort, unless overridden by the
+      project's [tool.pitloom] sbom-basename); model mode names the file
+      after the model's own filename or Hugging Face repo ID; embed-wheel
+      mode reuses the name it embeds into the wheel.
     required: false
-    default: "sbom.spdx3.json"
+    default: ""
   extras:
     description: >-
       Comma-separated pip extras to install alongside Pitloom, e.g. "ai"
@@ -199,7 +206,13 @@ runs:
             skip_output=true
           fi
         fi
-        if [ "${skip_output}" = false ]; then
+        # An explicit "output" input always wins. Otherwise leave -o off and
+        # let "loom" apply its own default-naming logic (packagename-version,
+        # falling back to packagename, then "sbom" as a last resort -- see
+        # pitloom.cli.options._resolve_output_path and
+        # pitloom._embed_wheel._derive_wheel_sbom_filename) rather than
+        # forcing a generic "sbom.spdx3.json" here.
+        if [ "${skip_output}" = false ] && [ -n "${PL_OUTPUT}" ]; then
           loom_args+=("-o" "${PL_OUTPUT}")
         fi
 
@@ -238,10 +251,39 @@ runs:
           loom_args+=("${extra_args[@]}")
         fi
 
-        loom "${loom_args[@]}"
+        # Capture stdout (while still echoing it to the log) so a
+        # loom-picked default filename can be recovered below when
+        # "output" was left empty.
+        loom_stdout=$(loom "${loom_args[@]}" | tee /dev/stderr)
 
         if [ "${skip_output}" = false ]; then
-          echo "sbom-path=${PL_OUTPUT}" >> "${GITHUB_OUTPUT}"
+          if [ -n "${PL_OUTPUT}" ]; then
+            sbom_path="${PL_OUTPUT}"
+          elif [ "${is_embed}" = true ]; then
+            # "loom embed-wheel" doesn't write a standalone copy unless -o is
+            # given (only the wheel's embedded copy, named via
+            # _derive_wheel_sbom_filename); extract that copy to disk so the
+            # action can still surface a sbom-path and upload it.
+            embed_wheel_path=$(
+              "${python_bin}" -c 'import glob, sys; print(glob.glob(sys.argv[1])[0])' \
+                "${PL_EMBED_WHEEL}"
+            )
+            arcname=$(
+              printf '%s\n' "${loom_stdout}" \
+                | sed -n 's/^pitloom: embedded \(.*\) into .*$/\1/p' | head -n1
+            )
+            sbom_path=$(basename "${arcname}")
+            "${python_bin}" -c 'import sys, zipfile; wp, an, op = sys.argv[1:4]; zf = zipfile.ZipFile(wp); data = zf.read(an); zf.close(); out = open(op, "wb"); out.write(data); out.close()' \
+              "${embed_wheel_path}" "${arcname}" "${sbom_path}"
+          else
+            # "loom project"/"loom model" print their resolved default path
+            # (see pitloom.cli.commands.utils._print_sbom_output_path).
+            sbom_path=$(
+              printf '%s\n' "${loom_stdout}" \
+                | sed -n 's/^SBOM_OUTPUT_PATH=//p' | head -n1
+            )
+          fi
+          echo "sbom-path=${sbom_path}" >> "${GITHUB_OUTPUT}"
         fi
 
     - name: Upload SBOM artifact

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -50,8 +50,11 @@ as any third-party action.
 ## Usage details
 
 By default the action scans the checkout root as a Python project and
-writes `sbom.spdx3.json`. Point it at an AI model instead of a project
-directory with `model:`:
+writes `<name>-<version>.spdx3.json` (falling back to `<name>.spdx3.json`,
+then `sbom.spdx3.json` as a last resort, unless the project's
+`[tool.pitloom] sbom-basename` overrides it -- the same default-naming
+logic `loom project` uses directly). Point it at an AI model instead of a
+project directory with `model:`:
 
 ```yaml
 - uses: bact/pitloom@v0.16.1
@@ -89,7 +92,7 @@ Inputs (all optional):
 | `project-path` | `.` | Directory to scan for a Python project. Ignored when `model` is set. |
 | `embed-wheel` | *(empty)* | Path or glob pattern of built wheel(s) to embed the SBOM into (PEP 770), e.g. `dist/*.whl`. |
 | `model` | *(empty)* | Local model file path, or Hugging Face URL/model ID. Switches to model mode. |
-| `output` | `sbom.spdx3.json` | SBOM output file path. |
+| `output` | *(empty)* | SBOM output file path. Empty lets `loom` apply its own default naming for the resolved mode: project mode uses `<name>-<version>.spdx3.json` (falling back to `<name>.spdx3.json`, then `sbom.spdx3.json`, unless `[tool.pitloom] sbom-basename` overrides it); model mode names the file after the model's own filename or Hugging Face repo ID; embed-wheel mode reuses the name it embeds into the wheel. |
 | `extras` | *(empty)* | Comma-separated pip extras to install alongside Pitloom, e.g. `ai` (all AI model formats, including Hugging Face Hub support). |
 | `pretty` | `false` | Pretty-print the SBOM output. |
 | `enrich` | *(empty)* | `true`/`false` to force README/model-card enrichment on or off; empty defers to the project's `[tool.pitloom] enrich` config (off by default). |

--- a/src/pitloom/cli/commands/embed_wheel.py
+++ b/src/pitloom/cli/commands/embed_wheel.py
@@ -16,7 +16,11 @@ from pitloom.assemble import (
     ConfigOverrides,
     embed_wheel_sbom,
 )
-from pitloom.cli.commands.utils import _collect_wheel_paths, cli_error_handler
+from pitloom.cli.commands.utils import (
+    _collect_wheel_paths,
+    _print_sbom_output_path,
+    cli_error_handler,
+)
 from pitloom.cli.options import _resolve_creation_metadata
 from pitloom.core.config import PitloomConfig
 from pitloom.extract.project import read_project
@@ -116,6 +120,8 @@ def _run_embed_wheel_command(args: argparse.Namespace) -> int:
             overrides=overrides,
         )
         _report_embed_result(arcname, wheel_path.name, removed, floored)
+        if output_path is not None:
+            _print_sbom_output_path(output_path)
     return 0
 
 

--- a/src/pitloom/cli/commands/env.py
+++ b/src/pitloom/cli/commands/env.py
@@ -15,7 +15,7 @@ from pitloom.__about__ import __version__
 from pitloom.assemble import (
     generate_env_sbom,
 )
-from pitloom.cli.commands.utils import cli_error_handler
+from pitloom.cli.commands.utils import _print_sbom_output_path, cli_error_handler
 from pitloom.cli.constants import _SPDX3_JSON_EXT
 from pitloom.cli.options import _resolve_common_options
 
@@ -41,6 +41,7 @@ def _run_env_command(args: argparse.Namespace) -> int:
         provenance=pitloom_config.provenance,
         offline=args.offline or None,
     )
+    _print_sbom_output_path(output_path)
     return 0
 
 

--- a/src/pitloom/cli/commands/model.py
+++ b/src/pitloom/cli/commands/model.py
@@ -16,7 +16,7 @@ from pitloom.__about__ import __version__
 from pitloom.assemble import (
     generate_model_sbom,
 )
-from pitloom.cli.commands.utils import cli_error_handler
+from pitloom.cli.commands.utils import _print_sbom_output_path, cli_error_handler
 from pitloom.cli.options import (
     _resolve_common_options,
     _resolve_hf_output_path,
@@ -70,6 +70,7 @@ def _run_model_command(args: argparse.Namespace) -> int:
         provenance=pitloom_config.provenance,
         enrich=args.enrich,
     )
+    _print_sbom_output_path(output_path)
     return 0
 
 

--- a/src/pitloom/cli/commands/project.py
+++ b/src/pitloom/cli/commands/project.py
@@ -14,7 +14,7 @@ from typing import Any
 from pitloom.assemble import (
     generate_project_sbom,
 )
-from pitloom.cli.commands.utils import cli_error_handler
+from pitloom.cli.commands.utils import _print_sbom_output_path, cli_error_handler
 from pitloom.cli.options import (
     _resolve_creation_metadata,
     _resolve_output_path,
@@ -68,6 +68,7 @@ def _run_project_command(args: argparse.Namespace) -> int:
         content_type=args.content_type,
         content_type_method=args.content_type_method,
     )
+    _print_sbom_output_path(output_path)
     return 0
 
 

--- a/src/pitloom/cli/commands/utils.py
+++ b/src/pitloom/cli/commands/utils.py
@@ -43,8 +43,10 @@ def _print_sbom_output_path(output_path: Path | str) -> None:
 
     Lets callers (e.g. the GitHub Action) discover the filename a command's
     own default-naming logic picked, without re-deriving it themselves.
+    Namespaced "PITLOOM_" so it reads unambiguously as this stdout line,
+    distinct from the GitHub Action's own "sbom-path" output.
     """
-    print(f"SBOM_OUTPUT_PATH={output_path}")
+    print(f"PITLOOM_SBOM_OUTPUT_PATH={output_path}")
 
 
 def _collect_wheel_paths(patterns: list[str]) -> list[Path]:

--- a/src/pitloom/cli/commands/utils.py
+++ b/src/pitloom/cli/commands/utils.py
@@ -38,6 +38,15 @@ def cli_error_handler(
     return decorator
 
 
+def _print_sbom_output_path(output_path: Path | str) -> None:
+    """Report the resolved SBOM output path in KEY=VALUE form (see CLAUDE.md).
+
+    Lets callers (e.g. the GitHub Action) discover the filename a command's
+    own default-naming logic picked, without re-deriving it themselves.
+    """
+    print(f"SBOM_OUTPUT_PATH={output_path}")
+
+
 def _collect_wheel_paths(patterns: list[str]) -> list[Path]:
     """Resolve and expand wheel file paths and glob patterns.
 

--- a/src/pitloom/cli/commands/wheel.py
+++ b/src/pitloom/cli/commands/wheel.py
@@ -18,7 +18,7 @@ from pitloom.assemble import (
     generate_wheel_sbom,
 )
 from pitloom.cli.commands.embed_wheel import _report_embed_result
-from pitloom.cli.commands.utils import cli_error_handler
+from pitloom.cli.commands.utils import _print_sbom_output_path, cli_error_handler
 from pitloom.cli.constants import _SPDX3_JSON_EXT
 from pitloom.cli.options import _resolve_common_options
 
@@ -74,6 +74,9 @@ def _run_wheel_command(args: argparse.Namespace) -> int:
     if embed:
         _, arcname, removed, floored = embed_sbom_in_wheel(wheel_path, sbom_json)
         _report_embed_result(arcname, wheel_path.name, removed, floored)
+
+    if output_path is not None:
+        _print_sbom_output_path(output_path)
 
     return 0
 


### PR DESCRIPTION
## Summary

If "output" is not set for action, use smart default name (packagename-version.spdx3.json)

Currently the GitHub Action forced `-o sbom.spdx3.json` unconditionally, overriding Pitloom's own packagename-version naming.

Fixed that.

Now `output:` defaults to empty, letting loom pick its default name; the action recovers the resolved filename via a new `SBOM_OUTPUT_PATH=` stdout line and by parsing the embed-wheel embed confirmation.

Adds self-test coverage for the default-output path.

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
