### PR TITLE
Fix review findings: preserve wheel truth, decouple release upload, avoid mutation

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -14,7 +14,9 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # gh release upload, for the standalone SBOM asset
+      contents: read
+    outputs:
+      sbom-path: ${{ steps.pitloom.outputs.sbom-path }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -58,17 +60,6 @@ jobs:
           upload-artifact: "true"
           artifact-name: "sbom"
 
-      - name: Attach SBOM to GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          SBOM_PATH: ${{ steps.pitloom.outputs.sbom-path }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          gh release upload "${RELEASE_TAG}" "${SBOM_PATH}" \
-            --clobber --repo "${REPO}"
-
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -92,3 +83,31 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
+
+  attach-release-sbom:
+    name: Attach SBOM to GitHub Release
+    needs: build
+    # Runs independently of "publish": the release asset is a nice-to-have,
+    # so a failure/skip here must never block the actual PyPI publish.
+    if: needs.build.outputs.sbom-path != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # gh release upload, for the standalone SBOM asset
+
+    steps:
+      - name: Download SBOM artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: sbom
+          path: sbom/
+
+      - name: Attach SBOM to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          SBOM_BASENAME: ${{ needs.build.outputs.sbom-path }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh release upload "${RELEASE_TAG}" "sbom/${SBOM_BASENAME}" \
+            --clobber --repo "${REPO}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to
   print `PITLOOM_SBOM_OUTPUT_PATH=<path>` to stdout after writing an SBOM,
   letting callers (e.g. the GitHub Action) discover the resolved output
   path without re-deriving the default-naming logic themselves ([#171])
+- The PyPI release workflow attaches the standalone SBOM as a GitHub
+  Release asset, generated via the project's own GitHub Action ([#172],
+  [#174])
 
 ### Fixed
 
@@ -34,8 +37,16 @@ and this project adheres to
   filename when `output` is left unset; it now defers to `loom`'s own
   default-naming logic (`packagename-version.spdx3.json`, falling back to
   `packagename.spdx3.json`, then `sbom.spdx3.json` as a last resort) ([#171])
+- `loom embed-wheel`'s Build SBOM now includes content-type and
+  file-header data for each file (previously silently dropped even with
+  `--content-type`/`--extract-file-header` enabled), while still
+  preserving the wheel's own file records -- hashes of the actually-built
+  wheel's bytes, `.dist-info/*` entries, and any build-hook-injected files
+  that a project-directory rescan alone can't see ([#172], [#174])
 
 [#171]: https://github.com/bact/pitloom/pull/171
+[#172]: https://github.com/bact/pitloom/pull/172
+[#174]: https://github.com/bact/pitloom/pull/174
 
 ## [0.16.1] - 2026-08-18
 

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -128,7 +128,10 @@ def _build_sbom_from_project_and_wheel(
     # extensions, auditwheel-repaired shared libraries) that read_wheel()
     # found in the actual wheel but that a source-tree rescan can't see.
     merged_files = _merge_file_extras(wheel_metadata.files, project_files)
-    wheel_metadata.files = merged_files
+    # dataclasses.replace, not an in-place `.files =` assignment, so the
+    # caller's wheel_metadata (e.g. embed_wheel_sbom's read_wheel() result)
+    # isn't silently mutated as a side effect of building this SBOM.
+    project_metadata = dataclasses.replace(wheel_metadata, files=merged_files)
     ai_models = scan_project_for_ai_models(project_dir, project_files)
     phantom_deps = find_phantom_dependencies(merged_files)
     enrichment_results = run_enrichers_for_models(
@@ -136,7 +139,7 @@ def _build_sbom_from_project_and_wheel(
     )
 
     doc = DocumentModel(
-        project=wheel_metadata,
+        project=project_metadata,
         creation_metadata=creation_metadata or CreationMetadata(),
         ai_models=ai_models,
         phantom_dependencies=phantom_deps,

--- a/src/pitloom/embed.py
+++ b/src/pitloom/embed.py
@@ -38,7 +38,7 @@ from pitloom.core.config import VALID_CONTENT_TYPE_METHODS, PitloomConfig
 from pitloom.core.creation import CreationMetadata
 from pitloom.core.document import DocumentModel
 from pitloom.core.models import get_wheel_files
-from pitloom.core.project import ProjectMetadata
+from pitloom.core.project import ProjectFile, ProjectMetadata
 from pitloom.core.provenance import ProvenanceConfig
 from pitloom.enrich import run_enrichers_for_models
 from pitloom.extract.binary import find_phantom_dependencies
@@ -71,6 +71,42 @@ __all__ = [
 ]
 
 
+def _merge_file_extras(
+    wheel_files: list[ProjectFile], project_files: list[ProjectFile]
+) -> list[ProjectFile]:
+    """Layer re-scanned content-type/header data onto the wheel's own files.
+
+    ``wheel_files`` (from :func:`pitloom.extract.wheel.read_wheel`) is the
+    source of truth for what the already-built wheel actually contains --
+    including ``.dist-info/*`` entries and any build-hook-injected files
+    that never existed in ``project_dir`` -- so it is kept intact,
+    including its hashes computed from the wheel's own bytes.
+    ``project_files`` (from :func:`~pitloom.core.models.get_wheel_files`)
+    only supplies the content-type/file-header extras it computed by
+    re-scanning the sources, adopted for files present in both lists.
+    """
+    extras_by_path = {f.distribution_path: f for f in project_files}
+    merged: list[ProjectFile] = []
+    for wheel_file in wheel_files:
+        extra = extras_by_path.get(wheel_file.distribution_path)
+        if extra is None:
+            merged.append(wheel_file)
+            continue
+        merged.append(
+            dataclasses.replace(
+                wheel_file,
+                copyright_text=extra.copyright_text,
+                copyright_source=extra.copyright_source,
+                file_contributors=extra.file_contributors,
+                file_type=extra.file_type,
+                spdx_license_identifier=extra.spdx_license_identifier,
+                content_type=extra.content_type,
+                content_type_method=extra.content_type_method,
+            )
+        )
+    return merged
+
+
 def _build_sbom_from_project_and_wheel(
     project_dir: Path,
     wheel_metadata: ProjectMetadata,
@@ -86,13 +122,15 @@ def _build_sbom_from_project_and_wheel(
         content_type_method=pitloom_config.content_type.method,
         content_type_overrides=pitloom_config.content_type.overrides,
     )
-    # Without this, the SBOM's file list comes from wheel_metadata.files
-    # (read_wheel()'s plain content-hash-only entries), silently dropping
-    # the content-type/file-header data get_wheel_files() just computed
-    # -- mirrors pitloom.plugins.hatch._build_document_model.
-    wheel_metadata.files = project_files
+    # Layer content-type/file-header extras onto the wheel's own file
+    # records rather than replacing them outright: replacing would drop
+    # .dist-info entries and any build-hook-injected files (e.g. compiled
+    # extensions, auditwheel-repaired shared libraries) that read_wheel()
+    # found in the actual wheel but that a source-tree rescan can't see.
+    merged_files = _merge_file_extras(wheel_metadata.files, project_files)
+    wheel_metadata.files = merged_files
     ai_models = scan_project_for_ai_models(project_dir, project_files)
-    phantom_deps = find_phantom_dependencies(wheel_metadata.files)
+    phantom_deps = find_phantom_dependencies(merged_files)
     enrichment_results = run_enrichers_for_models(
         ai_models, pitloom_config.enrich, project_dir
     )

--- a/tests/assemble/test_embed_overrides.py
+++ b/tests/assemble/test_embed_overrides.py
@@ -13,10 +13,12 @@ See also:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sys
 import zipfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 from installer.sources import WheelFile
@@ -125,12 +127,10 @@ def test_apply_config_overrides_full() -> None:
 def test_embed_wheel_content_type_reaches_sbom_files(tmp_path: Path) -> None:
     """content-type detection must reach the Build SBOM's file list.
 
-    Regression test: ``_build_sbom_from_project_and_wheel`` used to build
-    the document from ``wheel_metadata`` (``read_wheel()``'s plain
-    hash-only file records), discarding the content-type data
-    ``get_wheel_files()`` had just computed -- so ``--content-type`` was
-    silently a no-op for ``loom embed-wheel``'s Build SBOM, even though
-    ``_apply_config_overrides`` correctly flipped the config flag.
+    ``_build_sbom_from_project_and_wheel`` merges ``get_wheel_files()``'s
+    content-type/file-header data onto ``wheel_metadata``'s file records
+    (see ``_merge_file_extras``); this guards against a regression where
+    that data is computed but never reaches the assembled SBOM.
     """
     (tmp_path / "pyproject.toml").write_text(
         """
@@ -161,6 +161,110 @@ packages = ["ctpkg"]
     assert any(f.get("contentType") for f in files), (
         "content-type override did not reach the SBOM's file list"
     )
+
+
+def _sbom_files_by_name(sbom_json: str) -> dict[str, dict[str, Any]]:
+    """Map ``name`` -> node for every file-kind ``software_File`` in *sbom_json*."""
+    doc = json.loads(sbom_json)
+    return {
+        n["name"]: n
+        for n in doc["@graph"]
+        if n.get("type") == "software_File" and n.get("software_fileKind") == "file"
+    }
+
+
+def test_embed_wheel_preserves_wheel_truth_and_merges_content_type(
+    tmp_path: Path,
+) -> None:
+    """Merging must keep the wheel's own file list and hashes intact.
+
+    ``_build_sbom_from_project_and_wheel`` must not replace
+    ``wheel_metadata.files`` outright with a project-dir rescan: that would
+    drop ``.dist-info/*`` entries and report hashes of the *current*
+    source tree instead of the wheel's own already-built bytes. This
+    checks both are preserved while content-type still reaches the
+    matching file (see ``_merge_file_extras``).
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "ctpkg"
+version = "1.0.0"
+
+[tool.hatch.build.targets.wheel]
+packages = ["ctpkg"]
+""",
+        encoding="utf-8",
+    )
+    pkg_dir = tmp_path / "ctpkg"
+    pkg_dir.mkdir()
+    # Deliberately differs from the wheel's own __init__.py (see
+    # _make_dummy_wheel) so a hash mix-up between "source on disk" and
+    # "bytes actually in the wheel" would be caught.
+    (pkg_dir / "__init__.py").write_text("x = 1\n", encoding="utf-8")
+
+    wheel_path = _make_dummy_wheel(tmp_path / "dist", "ctpkg", "1.0.0")
+
+    _, _, sbom_json, _, _ = embed_wheel_sbom(
+        wheel_path,
+        project_dir=tmp_path,
+        overrides=ConfigOverrides(content_type=True),
+    )
+
+    files_by_name = _sbom_files_by_name(sbom_json)
+    assert "ctpkg-1.0.0.dist-info/METADATA" in files_by_name
+    assert "ctpkg-1.0.0.dist-info/WHEEL" in files_by_name
+    assert "ctpkg-1.0.0.dist-info/RECORD" in files_by_name
+
+    init_file = files_by_name["ctpkg/__init__.py"]
+    (hash_obj,) = init_file["verifiedUsing"]
+    expected_digest = hashlib.sha256(b"__version__ = '1.0.0'\n").hexdigest()
+    assert hash_obj["hashValue"] == expected_digest
+    assert init_file.get("contentType")
+
+
+def test_embed_wheel_scan_failure_keeps_wheel_files(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A get_wheel_files() scan failure must not empty the SBOM's file list.
+
+    ``get_wheel_files()`` returns ``(None, [])`` on any scan failure; the
+    merge in ``_build_sbom_from_project_and_wheel`` must fall back to the
+    wheel's own files rather than propagating that empty result.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "ctpkg"
+version = "1.0.0"
+
+[tool.hatch.build.targets.wheel]
+packages = ["ctpkg"]
+""",
+        encoding="utf-8",
+    )
+    pkg_dir = tmp_path / "ctpkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("x = 1\n", encoding="utf-8")
+
+    wheel_path = _make_dummy_wheel(tmp_path / "dist", "ctpkg", "1.0.0")
+
+    monkeypatch.setattr("pitloom.embed.get_wheel_files", lambda *a, **k: (None, []))
+
+    _, _, sbom_json, _, _ = embed_wheel_sbom(
+        wheel_path,
+        project_dir=tmp_path,
+        overrides=ConfigOverrides(content_type=True),
+    )
+
+    files_by_name = _sbom_files_by_name(sbom_json)
+    assert files_by_name.keys() == {
+        "ctpkg/__init__.py",
+        "ctpkg-1.0.0.dist-info/METADATA",
+        "ctpkg-1.0.0.dist-info/WHEEL",
+        "ctpkg-1.0.0.dist-info/RECORD",
+    }
+    assert not files_by_name["ctpkg/__init__.py"].get("contentType")
 
 
 def test_build_sbom_standalone_wheel_registry_options(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Follow-up fixes found during independent code review of #172, targeting that PR's branch rather than `main` since these are fixes on top of its unmerged changes.

- `src/pitloom/embed.py`: `_build_sbom_from_project_and_wheel` was overwriting `wheel_metadata.files` outright with a project-dir rescan (`get_wheel_files()`), discarding `read_wheel()`'s real wheel-archive file records -- silently dropping `.dist-info/*` entries and any build-hook-injected files (compiled extensions, `auditwheel`/`delocate`-repaired shared libraries), and reporting hashes of the *current* source tree instead of the wheel's own already-built bytes. Replaced with a new `_merge_file_extras()` helper: the wheel's own file records stay the source of truth, and only the content-type/file-header extras the rescan computed are layered onto matching entries. This also means a `get_wheel_files()` scan failure no longer empties the SBOM's file list, since the wheel's own records are the base rather than the (possibly empty) rescan result.
- Independent re-review flagged that the fix above mutated the caller-supplied `wheel_metadata` object in place with no signal of that in the function's signature. Changed to build a new `ProjectMetadata` via `dataclasses.replace()` instead -- no behavior change today, but removes the footgun for future callers.
- `.github/workflows/pypi-publish.yml`: moved "Attach SBOM to GitHub Release" into its own `attach-release-sbom` job that runs independently of `publish` and is skipped (not failed) via a job-level `if` when no `sbom-path` was produced, instead of failing the release-asset call with an empty path from inside the same job PyPI publishing depends on. `contents: write` is now scoped to that job alone rather than the whole `build` job.
- `tests/assemble/test_embed_overrides.py`: reworded the existing regression test's docstring to describe current behavior instead of narrating removed code, and added two more regression tests covering dist-info/hash preservation and the scan-failure fallback.

Verified: full test suite passes (825 passed; only 3 pre-existing sandbox-network failures unrelated to this change, confirmed identical on unmodified `publish-with-action`), `ruff format`/`ruff check`/`mypy`/`pylint` all clean on changed files. Also independently re-verified Action/CLI/API parity and CLI-flag/pyproject.toml precedence are unaffected by this change.

## Related issue

Follow-up to #172

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass (`ruff check src/ tests/`, `pylint src/ tests`, `mypy` on changed files)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XXUL9g9ufDKCBMhhQZNQh2)_