### PR TITLE
Prune two unreachable branches in _setuptools_cfg.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,12 @@ and this project adheres to
 
 - Reorganize Hugging Face tests ([#187])
 
+### Fixed
+
+- Prune two unreachable branches in `_setuptools_cfg.py` ([#188])
+
 [#187]: https://github.com/bact/pitloom/pull/187
+[#188]: https://github.com/bact/pitloom/pull/188
 
 ## [0.16.4] - 2026-08-21
 

--- a/src/pitloom/extract/_setuptools_cfg.py
+++ b/src/pitloom/extract/_setuptools_cfg.py
@@ -94,9 +94,9 @@ def _resolve_cfg_version(
     directive, value = m.group(1), m.group(2).strip()
     if directive == "file":
         return _resolve_cfg_version_file_directive(value, project_dir)
-    if directive == "attr":
-        return _resolve_cfg_attr_directive(value, project_dir)
-    return None, None
+    # _DIRECTIVE_RE only captures "file" or "attr" in this group, so
+    # "attr" is the only remaining case.
+    return _resolve_cfg_attr_directive(value, project_dir)
 
 
 def _resolve_cfg_file_directive(raw: str, project_dir: Path) -> str | None:
@@ -231,10 +231,10 @@ def read_setup_cfg(
     dependencies = _parse_cfg_requires(install_requires_raw)
 
     prov: dict[str, str] = {"name": "Source: setup.cfg | Field: metadata.name"}
+    # _resolve_cfg_version() always returns a paired (version, source) --
+    # never one truthy without the other -- so version_source alone gates it.
     if version_source:
         prov["version"] = version_source
-    elif version:
-        prov["version"] = "Source: setup.cfg | Field: metadata.version"
     if description:
         prov["description"] = "Source: setup.cfg | Field: metadata.description"
     if readme:


### PR DESCRIPTION
## Summary

Removes a dead directive fallback and a dead elif version check in _resolve_cfg_version/build_pitloom_config, both unreachable by construction (regex only matches two literals; the helper always returns a paired result).

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
