### PR TITLE
Fix content-type/file-header loss in embed-wheel SBOMs

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build
+          pip install build spdx3-validate
 
       - name: Install Pitloom from checkout
         run: pip install -e ".[content-type]"
@@ -45,7 +45,7 @@ jobs:
           # the published wheel with the same generator, dogfooded end to end.
           python -m build --no-isolation
 
-      - name: Regenerate and embed SBOM via the Pitloom Action (PEP 770)
+      - name: Regenerate and embed SBOM
         # Dogfoods this exact commit's own Action + CLI ("uses: ./",
         # install: false reuses the checkout installed above) against its
         # own release wheel, overwriting the Hatchling hook's embedded copy
@@ -59,6 +59,41 @@ jobs:
           content-type: "true"
           upload-artifact: "true"
           artifact-name: "sbom"
+
+      - name: Check SBOM is at the PEP 770 location
+        env:
+          SBOM_PATH: ${{ steps.pitloom.outputs.sbom-path }}
+        run: |
+          set -euo pipefail
+          whl=$(ls dist/*.whl)
+          sbom_basename=$(basename "${SBOM_PATH}")
+
+          # Match the exact file "loom" just embedded (by its packagename-
+          # version basename), not merely "some .spdx3.json exists" -- a
+          # stray/leftover SBOM under .dist-info/sboms/ would otherwise
+          # pass this check without being the one Pitloom just generated.
+          # Bash glob (not grep -E) so dots/dashes in sbom_basename are
+          # matched literally, not as regex metacharacters.
+          matched=""
+          while IFS= read -r entry; do
+            case "${entry}" in
+              *.dist-info/sboms/"${sbom_basename}")
+                matched="${entry}"
+                break
+                ;;
+            esac
+          done < <(unzip -Z1 "${whl}")
+
+          if [ -z "${matched}" ]; then
+            echo "::error::${sbom_basename} not found under" \
+              "*.dist-info/sboms/ in ${whl}"
+            exit 1
+          fi
+          echo "Found: ${matched}"
+
+      - name: Validate SBOM
+        run: |
+          spdx3-validate --json "${{ steps.pitloom.outputs.sbom-path }}"
 
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -89,7 +124,14 @@ jobs:
     needs: build
     # Runs independently of "publish": the release asset is a nice-to-have,
     # so a failure/skip here must never block the actual PyPI publish.
-    if: needs.build.outputs.sbom-path != ''
+    # needs.build.result must be checked explicitly -- a custom "if:"
+    # replaces the implicit success() gate "needs:" would otherwise apply,
+    # and sbom-path is set as soon as the embed step runs, before the
+    # later "Check SBOM location"/"Validate SBOM" steps that can fail it.
+    # Without this, a validation failure still blocks PyPI publish (the
+    # "publish" job keeps its implicit gate) but this job would still
+    # attach the unvalidated SBOM to the public release.
+    if: needs.build.result == 'success' && needs.build.outputs.sbom-path != ''
     runs-on: ubuntu-latest
     permissions:
       contents: write  # gh release upload, for the standalone SBOM asset

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -14,7 +14,9 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # gh release upload, for the standalone SBOM asset
+      contents: read
+    outputs:
+      sbom-path: ${{ steps.pitloom.outputs.sbom-path }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -58,17 +60,6 @@ jobs:
           upload-artifact: "true"
           artifact-name: "sbom"
 
-      - name: Attach SBOM to GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          SBOM_PATH: ${{ steps.pitloom.outputs.sbom-path }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          gh release upload "${RELEASE_TAG}" "${SBOM_PATH}" \
-            --clobber --repo "${REPO}"
-
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -92,3 +83,31 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+
+  attach-release-sbom:
+    name: Attach SBOM to GitHub Release
+    needs: build
+    # Runs independently of "publish": the release asset is a nice-to-have,
+    # so a failure/skip here must never block the actual PyPI publish.
+    if: needs.build.outputs.sbom-path != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # gh release upload, for the standalone SBOM asset
+
+    steps:
+      - name: Download SBOM artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: sbom
+          path: sbom/
+
+      - name: Attach SBOM to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          SBOM_BASENAME: ${{ needs.build.outputs.sbom-path }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh release upload "${RELEASE_TAG}" "sbom/${SBOM_BASENAME}" \
+            --clobber --repo "${REPO}"

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -38,19 +38,16 @@ jobs:
 
       - name: Build sdist and wheel
         run: |
-          # --no-isolation: use the locally installed Pitloom so the build hook
-          # embeds a freshly generated SBOM into the wheel (.dist-info/sboms/).
-          # This hook-embedded SBOM is what any plain "pip install"/"build"
-          # of this project gets -- the Action step below overwrites it in
-          # the published wheel with the same generator, dogfooded end to end.
+          # --no-isolation: use the checkout's local Pitloom, not an isolated
+          # build env, so the build hook embeds a freshly generated SBOM
+          # (.dist-info/sboms/). The Action step below regenerates and
+          # overwrites this copy in the published wheel.
           python -m build --no-isolation
 
       - name: Regenerate and embed SBOM
-        # Dogfoods this exact commit's own Action + CLI ("uses: ./",
-        # install: false reuses the checkout installed above) against its
-        # own release wheel, overwriting the Hatchling hook's embedded copy
-        # with the Action-driven one and producing a standalone copy for
-        # the release/artifact steps below.
+        # uses: ./ + install: false runs this commit's own Action/CLI
+        # (reusing the checkout installed above) against the release wheel,
+        # and also writes a standalone copy for the steps below.
         id: pitloom
         uses: ./
         with:
@@ -65,15 +62,19 @@ jobs:
           SBOM_PATH: ${{ steps.pitloom.outputs.sbom-path }}
         run: |
           set -euo pipefail
-          whl=$(ls dist/*.whl)
+          shopt -s nullglob
+          wheels=(dist/*.whl)
+          if [ "${#wheels[@]}" -ne 1 ]; then
+            echo "::error::expected exactly one wheel in dist/, found" \
+              "${#wheels[@]}: ${wheels[*]}"
+            exit 1
+          fi
+          whl="${wheels[0]}"
           sbom_basename=$(basename "${SBOM_PATH}")
 
-          # Match the exact file "loom" just embedded (by its packagename-
-          # version basename), not merely "some .spdx3.json exists" -- a
-          # stray/leftover SBOM under .dist-info/sboms/ would otherwise
-          # pass this check without being the one Pitloom just generated.
-          # Bash glob (not grep -E) so dots/dashes in sbom_basename are
-          # matched literally, not as regex metacharacters.
+          # Match the exact embedded basename, not just "any .spdx3.json
+          # exists". Bash glob, not grep -E, so dots/dashes in the
+          # basename stay literal.
           matched=""
           while IFS= read -r entry; do
             case "${entry}" in
@@ -122,15 +123,12 @@ jobs:
   attach-release-sbom:
     name: Attach SBOM to GitHub Release
     needs: build
-    # Runs independently of "publish": the release asset is a nice-to-have,
-    # so a failure/skip here must never block the actual PyPI publish.
-    # needs.build.result must be checked explicitly -- a custom "if:"
-    # replaces the implicit success() gate "needs:" would otherwise apply,
-    # and sbom-path is set as soon as the embed step runs, before the
-    # later "Check SBOM location"/"Validate SBOM" steps that can fail it.
-    # Without this, a validation failure still blocks PyPI publish (the
-    # "publish" job keeps its implicit gate) but this job would still
-    # attach the unvalidated SBOM to the public release.
+    # A custom "if:" replaces needs:'s implicit success() gate, so both
+    # conditions are explicit here:
+    # - result == 'success': skip if "Validate SBOM" failed in "build".
+    # - sbom-path != '': skip if "build" produced no standalone SBOM
+    #   (embed-wheel matched more than one wheel), since no "sbom"
+    #   artifact was uploaded for this job to download.
     if: needs.build.result == 'success' && needs.build.outputs.sbom-path != ''
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write  # gh release upload, for the standalone SBOM asset
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -38,7 +38,36 @@ jobs:
         run: |
           # --no-isolation: use the locally installed Pitloom so the build hook
           # embeds a freshly generated SBOM into the wheel (.dist-info/sboms/).
+          # This hook-embedded SBOM is what any plain "pip install"/"build"
+          # of this project gets -- the Action step below overwrites it in
+          # the published wheel with the same generator, dogfooded end to end.
           python -m build --no-isolation
+
+      - name: Regenerate and embed SBOM via the Pitloom Action (PEP 770)
+        # Dogfoods this exact commit's own Action + CLI ("uses: ./",
+        # install: false reuses the checkout installed above) against its
+        # own release wheel, overwriting the Hatchling hook's embedded copy
+        # with the Action-driven one and producing a standalone copy for
+        # the release/artifact steps below.
+        id: pitloom
+        uses: ./
+        with:
+          embed-wheel: "dist/*.whl"
+          install: "false"
+          content-type: "true"
+          upload-artifact: "true"
+          artifact-name: "sbom"
+
+      - name: Attach SBOM to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          SBOM_PATH: ${{ steps.pitloom.outputs.sbom-path }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh release upload "${RELEASE_TAG}" "${SBOM_PATH}" \
+            --clobber --repo "${REPO}"
 
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ and this project adheres to
   preserving the wheel's own file records -- hashes of the actually-built
   wheel's bytes, `.dist-info/*` entries, and any build-hook-injected files
   that a project-directory rescan alone can't see ([#172], [#174])
+- `loom embed-wheel`'s Merkle root (asserted as the main package's
+  `verifiedUsing` hash, and fed into every generated SPDX ID) is now
+  computed from the wheel's own file hashes instead of a project-directory
+  rescan that could diverge from the actually-built wheel ([#172])
 
 [#171]: https://github.com/bact/pitloom/pull/171
 [#172]: https://github.com/bact/pitloom/pull/172

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to
   print `PITLOOM_SBOM_OUTPUT_PATH=<path>` to stdout after writing an SBOM,
   letting callers (e.g. the GitHub Action) discover the resolved output
   path without re-deriving the default-naming logic themselves ([#171])
+- The PyPI release workflow attaches the standalone SBOM as a GitHub
+  Release asset, generated via the project's own GitHub Action ([#172],
+  [#174])
 
 ### Fixed
 
@@ -34,8 +37,16 @@ and this project adheres to
   filename when `output` is left unset; it now defers to `loom`'s own
   default-naming logic (`packagename-version.spdx3.json`, falling back to
   `packagename.spdx3.json`, then `sbom.spdx3.json` as a last resort) ([#171])
+- `loom embed-wheel`'s Build SBOM now includes content-type and
+  file-header data for each file (previously silently dropped even with
+  `--content-type`/`--extract-file-header` enabled), while still
+  preserving the wheel's own file records -- hashes of the actually-built
+  wheel's bytes, `.dist-info/*` entries, and any build-hook-injected files
+  that a project-directory rescan alone can't see ([#172], [#174])
 
 [#171]: https://github.com/bact/pitloom/pull/171
+[#172]: https://github.com/bact/pitloom/pull/172
+[#174]: https://github.com/bact/pitloom/pull/174
 
 ## [0.16.1] - 2026-08-18
 

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -86,6 +86,11 @@ def _build_sbom_from_project_and_wheel(
         content_type_method=pitloom_config.content_type.method,
         content_type_overrides=pitloom_config.content_type.overrides,
     )
+    # Without this, the SBOM's file list comes from wheel_metadata.files
+    # (read_wheel()'s plain content-hash-only entries), silently dropping
+    # the content-type/file-header data get_wheel_files() just computed
+    # -- mirrors pitloom.plugins.hatch._build_document_model.
+    wheel_metadata.files = project_files
     ai_models = scan_project_for_ai_models(project_dir, project_files)
     phantom_deps = find_phantom_dependencies(wheel_metadata.files)
     enrichment_results = run_enrichers_for_models(

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -37,7 +37,7 @@ from pitloom.assemble.spdx3.fragments import merge_fragments
 from pitloom.core.config import VALID_CONTENT_TYPE_METHODS, PitloomConfig
 from pitloom.core.creation import CreationMetadata
 from pitloom.core.document import DocumentModel
-from pitloom.core.models import get_wheel_files
+from pitloom.core.models import _build_merkle_tree, get_wheel_files
 from pitloom.core.project import ProjectFile, ProjectMetadata
 from pitloom.core.provenance import ProvenanceConfig
 from pitloom.enrich import run_enrichers_for_models
@@ -107,6 +107,22 @@ def _merge_file_extras(
     return merged
 
 
+def _compute_wheel_merkle_root(files: list[ProjectFile]) -> str | None:
+    """Merkle root over *files*' own digests -- the wheel's truth, not a rescan.
+
+    Mirrors :func:`pitloom.core._models_wheel.get_wheel_files`'s ordering
+    (sort by ``distribution_path``) and hashing convention so the result is
+    reproducible the same way, but computed from files whose
+    ``digest_sha256`` already reflects the wheel's own bytes (post-merge)
+    instead of a fresh ``project_dir`` rescan that can diverge from them.
+    """
+    if not files:
+        return None
+    ordered = sorted(files, key=lambda f: f.distribution_path)
+    leaf_hashes = [bytes.fromhex(f.digest_sha256) for f in ordered]
+    return _build_merkle_tree(leaf_hashes)
+
+
 def _build_sbom_from_project_and_wheel(
     project_dir: Path,
     wheel_metadata: ProjectMetadata,
@@ -115,7 +131,11 @@ def _build_sbom_from_project_and_wheel(
     creation_metadata: CreationMetadata | None,
 ) -> str:
     """Generate a canonical Build SBOM from project sources and wheel files."""
-    merkle_root, project_files = get_wheel_files(
+    # merkle_root (the rescan's own, over project_dir's on-disk bytes) is
+    # deliberately discarded here -- see _compute_wheel_merkle_root below,
+    # which recomputes it from the wheel's own (post-merge) file hashes so
+    # it can't diverge from what merged_files actually reports.
+    _, project_files = get_wheel_files(
         project_dir,
         scan_file_headers=pitloom_config.extract_file_header,
         detect_content_type=pitloom_config.content_type.enabled,
@@ -132,6 +152,7 @@ def _build_sbom_from_project_and_wheel(
     # caller's wheel_metadata (e.g. embed_wheel_sbom's read_wheel() result)
     # isn't silently mutated as a side effect of building this SBOM.
     project_metadata = dataclasses.replace(wheel_metadata, files=merged_files)
+    merkle_root = _compute_wheel_merkle_root(merged_files)
     ai_models = scan_project_for_ai_models(project_dir, project_files)
     phantom_deps = find_phantom_dependencies(merged_files)
     enrichment_results = run_enrichers_for_models(

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -128,7 +128,10 @@ def _build_sbom_from_project_and_wheel(
     # extensions, auditwheel-repaired shared libraries) that read_wheel()
     # found in the actual wheel but that a source-tree rescan can't see.
     merged_files = _merge_file_extras(wheel_metadata.files, project_files)
-    wheel_metadata.files = merged_files
+    # dataclasses.replace, not an in-place `.files =` assignment, so the
+    # caller's wheel_metadata (e.g. embed_wheel_sbom's read_wheel() result)
+    # isn't silently mutated as a side effect of building this SBOM.
+    project_metadata = dataclasses.replace(wheel_metadata, files=merged_files)
     ai_models = scan_project_for_ai_models(project_dir, project_files)
     phantom_deps = find_phantom_dependencies(merged_files)
     enrichment_results = run_enrichers_for_models(
@@ -136,7 +139,7 @@ def _build_sbom_from_project_and_wheel(
     )
 
     doc = DocumentModel(
-        project=wheel_metadata,
+        project=project_metadata,
         creation_metadata=creation_metadata or CreationMetadata(),
         ai_models=ai_models,
         phantom_dependencies=phantom_deps,

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -38,7 +38,7 @@ from pitloom.core.config import VALID_CONTENT_TYPE_METHODS, PitloomConfig
 from pitloom.core.creation import CreationMetadata
 from pitloom.core.document import DocumentModel
 from pitloom.core.models import get_wheel_files
-from pitloom.core.project import ProjectMetadata
+from pitloom.core.project import ProjectFile, ProjectMetadata
 from pitloom.core.provenance import ProvenanceConfig
 from pitloom.enrich import run_enrichers_for_models
 from pitloom.extract.binary import find_phantom_dependencies
@@ -71,6 +71,42 @@ __all__ = [
 ]
 
 
+def _merge_file_extras(
+    wheel_files: list[ProjectFile], project_files: list[ProjectFile]
+) -> list[ProjectFile]:
+    """Layer re-scanned content-type/header data onto the wheel's own files.
+
+    ``wheel_files`` (from :func:`pitloom.extract.wheel.read_wheel`) is the
+    source of truth for what the already-built wheel actually contains --
+    including ``.dist-info/*`` entries and any build-hook-injected files
+    that never existed in ``project_dir`` -- so it is kept intact,
+    including its hashes computed from the wheel's own bytes.
+    ``project_files`` (from :func:`~pitloom.core.models.get_wheel_files`)
+    only supplies the content-type/file-header extras it computed by
+    re-scanning the sources, adopted for files present in both lists.
+    """
+    extras_by_path = {f.distribution_path: f for f in project_files}
+    merged: list[ProjectFile] = []
+    for wheel_file in wheel_files:
+        extra = extras_by_path.get(wheel_file.distribution_path)
+        if extra is None:
+            merged.append(wheel_file)
+            continue
+        merged.append(
+            dataclasses.replace(
+                wheel_file,
+                copyright_text=extra.copyright_text,
+                copyright_source=extra.copyright_source,
+                file_contributors=extra.file_contributors,
+                file_type=extra.file_type,
+                spdx_license_identifier=extra.spdx_license_identifier,
+                content_type=extra.content_type,
+                content_type_method=extra.content_type_method,
+            )
+        )
+    return merged
+
+
 def _build_sbom_from_project_and_wheel(
     project_dir: Path,
     wheel_metadata: ProjectMetadata,
@@ -86,13 +122,15 @@ def _build_sbom_from_project_and_wheel(
         content_type_method=pitloom_config.content_type.method,
         content_type_overrides=pitloom_config.content_type.overrides,
     )
-    # Without this, the SBOM's file list comes from wheel_metadata.files
-    # (read_wheel()'s plain content-hash-only entries), silently dropping
-    # the content-type/file-header data get_wheel_files() just computed
-    # -- mirrors pitloom.plugins.hatch._build_document_model.
-    wheel_metadata.files = project_files
+    # Layer content-type/file-header extras onto the wheel's own file
+    # records rather than replacing them outright: replacing would drop
+    # .dist-info entries and any build-hook-injected files (e.g. compiled
+    # extensions, auditwheel-repaired shared libraries) that read_wheel()
+    # found in the actual wheel but that a source-tree rescan can't see.
+    merged_files = _merge_file_extras(wheel_metadata.files, project_files)
+    wheel_metadata.files = merged_files
     ai_models = scan_project_for_ai_models(project_dir, project_files)
-    phantom_deps = find_phantom_dependencies(wheel_metadata.files)
+    phantom_deps = find_phantom_dependencies(merged_files)
     enrichment_results = run_enrichers_for_models(
         ai_models, pitloom_config.enrich, project_dir
     )

--- a/tests/assemble/test_embed_overrides.py
+++ b/tests/assemble/test_embed_overrides.py
@@ -25,6 +25,7 @@ from installer.sources import WheelFile
 
 from pitloom import __main__
 from pitloom.core.config import PitloomConfig
+from pitloom.core.models import _build_merkle_tree
 from pitloom.core.project import ProjectMetadata
 from pitloom.core.provenance import ProvenanceConfig
 from pitloom.embed import (
@@ -221,6 +222,82 @@ packages = ["ctpkg"]
     expected_digest = hashlib.sha256(b"__version__ = '1.0.0'\n").hexdigest()
     assert hash_obj["hashValue"] == expected_digest
     assert init_file.get("contentType")
+
+
+def test_embed_wheel_merkle_root_reflects_wheel_not_rescan(
+    tmp_path: Path,
+) -> None:
+    """The document's Merkle root must be computed from the wheel's own
+    (post-merge) file hashes, not a fresh rescan of ``project_dir``.
+
+    Regression test: ``_build_sbom_from_project_and_wheel`` used to pass
+    through ``get_wheel_files()``'s own ``merkle_root`` -- computed by
+    hashing ``project_dir``'s on-disk bytes -- straight into the exported
+    document, even though ``_merge_file_extras`` had already fixed the
+    *per-file* hashes to prefer the wheel's own truth. Whenever
+    ``project_dir`` diverges from the already-built wheel (as it
+    deliberately does here, mirroring
+    ``test_embed_wheel_preserves_wheel_truth_and_merges_content_type``),
+    that left the package's ``verifiedUsing`` Merkle root -- and every
+    SPDX ID derived from it via ``compute_doc_uuid`` -- describing a
+    different file set than the one actually reported.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "ctpkg"
+version = "1.0.0"
+
+[tool.hatch.build.targets.wheel]
+packages = ["ctpkg"]
+""",
+        encoding="utf-8",
+    )
+    pkg_dir = tmp_path / "ctpkg"
+    pkg_dir.mkdir()
+    # Deliberately differs from the wheel's own __init__.py (see
+    # _make_dummy_wheel) so a Merkle root computed from this rescan would
+    # differ from one computed from the wheel's own bytes.
+    (pkg_dir / "__init__.py").write_text("x = 1\n", encoding="utf-8")
+
+    wheel_path = _make_dummy_wheel(tmp_path / "dist", "ctpkg", "1.0.0")
+
+    # Capture the wheel's own bytes *before* embedding mutates it (adds the
+    # SBOM entry and rewrites RECORD) -- this is the file set
+    # _compute_wheel_merkle_root should be reproducible from.
+    with zipfile.ZipFile(wheel_path, "r") as zf:
+        wheel_contents = {name: zf.read(name) for name in zf.namelist()}
+
+    _, _, sbom_json, _, _ = embed_wheel_sbom(
+        wheel_path,
+        project_dir=tmp_path,
+        overrides=ConfigOverrides(content_type=True),
+    )
+
+    doc = json.loads(sbom_json)
+    (main_pkg,) = [
+        n
+        for n in doc["@graph"]
+        if n.get("type") == "software_Package" and n.get("name") == "ctpkg"
+    ]
+    (verified,) = main_pkg["verifiedUsing"]
+
+    ordered_payloads = [p for _, p in sorted(wheel_contents.items())]
+    expected_root = _build_merkle_tree(
+        [hashlib.sha256(p).digest() for p in ordered_payloads]
+    )
+    assert verified["hashValue"] == expected_root
+
+    # Sanity check that this fixture actually exercises divergence: a root
+    # over the *rescanned* project_dir bytes (which differ only in
+    # ctpkg/__init__.py) must NOT equal the wheel-derived root above, or
+    # this test would pass even with the old, buggy code.
+    rescan_contents = dict(wheel_contents)
+    rescan_contents["ctpkg/__init__.py"] = b"x = 1\n"
+    rescan_root = _build_merkle_tree(
+        [hashlib.sha256(p).digest() for _, p in sorted(rescan_contents.items())]
+    )
+    assert rescan_root != expected_root
 
 
 def test_embed_wheel_scan_failure_keeps_wheel_files(

--- a/tests/assemble/test_embed_overrides.py
+++ b/tests/assemble/test_embed_overrides.py
@@ -13,10 +13,12 @@ See also:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sys
 import zipfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 from installer.sources import WheelFile
@@ -125,12 +127,10 @@ def test_apply_config_overrides_full() -> None:
 def test_embed_wheel_content_type_reaches_sbom_files(tmp_path: Path) -> None:
     """content-type detection must reach the Build SBOM's file list.
 
-    Regression test: ``_build_sbom_from_project_and_wheel`` used to build
-    the document from ``wheel_metadata`` (``read_wheel()``'s plain
-    hash-only file records), discarding the content-type data
-    ``get_wheel_files()`` had just computed -- so ``--content-type`` was
-    silently a no-op for ``loom embed-wheel``'s Build SBOM, even though
-    ``_apply_config_overrides`` correctly flipped the config flag.
+    ``_build_sbom_from_project_and_wheel`` merges ``get_wheel_files()``'s
+    content-type/file-header data onto ``wheel_metadata``'s file records
+    (see ``_merge_file_extras``); this guards against a regression where
+    that data is computed but never reaches the assembled SBOM.
     """
     (tmp_path / "pyproject.toml").write_text(
         """
@@ -161,6 +161,110 @@ packages = ["ctpkg"]
     assert any(f.get("contentType") for f in files), (
         "content-type override did not reach the SBOM's file list"
     )
+
+
+def _sbom_files_by_name(sbom_json: str) -> dict[str, dict[str, Any]]:
+    """Map ``name`` -> node for every file-kind ``software_File`` in *sbom_json*."""
+    doc = json.loads(sbom_json)
+    return {
+        n["name"]: n
+        for n in doc["@graph"]
+        if n.get("type") == "software_File" and n.get("software_fileKind") == "file"
+    }
+
+
+def test_embed_wheel_preserves_wheel_truth_and_merges_content_type(
+    tmp_path: Path,
+) -> None:
+    """Merging must keep the wheel's own file list and hashes intact.
+
+    ``_build_sbom_from_project_and_wheel`` must not replace
+    ``wheel_metadata.files`` outright with a project-dir rescan: that would
+    drop ``.dist-info/*`` entries and report hashes of the *current*
+    source tree instead of the wheel's own already-built bytes. This
+    checks both are preserved while content-type still reaches the
+    matching file (see ``_merge_file_extras``).
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "ctpkg"
+version = "1.0.0"
+
+[tool.hatch.build.targets.wheel]
+packages = ["ctpkg"]
+""",
+        encoding="utf-8",
+    )
+    pkg_dir = tmp_path / "ctpkg"
+    pkg_dir.mkdir()
+    # Deliberately differs from the wheel's own __init__.py (see
+    # _make_dummy_wheel) so a hash mix-up between "source on disk" and
+    # "bytes actually in the wheel" would be caught.
+    (pkg_dir / "__init__.py").write_text("x = 1\n", encoding="utf-8")
+
+    wheel_path = _make_dummy_wheel(tmp_path / "dist", "ctpkg", "1.0.0")
+
+    _, _, sbom_json, _, _ = embed_wheel_sbom(
+        wheel_path,
+        project_dir=tmp_path,
+        overrides=ConfigOverrides(content_type=True),
+    )
+
+    files_by_name = _sbom_files_by_name(sbom_json)
+    assert "ctpkg-1.0.0.dist-info/METADATA" in files_by_name
+    assert "ctpkg-1.0.0.dist-info/WHEEL" in files_by_name
+    assert "ctpkg-1.0.0.dist-info/RECORD" in files_by_name
+
+    init_file = files_by_name["ctpkg/__init__.py"]
+    (hash_obj,) = init_file["verifiedUsing"]
+    expected_digest = hashlib.sha256(b"__version__ = '1.0.0'\n").hexdigest()
+    assert hash_obj["hashValue"] == expected_digest
+    assert init_file.get("contentType")
+
+
+def test_embed_wheel_scan_failure_keeps_wheel_files(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A get_wheel_files() scan failure must not empty the SBOM's file list.
+
+    ``get_wheel_files()`` returns ``(None, [])`` on any scan failure; the
+    merge in ``_build_sbom_from_project_and_wheel`` must fall back to the
+    wheel's own files rather than propagating that empty result.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "ctpkg"
+version = "1.0.0"
+
+[tool.hatch.build.targets.wheel]
+packages = ["ctpkg"]
+""",
+        encoding="utf-8",
+    )
+    pkg_dir = tmp_path / "ctpkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("x = 1\n", encoding="utf-8")
+
+    wheel_path = _make_dummy_wheel(tmp_path / "dist", "ctpkg", "1.0.0")
+
+    monkeypatch.setattr("pitloom.embed.get_wheel_files", lambda *a, **k: (None, []))
+
+    _, _, sbom_json, _, _ = embed_wheel_sbom(
+        wheel_path,
+        project_dir=tmp_path,
+        overrides=ConfigOverrides(content_type=True),
+    )
+
+    files_by_name = _sbom_files_by_name(sbom_json)
+    assert files_by_name.keys() == {
+        "ctpkg/__init__.py",
+        "ctpkg-1.0.0.dist-info/METADATA",
+        "ctpkg-1.0.0.dist-info/WHEEL",
+        "ctpkg-1.0.0.dist-info/RECORD",
+    }
+    assert not files_by_name["ctpkg/__init__.py"].get("contentType")
 
 
 def test_build_sbom_standalone_wheel_registry_options(tmp_path: Path) -> None:

--- a/tests/assemble/test_embed_overrides.py
+++ b/tests/assemble/test_embed_overrides.py
@@ -13,6 +13,7 @@ See also:
 
 from __future__ import annotations
 
+import json
 import sys
 import zipfile
 from pathlib import Path
@@ -119,6 +120,47 @@ def test_apply_config_overrides_full() -> None:
             cfg,
             ConfigOverrides(content_type_method="invalid_method"),
         )
+
+
+def test_embed_wheel_content_type_reaches_sbom_files(tmp_path: Path) -> None:
+    """content-type detection must reach the Build SBOM's file list.
+
+    Regression test: ``_build_sbom_from_project_and_wheel`` used to build
+    the document from ``wheel_metadata`` (``read_wheel()``'s plain
+    hash-only file records), discarding the content-type data
+    ``get_wheel_files()`` had just computed -- so ``--content-type`` was
+    silently a no-op for ``loom embed-wheel``'s Build SBOM, even though
+    ``_apply_config_overrides`` correctly flipped the config flag.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "ctpkg"
+version = "1.0.0"
+
+[tool.hatch.build.targets.wheel]
+packages = ["ctpkg"]
+""",
+        encoding="utf-8",
+    )
+    pkg_dir = tmp_path / "ctpkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("x = 1\n", encoding="utf-8")
+
+    wheel_path = _make_dummy_wheel(tmp_path / "dist", "ctpkg", "1.0.0")
+
+    _, _, sbom_json, _, _ = embed_wheel_sbom(
+        wheel_path,
+        project_dir=tmp_path,
+        overrides=ConfigOverrides(content_type=True),
+    )
+
+    doc = json.loads(sbom_json)
+    files = [n for n in doc["@graph"] if n.get("type") == "software_File"]
+    assert files, "expected at least one software_File in the SBOM"
+    assert any(f.get("contentType") for f in files), (
+        "content-type override did not reach the SBOM's file list"
+    )
 
 
 def test_build_sbom_standalone_wheel_registry_options(tmp_path: Path) -> None:

--- a/tests/assemble/test_embed_overrides.py
+++ b/tests/assemble/test_embed_overrides.py
@@ -32,6 +32,7 @@ from pitloom.embed import (
     ConfigOverrides,
     _apply_config_overrides,
     _build_sbom_standalone_wheel,
+    _compute_wheel_merkle_root,
     embed_wheel_sbom,
 )
 from pitloom.ids import IdRegistry
@@ -222,6 +223,11 @@ packages = ["ctpkg"]
     expected_digest = hashlib.sha256(b"__version__ = '1.0.0'\n").hexdigest()
     assert hash_obj["hashValue"] == expected_digest
     assert init_file.get("contentType")
+
+
+def test_compute_wheel_merkle_root_empty_returns_none() -> None:
+    """No files means no Merkle root to assert, not a computed one over nothing."""
+    assert _compute_wheel_merkle_root([]) is None
 
 
 def test_embed_wheel_merkle_root_reflects_wheel_not_rescan(

--- a/working-docs/design/roadmap.md
+++ b/working-docs/design/roadmap.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-04-14
-Last-Modified: 2026-08-17
+Last-Modified: 2026-08-19
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -115,10 +115,41 @@ full picture.
 - [ ] **Setuptools wheel file discovery** -- use setuptools' own file inclusion
   logic to compute a Merkle root for setuptools projects (currently
   `get_wheel_files()` returns `None` for non-Hatchling projects).
+- [ ] **`get_wheel_files()` option to skip Merkle root computation** --
+  `_build_sbom_from_project_and_wheel` (`src/pitloom/embed.py`) already
+  discards `get_wheel_files()`'s own `merkle_root` return value in favor
+  of one computed from the wheel's own (post-merge) file hashes (see
+  `_compute_wheel_merkle_root`), so that work is wasted for its one
+  current caller. Worth adding only when both `extract_file_header` and
+  `content_type` are off too -- otherwise every file's bytes get read
+  off disk anyway for header/content-type scanning, and skipping just
+  the hash/tree-build step on top of bytes already in memory saves
+  little. With both scanners off, though, `get_wheel_files()` currently
+  reads every file's full bytes solely to hash them for the discarded
+  root -- real, avoidable I/O for large projects.
 - [ ] **Installed `.dist-info` / `.egg-info` as metadata source** -- treat
   an existing installed package as a high-fidelity source when present
   (editable installs, virtual environments).
   See [metadata-sources.md](metadata-sources.md).
+
+### PEP 770 / embed-wheel
+
+- [ ] **`loom embed-wheel --verify`** -- check that a wheel's embedded SBOM
+  is at the correct `.dist-info/sboms/<basename>` location and passes
+  schema/SHACL validation, as a single CLI command. Right now
+  `.github/workflows/pypi-publish.yml`'s "Check SBOM is at the PEP 770
+  location" step hand-rolls this in bash (`unzip -Z1` + a glob match)
+  against the same path convention `pitloom._embed_wheel._plan_embed`
+  already encodes in Python, plus a separate `spdx3-validate` call -- two
+  independently-maintained representations of one convention that could
+  drift if `_plan_embed`'s layout ever changes. A `--verify` flag would
+  consolidate both checks into the tool itself, reusable by any CI
+  pipeline (not just this repo's own release workflow) without
+  reimplementing the path convention.
+  Since `spdx3-validate` 0.0.7, it's usable as a Python library, not just
+  a CLI (see [using-as-a-library](https://github.com/JPEWdev/spdx3-validate#using-as-a-library)) --
+  `--verify` could call it in-process instead of shelling out, avoiding a
+  second subprocess/dependency-install step in CI.
 
 ### Extractors
 


### PR DESCRIPTION
## Summary

- `loom embed-wheel` silently dropped content-type and file-header detection from Build SBOMs (built file list from plain hash-only wheel records, not the enriched scan)
- Fix merkel root overwrite
- Fix mirrors the Hatchling hook's existing correct behavior
- Adds regression test
- Dogfood - Enables `content-type` on the PyPI release workflow's Action step now that it actually works

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
