### PR TITLE
Deduplicated dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to
 - Full release notes: <https://github.com/bact/pitloom/releases>
 - Commit history: <https://github.com/bact/pitloom/compare/v0.16.2...v0.16.3>
 
+## [Unreleased]
+
+### Fixed
+
+- Deduplicate dependencies ([#184])
+
+[#184]:  https://github.com/bact/pitloom/pull/184
+
 ## [0.16.3] - 2026-08-21
 
 ### Added

--- a/src/pitloom/assemble/spdx3/deps.py
+++ b/src/pitloom/assemble/spdx3/deps.py
@@ -225,7 +225,14 @@ def add_dependencies(
     content_type_method: str = "auto",
 ) -> None:
     """Build SPDX ``software_Package`` and ``Relationship`` elements for
-    dependencies."""
+    dependencies.
+
+    Multiple declared dependency strings that resolve to the same
+    ``(name, version)`` -- e.g. the same package listed under more than one
+    ``pyproject.toml`` extra, each split by a ``python_version`` marker --
+    collapse into a single ``software_Package`` node. Their raw declared
+    strings are preserved together in that node's provenance comment.
+    """
     resolved = []
     for dep in dependencies:
         dep_name = _parse_dep_name(dep)
@@ -239,10 +246,16 @@ def add_dependencies(
         )
     )
 
+    grouped: dict[tuple[str, str], list[tuple[str, str | None]]] = {}
     for dep, dep_name, dep_version, version_note in resolved:
+        grouped.setdefault((dep_name, dep_version), []).append((dep, version_note))
+
+    for (dep_name, dep_version), declared in grouped.items():
+        declared_constraints = [dep for dep, _note in declared]
+        version_note = next((note for _dep, note in declared if note), None)
         dep_provenance_fields: dict[str, str] = {
             "dependencies": dep_provenance,
-            "declared_constraint": dep,
+            "declared_constraint": " | ".join(declared_constraints),
         }
         if version_note:
             dep_provenance_fields["version"] = version_note

--- a/tests/assemble/test_deps_enrichment_names_versions.py
+++ b/tests/assemble/test_deps_enrichment_names_versions.py
@@ -190,6 +190,65 @@ def test_add_dependencies_sets_name_only_purl_for_unresolved_version(
     assert dep.software_packageVersion == "unknown"
 
 
+def test_add_dependencies_dedupes_same_resolved_name_and_version() -> None:
+    """Regression: a package declared under more than one
+    ``pyproject.toml`` extra, each split by a ``python_version`` marker
+    (e.g. Pitloom's own ``numpy`` under both the ``ai`` and ``numpy``
+    extras), used to produce one ``software_Package`` node per raw
+    declared string even though they all resolve to the same pinned
+    ``(name, version)`` -- duplicate nodes in the emitted SBOM. Declared
+    strings that resolve to the same ``(name, version)`` must collapse
+    into a single node, with every raw string preserved in its
+    provenance comment."""
+    doc_uuid = compute_doc_uuid("deduptest", "1.0", [])
+    _clear_doc_counters(doc_uuid)
+    exporter = Spdx3JsonExporter()
+    ci = _make_ci()
+    main_pkg = spdx3.software_Package(
+        spdxId=generate_spdx_id("Package", doc_name="deduptest", doc_uuid=doc_uuid),
+        name="deduptest",
+        creationInfo=ci,
+    )
+    exporter.add_package(main_pkg)
+
+    add_dependencies(
+        [
+            "numpy==2.5.2; python_version<'3.11' and extra == 'ai'",
+            "numpy==2.5.2; python_version>='3.11' and extra == 'ai'",
+            "numpy==2.5.2; python_version<'3.11' and extra == 'numpy'",
+            "numpy==2.5.2; python_version>='3.11' and extra == 'numpy'",
+        ],
+        "Source: pyproject.toml | Field: project.optional-dependencies",
+        require_spdx_id(main_pkg),
+        ci,
+        "deduptest",
+        doc_uuid,
+        exporter,
+        offline=True,
+    )
+
+    packages = [
+        o for o in exporter.object_set.objects if isinstance(o, spdx3.software_Package)
+    ]
+    numpy_packages = [p for p in packages if p.name == "numpy"]
+    assert len(numpy_packages) == 1
+
+    relationships = [
+        o for o in exporter.object_set.objects if isinstance(o, spdx3.Relationship)
+    ]
+    depends_on = [
+        r
+        for r in relationships
+        if r.relationshipType == spdx3.RelationshipType.dependsOn
+    ]
+    assert len(depends_on) == 1
+
+    dep_comment = numpy_packages[0].comment
+    assert dep_comment is not None
+    assert dep_comment.count("extra == 'ai'") == 2
+    assert dep_comment.count("extra == 'numpy'") == 2
+
+
 # ---------------------------------------------------------------------------
 # _enrich_from_installed -- the discarded-concluded-license-relationship bug
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Multiple declarations of the same dependency should count 1.

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
