### PR TITLE
Add sigstore and provenance attestation

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -122,14 +122,18 @@ jobs:
 
   attach-release-sbom:
     name: Attach SBOM to GitHub Release
-    needs: build
-    # A custom "if:" replaces needs:'s implicit success() gate, so both
+    needs: [build, publish]
+    # A custom "if:" replaces needs:'s implicit success() gate, so all
     # conditions are explicit here:
-    # - result == 'success': skip if "Validate SBOM" failed in "build".
+    # - build.result == 'success': skip if "Validate SBOM" failed in "build".
+    # - publish.result == 'success': skip if PyPI publish failed, so the
+    #   release never carries an SBOM for a package that wasn't published.
     # - sbom-path != '': skip if "build" produced no standalone SBOM
     #   (embed-wheel matched more than one wheel), since no "sbom"
     #   artifact was uploaded for this job to download.
-    if: needs.build.result == 'success' && needs.build.outputs.sbom-path != ''
+    if: |
+      needs.build.result == 'success' && needs.publish.result == 'success' &&
+      needs.build.outputs.sbom-path != ''
     runs-on: ubuntu-latest
     permissions:
       contents: write  # gh release upload, for the standalone SBOM asset
@@ -150,4 +154,73 @@ jobs:
         run: |
           set -euo pipefail
           gh release upload "${RELEASE_TAG}" "sbom/${SBOM_BASENAME}" \
+            --clobber --repo "${REPO}"
+
+  attach-release-dist:
+    name: Attach distribution to GitHub Release
+    needs: [build, publish]
+    # Only attach once PyPI publish has actually succeeded, so the release
+    # page never carries artifacts that weren't published (or were
+    # published as something different, if a later step were to fail).
+    if: needs.build.result == 'success' && needs.publish.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # gh release upload, for the sdist/wheel assets
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Attach sdist and wheel to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh release upload "${RELEASE_TAG}" dist/*.whl dist/*.tar.gz \
+            --clobber --repo "${REPO}"
+
+  sign-and-attest:
+    name: Sign artifacts and attach provenance
+    needs: [build, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write       # gh release upload, for signature/attestation assets
+      id-token: write       # Sigstore keyless signing + attestation signing
+      attestations: write   # actions/attest-build-provenance
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Sign artifacts with Sigstore
+        uses: sigstore/gh-action-sigstore-python@f7ad0af51a5648d09a20d00370f0a91c3bdf8f84  # v3.0.1
+        with:
+          inputs: dist/*.whl dist/*.tar.gz
+          # Default is "true" and, on a release-triggered run, additionally
+          # downloads and signs GitHub's auto-generated source zip/tar.gz
+          # archives -- unwanted here, and a hard failure (unhandled
+          # requests.raise_for_status()) if that download ever 404s/429s.
+          release-signing-artifacts: "false"
+
+      - name: Generate build provenance attestation
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a  # v3.0.0
+        with:
+          subject-path: "dist/*.whl, dist/*.tar.gz"
+
+      - name: Attach signatures and provenance to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh release upload "${RELEASE_TAG}" dist/*.sigstore.json \
             --clobber --repo "${REPO}"


### PR DESCRIPTION
## Summary

Add sigstore and provenance attestation to GitHub Releases artifact

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
