### PR TITLE
Add version-independent tests for tomllib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,10 @@ and this project adheres to
 
 ## Fixed
 
-- Test coverage near 100% ([#176])
+- Test coverage near 100% ([#176], [#177])
 
 [#176]: https://github.com/bact/pitloom/pull/176
+[#177]: https://github.com/bact/pitloom/pull/177
 
 ## [0.16.2] - 2026-08-19
 

--- a/tests/cli/test_cli_options.py
+++ b/tests/cli/test_cli_options.py
@@ -323,6 +323,25 @@ def test_read_pitloom_tool_stdlib_tomllib_branch(
     assert _load_pitloom_tool_section(p) == {"pretty": True}
 
 
+def test_read_pitloom_tool_tomli_backport_branch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """On a Python < 3.11 interpreter, the ``tomli`` backport is imported
+    instead of stdlib ``tomllib`` -- the mirror-image branch of the test
+    above, needed so this stays covered regardless of which Python version
+    CI happens to collect coverage on (this repo's CI matrix runs both
+    3.10 and 3.14). ``_load_pitloom_tool_section`` imports fresh on every
+    call (no module-level import to reload), so faking
+    ``sys.version_info`` alone is enough."""
+    from pitloom.cli.options import _load_pitloom_tool_section
+
+    monkeypatch.setattr(sys, "version_info", (3, 10, 0, "final", 0))
+
+    p = tmp_path / "pyproject.toml"
+    p.write_text("[tool.pitloom]\npretty = true\n")
+    assert _load_pitloom_tool_section(p) == {"pretty": True}
+
+
 def test_resolve_describe_relationship_and_pretty() -> None:
     import argparse
 

--- a/tests/extract/test_hatchling_tomllib.py
+++ b/tests/extract/test_hatchling_tomllib.py
@@ -1,0 +1,43 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Python-version-gated ``tomllib``/``tomli`` import in
+``pitloom.extract.hatchling``.
+
+See also: :mod:`tests.extract.test_hatch_hook_metadata` for the rest of
+``metadata_from_hatchling()`` parsing, and :mod:`tests.tomllib_fixtures`
+for the shared version-forcing helpers used here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import pitloom.extract.hatchling as hatchling_module
+from tests.tomllib_fixtures import force_tomli_branch, force_tomllib_branch
+
+
+def test_hatchling_uses_stdlib_tomllib_on_py311_plus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a Python >= 3.11 interpreter, ``pitloom.extract.hatchling``
+    imports the stdlib ``tomllib`` at module load time instead of the
+    ``tomli`` backport."""
+    with force_tomllib_branch(monkeypatch, hatchling_module):
+        tomllib_mod: object = hatchling_module.tomllib  # type: ignore[attr-defined]
+        assert tomllib_mod.__name__ == "tomllib"  # type: ignore[attr-defined]
+
+
+def test_hatchling_uses_tomli_backport_below_py311(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a Python < 3.11 interpreter, ``pitloom.extract.hatchling``
+    imports the ``tomli`` backport instead of stdlib ``tomllib`` -- the
+    mirror-image branch of the test above, needed so this stays covered
+    regardless of which Python version CI happens to collect coverage on
+    (this repo's CI matrix runs both 3.10 and 3.14)."""
+    with force_tomli_branch(monkeypatch, hatchling_module):
+        tomllib_mod: object = hatchling_module.tomllib  # type: ignore[attr-defined]
+        assert tomllib_mod.__name__ == "tomli"  # type: ignore[attr-defined]

--- a/tests/extract/test_poetry_tomllib.py
+++ b/tests/extract/test_poetry_tomllib.py
@@ -1,0 +1,44 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Python-version-gated ``tomllib``/``tomli`` import in
+``pitloom.extract._poetry``.
+
+See also: :mod:`tests.extract.test_poetry_parsing` and
+:mod:`tests.extract.test_poetry_pyproject` for the rest of ``[tool.poetry]``
+parsing, and :mod:`tests.tomllib_fixtures` for the shared version-forcing
+helpers used here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import pitloom.extract._poetry as poetry_module
+from tests.tomllib_fixtures import force_tomli_branch, force_tomllib_branch
+
+
+def test_poetry_uses_stdlib_tomllib_on_py311_plus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a Python >= 3.11 interpreter, ``pitloom.extract._poetry``
+    imports the stdlib ``tomllib`` at module load time instead of the
+    ``tomli`` backport."""
+    with force_tomllib_branch(monkeypatch, poetry_module):
+        tomllib_mod: object = poetry_module.tomllib  # type: ignore[attr-defined]
+        assert tomllib_mod.__name__ == "tomllib"  # type: ignore[attr-defined]
+
+
+def test_poetry_uses_tomli_backport_below_py311(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a Python < 3.11 interpreter, ``pitloom.extract._poetry``
+    imports the ``tomli`` backport instead of stdlib ``tomllib`` -- the
+    mirror-image branch of the test above, needed so this stays covered
+    regardless of which Python version CI happens to collect coverage on
+    (this repo's CI matrix runs both 3.10 and 3.14)."""
+    with force_tomli_branch(monkeypatch, poetry_module):
+        tomllib_mod: object = poetry_module.tomllib  # type: ignore[attr-defined]
+        assert tomllib_mod.__name__ == "tomli"  # type: ignore[attr-defined]

--- a/tests/extract/test_pyproject_tomllib.py
+++ b/tests/extract/test_pyproject_tomllib.py
@@ -1,0 +1,43 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Python-version-gated ``tomllib``/``tomli`` import in
+``pitloom.extract._pyproject``.
+
+See also: :mod:`tests.extract.test_pyproject` for the rest of
+``read_pyproject()`` parsing, and :mod:`tests.tomllib_fixtures` for the
+shared version-forcing helpers used here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import pitloom.extract._pyproject as pyproject_module
+from tests.tomllib_fixtures import force_tomli_branch, force_tomllib_branch
+
+
+def test_pyproject_uses_stdlib_tomllib_on_py311_plus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a Python >= 3.11 interpreter, ``pitloom.extract._pyproject``
+    imports the stdlib ``tomllib`` at module load time instead of the
+    ``tomli`` backport."""
+    with force_tomllib_branch(monkeypatch, pyproject_module):
+        tomllib_mod: object = pyproject_module.tomllib  # type: ignore[attr-defined]
+        assert tomllib_mod.__name__ == "tomllib"  # type: ignore[attr-defined]
+
+
+def test_pyproject_uses_tomli_backport_below_py311(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a Python < 3.11 interpreter, ``pitloom.extract._pyproject``
+    imports the ``tomli`` backport instead of stdlib ``tomllib`` -- the
+    mirror-image branch of the test above, needed so this stays covered
+    regardless of which Python version CI happens to collect coverage on
+    (this repo's CI matrix runs both 3.10 and 3.14)."""
+    with force_tomli_branch(monkeypatch, pyproject_module):
+        tomllib_mod: object = pyproject_module.tomllib  # type: ignore[attr-defined]
+        assert tomllib_mod.__name__ == "tomli"  # type: ignore[attr-defined]

--- a/tests/extract/test_sdist_tomllib.py
+++ b/tests/extract/test_sdist_tomllib.py
@@ -4,38 +4,38 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the Python-version-gated ``tomllib``/``tomli`` import in
-``pitloom.core._config_parse``.
+``pitloom.extract._sdist``.
 
-See also: :mod:`tests.core.test_config` for the rest of
-``[tool.pitloom]`` parsing, and :mod:`tests.tomllib_fixtures` for the
-shared version-forcing helpers used here.
+See also: :mod:`tests.extract.test_sdist` for the rest of sdist archive
+metadata extraction, and :mod:`tests.tomllib_fixtures` for the shared
+version-forcing helpers used here.
 """
 
 from __future__ import annotations
 
 import pytest
 
-import pitloom.core._config_parse as config_parse
+import pitloom.extract._sdist as sdist_module
 from tests.tomllib_fixtures import force_tomli_branch, force_tomllib_branch
 
 
-def test_config_parse_uses_stdlib_tomllib_on_py311_plus(
+def test_sdist_uses_stdlib_tomllib_on_py311_plus(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """On a Python >= 3.11 interpreter, ``pitloom.core._config_parse``
+    """On a Python >= 3.11 interpreter, ``pitloom.extract._sdist``
     imports the stdlib ``tomllib`` at module load time instead of the
     ``tomli`` backport."""
-    with force_tomllib_branch(monkeypatch, config_parse):
-        assert config_parse.tomllib.__name__ == "tomllib"  # type: ignore[attr-defined]
+    with force_tomllib_branch(monkeypatch, sdist_module):
+        assert sdist_module.tomllib.__name__ == "tomllib"  # type: ignore[attr-defined]
 
 
-def test_config_parse_uses_tomli_backport_below_py311(
+def test_sdist_uses_tomli_backport_below_py311(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """On a Python < 3.11 interpreter, ``pitloom.core._config_parse``
+    """On a Python < 3.11 interpreter, ``pitloom.extract._sdist``
     imports the ``tomli`` backport instead of stdlib ``tomllib`` -- the
     mirror-image branch of the test above, needed so this stays covered
     regardless of which Python version CI happens to collect coverage on
     (this repo's CI matrix runs both 3.10 and 3.14)."""
-    with force_tomli_branch(monkeypatch, config_parse):
-        assert config_parse.tomllib.__name__ == "tomli"  # type: ignore[attr-defined]
+    with force_tomli_branch(monkeypatch, sdist_module):
+        assert sdist_module.tomllib.__name__ == "tomli"  # type: ignore[attr-defined]

--- a/tests/extract/test_setuptools_tomllib.py
+++ b/tests/extract/test_setuptools_tomllib.py
@@ -1,0 +1,43 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Python-version-gated ``tomllib``/``tomli`` import in
+``pitloom.extract._setuptools``.
+
+See also: :mod:`tests.extract.test_setuptools_integration` for the rest of
+``read_setuptools()`` parsing, and :mod:`tests.tomllib_fixtures` for the
+shared version-forcing helpers used here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import pitloom.extract._setuptools as setuptools_module
+from tests.tomllib_fixtures import force_tomli_branch, force_tomllib_branch
+
+
+def test_setuptools_uses_stdlib_tomllib_on_py311_plus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a Python >= 3.11 interpreter, ``pitloom.extract._setuptools``
+    imports the stdlib ``tomllib`` at module load time instead of the
+    ``tomli`` backport."""
+    with force_tomllib_branch(monkeypatch, setuptools_module):
+        tomllib_mod: object = setuptools_module.tomllib  # type: ignore[attr-defined]
+        assert tomllib_mod.__name__ == "tomllib"  # type: ignore[attr-defined]
+
+
+def test_setuptools_uses_tomli_backport_below_py311(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a Python < 3.11 interpreter, ``pitloom.extract._setuptools``
+    imports the ``tomli`` backport instead of stdlib ``tomllib`` -- the
+    mirror-image branch of the test above, needed so this stays covered
+    regardless of which Python version CI happens to collect coverage on
+    (this repo's CI matrix runs both 3.10 and 3.14)."""
+    with force_tomli_branch(monkeypatch, setuptools_module):
+        tomllib_mod: object = setuptools_module.tomllib  # type: ignore[attr-defined]
+        assert tomllib_mod.__name__ == "tomli"  # type: ignore[attr-defined]

--- a/tests/tomllib_fixtures.py
+++ b/tests/tomllib_fixtures.py
@@ -1,0 +1,80 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for exercising the ``sys.version_info``-gated
+``tomllib``/``tomli`` import branch present in each of Pitloom's TOML-reading
+modules, regardless of which Python version pytest actually runs under.
+
+Every module of the form::
+
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:
+        import tomli as tomllib
+
+needs BOTH branches covered for the coverage floor to hold on every CI leg:
+this repo's CI test matrix runs coverage collection on Python 3.14 (stdlib
+``tomllib`` naturally taken there) but also runs the full suite on 3.10
+(``tomli`` backport naturally taken there) -- whichever branch the *real*
+interpreter doesn't take has to be forced via ``sys.version_info`` faking
+plus a module reload.
+
+``tomli`` is always genuinely importable here regardless of interpreter
+version: it's pulled in transitively via Pitloom's own ``pipdeptree``
+dependency (which requires it unconditionally, not just for <3.11), so
+forcing the ``tomli`` branch never needs a fake stand-in module -- only
+forcing the ``tomllib`` branch does, since real stdlib ``tomllib`` doesn't
+exist before 3.11.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import ModuleType
+
+import pytest
+import tomli
+
+
+@contextmanager
+def force_tomllib_branch(
+    monkeypatch: pytest.MonkeyPatch, module: ModuleType
+) -> Iterator[None]:
+    """Force *module* to take its ``import tomllib`` (stdlib) branch: fake
+    ``sys.version_info >= (3, 11)`` and a ``tomllib`` sys.modules entry
+    (backed by the real ``tomli`` parser), then reload *module*. Restores
+    *module* to its real, unpatched state on exit."""
+    fake_tomllib = types.ModuleType("tomllib")
+    fake_tomllib.load = tomli.load  # type: ignore[attr-defined]
+    fake_tomllib.loads = tomli.loads  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tomllib", fake_tomllib)
+    monkeypatch.setattr(sys, "version_info", (3, 11, 0, "final", 0))
+    try:
+        importlib.reload(module)
+        yield
+    finally:
+        monkeypatch.undo()
+        importlib.reload(module)
+
+
+@contextmanager
+def force_tomli_branch(
+    monkeypatch: pytest.MonkeyPatch, module: ModuleType
+) -> Iterator[None]:
+    """Force *module* to take its ``import tomli as tomllib`` (backport)
+    branch: fake ``sys.version_info < (3, 11)``, then reload *module* (the
+    real ``tomli`` package is always importable here -- see module
+    docstring). Restores *module* to its real, unpatched state on exit."""
+    monkeypatch.setattr(sys, "version_info", (3, 10, 0, "final", 0))
+    try:
+        importlib.reload(module)
+        yield
+    finally:
+        monkeypatch.undo()
+        importlib.reload(module)


### PR DESCRIPTION
## Summary

Test tomllib backport branch

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
