### PR TITLE
Cap artifact-metadata annotation size, canonicalize via RFC 8785

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-Last-Modified: 2026-08-21
+Last-Modified: 2026-08-26
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -20,6 +20,17 @@ and this project adheres to
 - Commit history: <https://github.com/bact/pitloom/compare/v0.16.3...v0.16.4>
 
 ## [Unreleased]
+
+### Added
+
+- Serialize every Annotation's `statement` via RFC 8785 (JSON
+  Canonicalization Scheme) instead of plain JSON, shrinking the output
+  and closing a spec-compliance gap
+- Cap artifact-metadata `Annotation.statement` size via
+  `[tool.pitloom.provenance] max-source-metadata-bytes` /
+  `--max-source-metadata-bytes`; truncates by dropping the largest
+  metadata keys first and marks the result with
+  `truncated`/`truncatedKeys`/`maxMetadataBytes`
 
 ### Changed
 

--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,15 @@ inputs:
       [tool.pitloom.content-type] method, which is "auto" by default.
     required: false
     default: ""
+  max-source-metadata-bytes:
+    description: >-
+      Cap the artifact-metadata preservation Annotation's serialized size
+      to this many UTF-8 bytes; truncates the largest metadata entries
+      first when exceeded. Empty (default) defers to
+      [tool.pitloom.provenance] max-source-metadata-bytes, which is 0
+      (unbounded) by default.
+    required: false
+    default: ""
   args:
     description: "Extra raw flags passed through to the loom command."
     required: false
@@ -167,6 +176,7 @@ runs:
         PL_EXTRACT_FILE_HEADER: ${{ inputs.extract-file-header }}
         PL_CONTENT_TYPE: ${{ inputs.content-type }}
         PL_CONTENT_TYPE_METHOD: ${{ inputs.content-type-method }}
+        PL_MAX_SOURCE_METADATA_BYTES: ${{ inputs.max-source-metadata-bytes }}
         PL_ARGS: ${{ inputs.args }}
       run: |
         set -euo pipefail
@@ -236,6 +246,9 @@ runs:
         fi
         if [ -n "${PL_CONTENT_TYPE_METHOD}" ]; then
           loom_args+=("--content-type-method" "${PL_CONTENT_TYPE_METHOD}")
+        fi
+        if [ -n "${PL_MAX_SOURCE_METADATA_BYTES}" ]; then
+          loom_args+=("--max-source-metadata-bytes" "${PL_MAX_SOURCE_METADATA_BYTES}")
         fi
         if [ -n "${PL_ARGS}" ]; then
           # Quote-aware split: PL_ARGS is a shell-like list of extra flags

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-08-11
-Last-Modified: 2026-08-14
+Last-Modified: 2026-08-26
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -257,7 +257,12 @@ Controlled by `[tool.pitloom.provenance]` in `pyproject.toml`:
 format = "both"                    # "annotation" | "comment" | "both" (default)
 detail = "minimal"                 # "minimal" (default) | "full"
 preserve-source-metadata = "auto"  # "auto" (default) | "always" | "never"
+max-source-metadata-bytes = 0      # 0 (default, unlimited) | a byte budget
 ```
+
+`max-source-metadata-bytes` also has a `--max-source-metadata-bytes BYTES`
+CLI flag -- an operational override for the byte cap without editing
+`pyproject.toml`, unlike every other key above.
 
 See [Metadata provenance](metadata-provenance.md) for what each setting
 does and worked examples.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,25 +169,24 @@ Config-only, except `max-source-metadata-bytes` (see below) -- see
 [Metadata provenance](metadata-provenance.md) for what each setting
 changes in the generated SBOM's Annotations.
 
-| Key | Type | Default | CLI flag / Action input | Meaning |
-| :-- | :--- | :------ | :----------------------- | :------ |
-| `format` | `"annotation"` \| `"comment"` \| `"both"` | `"both"` | -- | How metadata provenance is recorded: SPDX Core `Annotation` elements, legacy `Element.comment` strings, or both. |
-| `schema` | string | `"pitloom/1"` | -- | Which statement schema encodes provenance Annotations. |
-| `detail` | `"minimal"` \| `"full"` | `"minimal"` | -- | `"minimal"` emits a field-source Annotation only when the source adds signal the native value can't convey; `"full"` emits the per-field source map for every field. |
-| `preserve-source-metadata` | `"auto"` \| `"always"` \| `"never"` | `"auto"` | -- | Whether to embed an artifact's verbatim original metadata blob. `"auto"` does so only when the artifact isn't shipped with the distribution (and so can't be re-extracted later). |
-| `max-source-metadata-bytes` | non-negative integer | `0` | `--max-source-metadata-bytes` / `max-source-metadata-bytes` | Byte budget for the serialized artifact-metadata `Annotation.statement`. `0` means unlimited (today's behavior). When exceeded, the largest metadata entries are dropped first and the result is marked `truncated`/`truncatedKeys`/`truncatedKeyCount`/`maxMetadataBytes` -- see [Metadata provenance](metadata-provenance.md#size-bounded-preservation). Unlike its siblings above, this one has a CLI flag / Action input: a byte cap is an operational knob someone may want to override per-run without editing `pyproject.toml`. |
+| Key | Type | Default | CLI flag | Action input | API param | Meaning |
+| :-- | :--- | :------ | :------- | :------------ | :-------- | :------ |
+| `format` | `"annotation"` \| `"comment"` \| `"both"` | `"both"` | -- | -- | -- | How metadata provenance is recorded: SPDX Core `Annotation` elements, legacy `Element.comment` strings, or both. |
+| `schema` | string | `"pitloom/1"` | -- | -- | -- | Which statement schema encodes provenance Annotations. |
+| `detail` | `"minimal"` \| `"full"` | `"minimal"` | -- | -- | -- | `"minimal"` emits a field-source Annotation only when the source adds signal the native value can't convey; `"full"` emits the per-field source map for every field. |
+| `preserve-source-metadata` | `"auto"` \| `"always"` \| `"never"` | `"auto"` | -- | -- | -- | Whether to embed an artifact's verbatim original metadata blob. `"auto"` does so only when the artifact isn't shipped with the distribution (and so can't be re-extracted later). |
+| `max-source-metadata-bytes` | non-negative integer | `0` | `--max-source-metadata-bytes` | `max-source-metadata-bytes` | -- | Byte budget for the serialized artifact-metadata `Annotation.statement`. `0` means unlimited (today's behavior). When exceeded, the largest metadata entries are dropped first and the result is marked `truncated`/`truncatedKeys`/`truncatedKeyCount`/`maxMetadataBytes` -- see [Metadata provenance](metadata-provenance.md#size-bounded-preservation). Unlike its siblings above, this one has a CLI flag / Action input (no dedicated API param -- set it via the same `ProvenanceConfig` object the others use): a byte cap is an operational knob someone may want to override per-run without editing `pyproject.toml`. |
 
 **Invalid values / fallback behavior:** a non-string value, or a
 `format`/`detail`/`preserve-source-metadata` outside its listed set,
 raises `ValueError` at config-read time. An unknown `schema` id is not
 caught here (`core` doesn't import the assembly layer's encoder
 registry) -- it's caught with a clear error the first time an SBOM is
-actually generated.
-`max-source-metadata-bytes`: a non-integer or `bool`
-value raises `ValueError` at config-read time; a negative value, or a
-positive value below the smallest possible JSON object it could ever
-hold (8 bytes), is normalized to `0` (unlimited) with a logged
-`WARNING`, not rejected.
+actually generated. `max-source-metadata-bytes`: a non-integer or
+`bool` value raises `ValueError` at config-read time; a negative
+value, or a positive value below the smallest possible JSON object it
+could ever hold (8 bytes), is normalized to `0` (unlimited) with a
+logged `WARNING`, not rejected.
 
 ## See also
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-08-12
-Last-Modified: 2026-08-20
+Last-Modified: 2026-08-26
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -165,15 +165,17 @@ the whole configured list for that run rather than merging with it.
 
 ## `[tool.pitloom.provenance]`
 
-Config-only (no CLI flags) -- see [Metadata provenance](metadata-provenance.md)
-for what each setting changes in the generated SBOM's Annotations.
+Config-only, except `max-source-metadata-bytes` (see below) -- see
+[Metadata provenance](metadata-provenance.md) for what each setting
+changes in the generated SBOM's Annotations.
 
-| Key | Type | Default | Meaning |
-| :-- | :--- | :------ | :------ |
-| `format` | `"annotation"` \| `"comment"` \| `"both"` | `"both"` | How metadata provenance is recorded: SPDX Core `Annotation` elements, legacy `Element.comment` strings, or both. |
-| `schema` | string | `"pitloom/1"` | Which statement schema encodes provenance Annotations. |
-| `detail` | `"minimal"` \| `"full"` | `"minimal"` | `"minimal"` emits a field-source Annotation only when the source adds signal the native value can't convey; `"full"` emits the per-field source map for every field. |
-| `preserve-source-metadata` | `"auto"` \| `"always"` \| `"never"` | `"auto"` | Whether to embed an artifact's verbatim original metadata blob. `"auto"` does so only when the artifact isn't shipped with the distribution (and so can't be re-extracted later). |
+| Key | Type | Default | CLI flag / Action input | Meaning |
+| :-- | :--- | :------ | :----------------------- | :------ |
+| `format` | `"annotation"` \| `"comment"` \| `"both"` | `"both"` | -- | How metadata provenance is recorded: SPDX Core `Annotation` elements, legacy `Element.comment` strings, or both. |
+| `schema` | string | `"pitloom/1"` | -- | Which statement schema encodes provenance Annotations. |
+| `detail` | `"minimal"` \| `"full"` | `"minimal"` | -- | `"minimal"` emits a field-source Annotation only when the source adds signal the native value can't convey; `"full"` emits the per-field source map for every field. |
+| `preserve-source-metadata` | `"auto"` \| `"always"` \| `"never"` | `"auto"` | -- | Whether to embed an artifact's verbatim original metadata blob. `"auto"` does so only when the artifact isn't shipped with the distribution (and so can't be re-extracted later). |
+| `max-source-metadata-bytes` | non-negative integer | `0` | `--max-source-metadata-bytes` / `max-source-metadata-bytes` | Byte budget for the serialized artifact-metadata `Annotation.statement`. `0` means unlimited (today's behavior). When exceeded, the largest metadata entries are dropped first and the result is marked `truncated`/`truncatedKeys`/`truncatedKeyCount`/`maxMetadataBytes` -- see [Metadata provenance](metadata-provenance.md#size-bounded-preservation). Unlike its siblings above, this one has a CLI flag / Action input: a byte cap is an operational knob someone may want to override per-run without editing `pyproject.toml`. |
 
 **Invalid values / fallback behavior:** a non-string value, or a
 `format`/`detail`/`preserve-source-metadata` outside its listed set,
@@ -181,6 +183,11 @@ raises `ValueError` at config-read time. An unknown `schema` id is not
 caught here (`core` doesn't import the assembly layer's encoder
 registry) -- it's caught with a clear error the first time an SBOM is
 actually generated.
+`max-source-metadata-bytes`: a non-integer or `bool`
+value raises `ValueError` at config-read time; a negative value, or a
+positive value below the smallest possible JSON object it could ever
+hold (8 bytes), is normalized to `0` (unlimited) with a logged
+`WARNING`, not rejected.
 
 ## See also
 

--- a/docs/metadata-provenance.md
+++ b/docs/metadata-provenance.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-07-08
-Last-Modified: 2026-08-14
+Last-Modified: 2026-08-26
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -26,6 +26,7 @@ machine-readable JSON keyed by field name -- with the original human-readable
 format = "both"                    # "annotation" | "comment" | "both" (default)
 detail = "minimal"                 # "minimal" (default) | "full"
 preserve-source-metadata = "auto"  # "auto" (default) | "always" | "never"
+max-source-metadata-bytes = 0      # 0 (default, unlimited) | a byte budget
 ```
 
 By default (`detail = "minimal"`), a field only gets a provenance
@@ -75,6 +76,51 @@ This transparency is crucial for:
   extracted facts from inferred/detected ones
 - **Machine consumption**: Automated tools can parse provenance
 - **Human review**: Manual inspection of data sources
+
+## Size-bounded preservation
+
+`preserve-source-metadata` can embed an artifact's verbatim original
+metadata (e.g. a GGUF model's full KV header, including its tokenizer
+vocabulary) into a single `Annotation.statement`. For a real model this
+can be large -- a 32K-128K-entry vocab array easily reaches multi-megabyte
+territory. `max-source-metadata-bytes` (also `--max-source-metadata-bytes`
+on the CLI, or the Action's `max-source-metadata-bytes` input) caps the
+serialized `Annotation.statement`'s size in UTF-8 bytes; `0` (the default)
+means unlimited.
+
+When the budget is exceeded, whole metadata entries are dropped --
+largest first, to keep as many entries as possible -- never a value
+truncated mid-string, which would produce invalid JSON. The reduction is
+always marked explicitly in the same envelope, never silent:
+
+```json
+{
+  "schema": "https://pitloom.dev/provenance/artifact-metadata/1",
+  "kind": "artifact-metadata",
+  "format": "gguf",
+  "metadata": {
+    "general.architecture": "llama",
+    "block_count": 32
+  },
+  "truncated": true,
+  "truncatedKeys": ["tokenizer.ggml.tokens"],
+  "truncatedKeyCount": 1,
+  "maxMetadataBytes": 500
+}
+```
+
+If the budget is too small to hold even an empty `metadata: {}` plus the
+marker fields, no Annotation is emitted for that artifact at all (a
+`WARNING` is logged) -- an Annotation whose own `maxMetadataBytes` field
+claims a budget its own overhead violates would be worse than omitting
+it. A budget that forces every key to be dropped, but still fits the
+marker overhead, is emitted with `metadata: {}` and a `WARNING`.
+
+The `Annotation.statement` value is itself serialized via RFC 8785 (JSON
+Canonicalization Scheme, JCS) -- the same canonicalization the whole SBOM
+document uses -- so it has no insignificant whitespace and a
+deterministic key order; byte-for-byte comparing or hashing this blob
+across runs with unchanged input is safe.
 
 ## What the `method` values mean
 

--- a/skills/sbom-enrich/SKILL.md
+++ b/skills/sbom-enrich/SKILL.md
@@ -1,6 +1,6 @@
 ---
 # Created: 2026-07-05
-# Last-Modified: 2026-08-25
+# Last-Modified: 2026-08-26
 # SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
@@ -302,6 +302,15 @@ g. **Final report.** List which elements are now satisfied, which remain unknown
 `references/minimum-elements.md` also lists a manual, optional cross-check
 (`ntia-conformance-checker`) for NTIA/CISA targets -- not a required step, and not
 wired into this skill.
+
+## Check stderr for WARNING:/ERROR: lines
+
+`loom enrich`/`loom project`/`loom generate` log to stderr with a
+grep-able `WARNING:`/`ERROR:` prefix. These don't always fail the
+command or show up in the output JSON, so after running one, scan the
+captured stderr for these prefixes and mention any hit to the user in
+plain language -- don't let a real warning pass by unmentioned just
+because the command exited 0.
 
 ## See also
 

--- a/skills/sbom-generate/SKILL.md
+++ b/skills/sbom-generate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 # Created: 2026-07-05
-# Last-Modified: 2026-08-19
+# Last-Modified: 2026-08-26
 # SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
@@ -205,6 +205,17 @@ both -- just run the base generate command.
 A quick `@graph`-presence sanity check is enough for most runs (see
 `references/examples.md`), but for a schema/shape-level conformance
 check, use the `sbom-validate` skill on the output.
+
+## Check stderr for WARNING:/ERROR: lines
+
+Pitloom logs to stderr with a grep-able `WARNING:`/`ERROR:` prefix (e.g.
+"a config value was too small to be useful and got normalized instead",
+"a requested detector isn't installed"). These don't always fail the
+command or show up in the output JSON itself, so after running `loom`,
+scan the captured stderr for these prefixes and mention any hit to the
+user in plain language -- don't let a real warning about the SBOM's own
+completeness or configuration pass by unmentioned just because the
+command exited 0 and produced a file.
 
 ## Known limitations -- say so, don't paper over it
 

--- a/src/pitloom/assemble/spdx3/_ai_package.py
+++ b/src/pitloom/assemble/spdx3/_ai_package.py
@@ -64,6 +64,7 @@ def _emit_source_metadata(
     ai_pkg: spdx3.ai_AIPackage,
     file_spdx_ids: dict[str, str],
     preserve_source_metadata: str,
+    max_source_metadata_bytes: int,
     creation_info: spdx3.CreationInfo,
     doc_name: str,
     doc_uuid: str,
@@ -80,6 +81,7 @@ def _emit_source_metadata(
         creation_info=creation_info,
         doc_name=doc_name,
         doc_uuid=doc_uuid,
+        max_metadata_bytes=max_source_metadata_bytes,
     )
     if annotation is not None:
         exporter.add_annotation(annotation)

--- a/src/pitloom/assemble/spdx3/_document_model.py
+++ b/src/pitloom/assemble/spdx3/_document_model.py
@@ -267,6 +267,7 @@ def build_model(
         ai_pkg,
         {},
         prov_cfg.preserve_source_metadata,
+        prov_cfg.max_source_metadata_bytes,
         spdx_ci,
         doc_name,
         doc_uuid,

--- a/src/pitloom/assemble/spdx3/ai.py
+++ b/src/pitloom/assemble/spdx3/ai.py
@@ -138,6 +138,7 @@ def _add_single_ai_model(
         ai_pkg,
         file_spdx_ids,
         config.preserve_source_metadata,
+        config.max_source_metadata_bytes,
         creation_info,
         doc_name,
         doc_uuid,

--- a/src/pitloom/assemble/spdx3/provenance.py
+++ b/src/pitloom/assemble/spdx3/provenance.py
@@ -13,10 +13,11 @@ See Also:
 from __future__ import annotations
 
 import base64
-import json
+import logging
 import math
-from typing import Any, TypedDict
+from typing import Any, TypedDict, cast
 
+import rfc8785
 from spdx_python_model.bindings import v3_0_1 as spdx3
 
 from pitloom.assemble.spdx3._provenance_encoders import (
@@ -32,8 +33,13 @@ from pitloom.assemble.spdx3._provenance_encoders import (
     resolve_encoder,
 )
 from pitloom.core.models import generate_spdx_id
-from pitloom.core.provenance import ProvenanceConfig
+from pitloom.core.provenance import (
+    ProvenanceConfig,
+    normalize_max_source_metadata_bytes,
+)
 from pitloom.export.spdx3_json import Spdx3JsonExporter, require_spdx_id
+
+log = logging.getLogger(__name__)
 
 #: Statement-schema URL for a fragment-unification process Annotation (A1).
 UNIFICATION_SCHEMA_URL = "https://pitloom.dev/provenance/unification/1"
@@ -91,8 +97,23 @@ def _sanitize_for_json(obj: object) -> object:
         return [_sanitize_for_json(v) for v in obj]
     if isinstance(obj, (set, frozenset)):
         sanitized = [_sanitize_for_json(v) for v in obj]
-        return sorted(sanitized, key=lambda v: json.dumps(v, sort_keys=True))
-    return obj
+        return sorted(sanitized, key=_canonical_bytes)
+    if isinstance(obj, (str, int, bool)) or obj is None:
+        return obj
+    # RFC 8785 has no default=str-style hook for unrecognized types (unlike
+    # plain json.dumps) -- stringify anything else here so it never reaches
+    # the serializer, matching the previous default=str fallback.
+    return str(obj)
+
+
+def _canonical_bytes(obj: object) -> bytes:
+    """Serialize obj via RFC 8785 (JSON Canonicalization Scheme), as bytes."""
+    return rfc8785.dumps(cast(Any, _sanitize_for_json(obj)))
+
+
+def _canonical_json(obj: object) -> str:
+    """Serialize obj via RFC 8785 (JSON Canonicalization Scheme), as a str."""
+    return _canonical_bytes(obj).decode("utf-8")
 
 
 def _build_json_annotation(
@@ -108,12 +129,7 @@ def _build_json_annotation(
         annotationType=spdx3.AnnotationType.other,
         contentType="application/json",
         subject=subject_spdx_id,
-        statement=json.dumps(
-            _sanitize_for_json(statement_obj),
-            ensure_ascii=False,
-            sort_keys=True,
-            default=str,
-        ),
+        statement=_canonical_json(statement_obj),
     )
 
 
@@ -196,6 +212,74 @@ def build_enrichment_annotation(
     )
 
 
+def _artifact_metadata_envelope(
+    source_format: str,
+    kept_metadata: dict[str, Any],
+    dropped_keys: list[str],
+    max_metadata_bytes: int,
+) -> dict[str, Any]:
+    """Build the artifact-metadata ``statement`` envelope (P1)."""
+    statement: dict[str, Any] = {
+        "schema": ARTIFACT_METADATA_SCHEMA_URL,
+        "kind": "artifact-metadata",
+        "format": source_format,
+        "metadata": kept_metadata,
+    }
+    if dropped_keys:
+        statement["truncated"] = True
+        statement["truncatedKeys"] = sorted(dropped_keys)
+        statement["truncatedKeyCount"] = len(dropped_keys)
+        statement["maxMetadataBytes"] = max_metadata_bytes
+    return statement
+
+
+def _truncate_metadata_for_budget(
+    metadata: dict[str, Any],
+    source_format: str,
+    max_metadata_bytes: int,
+) -> tuple[dict[str, Any], list[str]] | None:
+    """Drop the largest metadata entries first until the artifact-metadata
+    envelope's serialized size fits ``max_metadata_bytes``.
+
+    Returns ``(kept_metadata, dropped_keys)`` -- ``dropped_keys`` is empty
+    when nothing needed dropping. Returns ``None`` if even an empty
+    ``metadata: {}`` (plus the marker fields) wouldn't fit the budget.
+
+    Re-checks the real serialized size of the candidate envelope at every
+    step rather than approximating it -- the realistic key count here (a
+    single AI model's metadata table) is small enough (dozens of keys, not
+    thousands) that this stays cheap even though it isn't asymptotically
+    optimal.
+    """
+    sanitized = cast(dict[str, Any], _sanitize_for_json(metadata))
+
+    def envelope_bytes(kept: dict[str, Any], dropped: list[str]) -> int:
+        envelope = _artifact_metadata_envelope(
+            source_format, kept, dropped, max_metadata_bytes
+        )
+        return len(_canonical_bytes(envelope))
+
+    if envelope_bytes(sanitized, []) <= max_metadata_bytes:
+        return sanitized, []
+
+    entry_bytes = {
+        key: len(_canonical_bytes(key)) + 1 + len(_canonical_bytes(value))
+        for key, value in sanitized.items()
+    }
+    drop_order = sorted(sanitized, key=lambda key: (-entry_bytes[key], key))
+
+    kept = dict(sanitized)
+    dropped: list[str] = []
+    for key in drop_order:
+        del kept[key]
+        dropped.append(key)
+        if envelope_bytes(kept, dropped) <= max_metadata_bytes:
+            return kept, dropped
+
+    return None
+
+
+# pylint: disable-next=too-many-arguments,too-many-positional-arguments
 def build_source_metadata_annotation(
     subject_spdx_id: str,
     source_format: str,
@@ -203,16 +287,50 @@ def build_source_metadata_annotation(
     creation_info: spdx3.CreationInfo,
     doc_name: str,
     doc_uuid: str,
+    max_metadata_bytes: int = 0,
 ) -> spdx3.Annotation | None:
-    """Return an Annotation embedding verbatim original metadata (P1)."""
+    """Return an Annotation embedding verbatim original metadata (P1).
+
+    ``max_metadata_bytes`` (0 = unlimited, the default) caps the serialized
+    Annotation's size: when exceeded, the largest metadata entries are
+    dropped first and the result is marked with
+    ``truncated``/``truncatedKeys``/``truncatedKeyCount``/
+    ``maxMetadataBytes`` so the reduction is visible rather than silent.
+    If even an empty ``metadata: {}`` plus the marker fields wouldn't fit
+    the budget, no Annotation is emitted at all.
+    """
     if not metadata:
         return None
-    statement = {
-        "schema": ARTIFACT_METADATA_SCHEMA_URL,
-        "kind": "artifact-metadata",
-        "format": source_format,
-        "metadata": metadata,
-    }
+
+    max_metadata_bytes = normalize_max_source_metadata_bytes(max_metadata_bytes)
+    dropped_keys: list[str] = []
+    kept_metadata = metadata
+    if max_metadata_bytes:
+        result = _truncate_metadata_for_budget(
+            metadata, source_format, max_metadata_bytes
+        )
+        if result is None:
+            log.warning(
+                "Artifact-metadata Annotation for %r dropped entirely: "
+                "max-source-metadata-bytes=%d is too small to hold even an "
+                "empty metadata envelope.",
+                subject_spdx_id,
+                max_metadata_bytes,
+            )
+            return None
+        kept_metadata, dropped_keys = result
+        if dropped_keys and not kept_metadata:
+            log.warning(
+                "Artifact-metadata Annotation for %r had all %d metadata "
+                "keys dropped to fit max-source-metadata-bytes=%d.",
+                subject_spdx_id,
+                len(dropped_keys),
+                max_metadata_bytes,
+            )
+
+    statement = _artifact_metadata_envelope(
+        source_format, kept_metadata, dropped_keys, max_metadata_bytes
+    )
     annotation_spdx_id = generate_spdx_id(
         "Annotation", doc_name=doc_name, doc_uuid=doc_uuid
     )

--- a/src/pitloom/cli/commands/embed_wheel.py
+++ b/src/pitloom/cli/commands/embed_wheel.py
@@ -20,6 +20,7 @@ from pitloom.cli.commands.utils import (
     _collect_wheel_paths,
     _print_sbom_output_path,
     cli_error_handler,
+    resolve_effective_provenance,
 )
 from pitloom.cli.options import _resolve_creation_metadata
 from pitloom.core.config import PitloomConfig
@@ -103,7 +104,7 @@ def _run_embed_wheel_command(args: argparse.Namespace) -> int:
         extract_file_header=args.extract_file_header,
         content_type=args.content_type,
         content_type_method=args.content_type_method,
-        provenance=pitloom_config.provenance,
+        provenance=resolve_effective_provenance(pitloom_config, args),
         offline=args.offline or None,
     )
     for wheel_path in unique_wheels:

--- a/src/pitloom/cli/commands/generate.py
+++ b/src/pitloom/cli/commands/generate.py
@@ -15,7 +15,7 @@ from typing import Any
 from pitloom.assemble import (
     generate,
 )
-from pitloom.cli.commands.utils import cli_error_handler
+from pitloom.cli.commands.utils import cli_error_handler, resolve_effective_provenance
 from pitloom.cli.options import _resolve_common_options
 
 
@@ -54,7 +54,7 @@ def _run_generate_command(args: argparse.Namespace) -> int:
         describe_relationship=describe_relationship,
         registry=args.registry,
         update_registry=args.update_registry,
-        provenance=pitloom_config.provenance,
+        provenance=resolve_effective_provenance(pitloom_config, args),
         enrich=args.enrich,
         extract_file_header=args.extract_file_header,
         content_type=args.content_type,

--- a/src/pitloom/cli/commands/model.py
+++ b/src/pitloom/cli/commands/model.py
@@ -16,7 +16,11 @@ from pitloom.__about__ import __version__
 from pitloom.assemble import (
     generate_model_sbom,
 )
-from pitloom.cli.commands.utils import _print_sbom_output_path, cli_error_handler
+from pitloom.cli.commands.utils import (
+    _print_sbom_output_path,
+    cli_error_handler,
+    resolve_effective_provenance,
+)
 from pitloom.cli.options import (
     _resolve_common_options,
     _resolve_hf_output_path,
@@ -67,7 +71,7 @@ def _run_model_command(args: argparse.Namespace) -> int:
         pretty=effective_pretty,
         describe_relationship=effective_describe,
         registry=args.registry,
-        provenance=pitloom_config.provenance,
+        provenance=resolve_effective_provenance(pitloom_config, args),
         enrich=args.enrich,
     )
     _print_sbom_output_path(output_path)

--- a/src/pitloom/cli/commands/project.py
+++ b/src/pitloom/cli/commands/project.py
@@ -14,7 +14,11 @@ from typing import Any
 from pitloom.assemble import (
     generate_project_sbom,
 )
-from pitloom.cli.commands.utils import _print_sbom_output_path, cli_error_handler
+from pitloom.cli.commands.utils import (
+    _print_sbom_output_path,
+    cli_error_handler,
+    resolve_effective_provenance,
+)
 from pitloom.cli.options import (
     _resolve_creation_metadata,
     _resolve_output_path,
@@ -62,7 +66,7 @@ def _run_project_command(args: argparse.Namespace) -> int:
         pitloom_config=pitloom_config,
         registry=args.registry,
         update_registry=args.update_registry,
-        provenance=pitloom_config.provenance,
+        provenance=resolve_effective_provenance(pitloom_config, args),
         enrich=args.enrich,
         offline=args.offline or None,
         extract_file_header=args.extract_file_header,

--- a/src/pitloom/cli/commands/utils.py
+++ b/src/pitloom/cli/commands/utils.py
@@ -7,6 +7,8 @@
 
 from __future__ import annotations
 
+import argparse
+import dataclasses
 import glob
 import sys
 import traceback
@@ -14,6 +16,12 @@ from collections.abc import Callable
 from functools import wraps
 from pathlib import Path
 from typing import Any
+
+from pitloom.core.config import PitloomConfig
+from pitloom.core.provenance import (
+    ProvenanceConfig,
+    normalize_max_source_metadata_bytes,
+)
 
 
 def cli_error_handler(
@@ -36,6 +44,25 @@ def cli_error_handler(
         return wrapper
 
     return decorator
+
+
+def resolve_effective_provenance(
+    pitloom_config: PitloomConfig, args: argparse.Namespace
+) -> ProvenanceConfig:
+    """Apply --max-source-metadata-bytes onto the config-sourced ProvenanceConfig.
+
+    Every [tool.pitloom.provenance] key besides this one is config-only (no
+    CLI flag); this one gets a flag since a byte cap is an operational knob
+    someone may want to override per-run without editing pyproject.toml.
+    """
+    provenance = pitloom_config.provenance
+    override = getattr(args, "max_source_metadata_bytes", None)
+    if override is not None:
+        provenance = dataclasses.replace(
+            provenance,
+            max_source_metadata_bytes=normalize_max_source_metadata_bytes(override),
+        )
+    return provenance
 
 
 def _print_sbom_output_path(output_path: Path | str) -> None:

--- a/src/pitloom/cli/commands/wheel.py
+++ b/src/pitloom/cli/commands/wheel.py
@@ -18,7 +18,11 @@ from pitloom.assemble import (
     generate_wheel_sbom,
 )
 from pitloom.cli.commands.embed_wheel import _report_embed_result
-from pitloom.cli.commands.utils import _print_sbom_output_path, cli_error_handler
+from pitloom.cli.commands.utils import (
+    _print_sbom_output_path,
+    cli_error_handler,
+    resolve_effective_provenance,
+)
 from pitloom.cli.constants import _SPDX3_JSON_EXT
 from pitloom.cli.options import _resolve_common_options
 
@@ -68,7 +72,7 @@ def _run_wheel_command(args: argparse.Namespace) -> int:
         describe_relationship=effective_describe,
         registry=args.registry,
         update_registry=args.update_registry,
-        provenance=pitloom_config.provenance,
+        provenance=resolve_effective_provenance(pitloom_config, args),
         offline=args.offline or None,
     )
 

--- a/src/pitloom/cli/parser.py
+++ b/src/pitloom/cli/parser.py
@@ -154,6 +154,20 @@ def _build_parent_parser() -> argparse.ArgumentParser:
         ),
     )
     parent.add_argument(
+        "--max-source-metadata-bytes",
+        type=int,
+        default=None,
+        metavar="BYTES",
+        help=(
+            "Cap the artifact-metadata preservation Annotation's serialized "
+            "size to this many UTF-8 bytes; truncates the largest metadata "
+            "entries first when exceeded. 0 (or any value too small to "
+            "hold data) disables the cap. Defers to "
+            "[tool.pitloom.provenance] max-source-metadata-bytes (0, "
+            "unbounded, by default) when omitted."
+        ),
+    )
+    parent.add_argument(
         "-v",
         "--verbose",
         action="store_true",

--- a/src/pitloom/core/_config_parse.py
+++ b/src/pitloom/core/_config_parse.py
@@ -26,6 +26,7 @@ from pitloom.core._config_types import (
 )
 from pitloom.core.content_type_config import ContentTypeOverride
 from pitloom.core.creation import Creator, Tool
+from pitloom.core.provenance import normalize_max_source_metadata_bytes
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -50,6 +51,26 @@ def _read_bool_setting(
     if not isinstance(value, bool):
         raise ValueError(
             f"{table_path} {key!r} must be a boolean, got "
+            f"{type(value).__name__}: {value!r}"
+        )
+    return value
+
+
+def _read_int_setting(
+    data: dict[str, Any],
+    key: str,
+    default: int,
+    table_path: str = "[tool.pitloom]",
+) -> int:
+    """Read an int key from data, defaulting to default when absent.
+
+    Rejects a bool value explicitly -- ``isinstance(True, int)`` is ``True``
+    in Python, so a TOML ``key = true`` would otherwise silently pass as 1.
+    """
+    value = data.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(
+            f"{table_path} {key!r} must be an integer, got "
             f"{type(value).__name__}: {value!r}"
         )
     return value
@@ -148,9 +169,17 @@ def _provenance_str(raw: dict[str, Any], keys: tuple[str, ...], default: str) ->
     return default
 
 
+def _provenance_int(raw: dict[str, Any], keys: tuple[str, ...], default: int) -> int:
+    """Return the first present ``[tool.pitloom.provenance]`` key as an int."""
+    for key in keys:
+        if key in raw:
+            return _read_int_setting(raw, key, default, "[tool.pitloom.provenance]")
+    return default
+
+
 def _read_provenance_settings(
     pitloom_data: dict[str, Any],
-) -> tuple[str, str, str, str]:
+) -> tuple[str, str, str, str, int]:
     """Read ``[tool.pitloom.provenance]`` settings."""
     raw = pitloom_data.get("provenance", {})
     if not isinstance(raw, dict):
@@ -181,7 +210,12 @@ def _read_provenance_settings(
         "preserve-source-metadata",
     )
 
-    return fmt, schema, detail, preserve
+    max_metadata_bytes = _provenance_int(
+        raw, ("max-source-metadata-bytes", "max_source_metadata_bytes"), 0
+    )
+    max_metadata_bytes = normalize_max_source_metadata_bytes(max_metadata_bytes)
+
+    return fmt, schema, detail, preserve, max_metadata_bytes
 
 
 def _read_ids_file(pitloom_data: dict[str, Any]) -> str | None:
@@ -315,6 +349,7 @@ def parse_pitloom_config(data: dict[str, Any]) -> PitloomConfig:
         provenance_schema,
         provenance_detail,
         provenance_preserve,
+        provenance_max_metadata_bytes,
     ) = _read_provenance_settings(pitloom_data)
     enrich_local = _read_enrich_settings(pitloom_data)
     extract_file_header = _read_extract_file_header(pitloom_data)
@@ -364,6 +399,7 @@ def parse_pitloom_config(data: dict[str, Any]) -> PitloomConfig:
         provenance_schema=provenance_schema,
         provenance_detail=provenance_detail,
         provenance_preserve_source_metadata=provenance_preserve,
+        provenance_max_source_metadata_bytes=provenance_max_metadata_bytes,
         enrich_local=enrich_local,
         extract_file_header=extract_file_header,
         content_type_enabled=content_type_enabled,

--- a/src/pitloom/core/_config_types.py
+++ b/src/pitloom/core/_config_types.py
@@ -42,6 +42,7 @@ class PitloomConfig:
     provenance_schema: str = _DEFAULT_PROVENANCE_SCHEMA
     provenance_detail: str = "minimal"
     provenance_preserve_source_metadata: str = "auto"
+    provenance_max_source_metadata_bytes: int = 0
     enrich_local: bool = False
     extract_file_header: bool = True
     content_type_enabled: bool = False
@@ -57,6 +58,7 @@ class PitloomConfig:
             schema=self.provenance_schema,
             detail=self.provenance_detail,
             preserve_source_metadata=self.provenance_preserve_source_metadata,
+            max_source_metadata_bytes=self.provenance_max_source_metadata_bytes,
         )
 
     @property

--- a/src/pitloom/core/provenance.py
+++ b/src/pitloom/core/provenance.py
@@ -7,9 +7,39 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
+import rfc8785
+
+log = logging.getLogger(__name__)
+
 DEFAULT_PROVENANCE_SCHEMA = "pitloom/1"
+
+#: Smallest possible non-empty JCS-encoded JSON object (e.g. ``{"a":""}``),
+#: computed from the real serializer so it can't silently drift from it.
+_MIN_EFFECTIVE_MAX_SOURCE_METADATA_BYTES = len(rfc8785.dumps({"a": ""}))
+
+
+def normalize_max_source_metadata_bytes(value: int) -> int:
+    """Collapse a too-small-to-be-useful metadata byte budget to 0.
+
+    ``0`` means "no cap" (embed the full artifact-metadata blob, today's
+    unbounded behavior). A negative value, or a positive value below the
+    smallest possible JCS-encoded JSON object, can never hold any real
+    metadata -- both are treated the same as ``0``, with a logged warning,
+    rather than rejected outright, since they're well-typed but merely
+    pointless rather than structurally invalid.
+    """
+    if value != 0 and value < _MIN_EFFECTIVE_MAX_SOURCE_METADATA_BYTES:
+        log.warning(
+            "max-source-metadata-bytes=%d is too small to ever hold data "
+            "(minimum useful value is %d bytes); using 0 (unlimited) instead.",
+            value,
+            _MIN_EFFECTIVE_MAX_SOURCE_METADATA_BYTES,
+        )
+        return 0
+    return value
 
 
 @dataclass(frozen=True)
@@ -22,9 +52,13 @@ class ProvenanceConfig:
         detail: Provenance detail level ("minimal", "full").
         preserve_source_metadata: How to preserve source metadata
             ("auto", "always", "never").
+        max_source_metadata_bytes: Byte budget for the serialized
+            artifact-metadata Annotation.statement; 0 (default) means
+            unlimited. See :func:`normalize_max_source_metadata_bytes`.
     """
 
     format: str = "both"
     schema: str = DEFAULT_PROVENANCE_SCHEMA
     detail: str = "minimal"
     preserve_source_metadata: str = "auto"
+    max_source_metadata_bytes: int = 0

--- a/tests/assemble/test_annotation_metadata_truncation.py
+++ b/tests/assemble/test_annotation_metadata_truncation.py
@@ -1,0 +1,233 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for build_source_metadata_annotation()'s max_metadata_bytes cap
+(P1 artifact-metadata size truncation).
+
+See also: test_annotation_provenance_annotations.py, which covers the
+rest of build_source_metadata_annotation()'s shape/determinism.
+"""
+
+# pylint: disable=missing-function-docstring
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from pitloom.assemble.spdx3.provenance import build_source_metadata_annotation
+from pitloom.core.models import _clear_doc_counters
+
+from .conftest import _DOC_NAME, _DOC_UUID, _make_ci
+
+
+def _small_metadata() -> dict[str, object]:
+    return {"general.architecture": "llama", "block_count": 32}
+
+
+def _metadata_with_one_huge_key() -> dict[str, object]:
+    metadata = _small_metadata()
+    metadata["tokenizer.ggml.tokens"] = [f"token_{i}" for i in range(2000)]
+    return metadata
+
+
+def test_default_max_bytes_zero_is_unbounded_no_op() -> None:
+    ci = _make_ci()
+    metadata = _metadata_with_one_huge_key()
+    ann = build_source_metadata_annotation(
+        "urn:doc#ai_AIPackage-1", "gguf", metadata, ci, _DOC_NAME, _DOC_UUID
+    )
+    assert ann is not None
+    assert ann.statement is not None
+    statement = json.loads(ann.statement)
+    assert "truncated" not in statement
+    assert len(statement["metadata"]["tokenizer.ggml.tokens"]) == 2000
+
+
+def test_budget_above_real_size_no_marker_keys() -> None:
+    ci = _make_ci()
+    metadata = _small_metadata()
+    ann = build_source_metadata_annotation(
+        "urn:doc#ai_AIPackage-1",
+        "gguf",
+        metadata,
+        ci,
+        _DOC_NAME,
+        _DOC_UUID,
+        max_metadata_bytes=100_000,
+    )
+    assert ann is not None
+    assert ann.statement is not None
+    statement = json.loads(ann.statement)
+    assert "truncated" not in statement
+    assert "truncatedKeys" not in statement
+    assert "maxMetadataBytes" not in statement
+    assert statement["metadata"] == metadata
+
+
+def test_budget_drops_the_huge_key_keeps_small_ones() -> None:
+    ci = _make_ci()
+    metadata = _metadata_with_one_huge_key()
+    # Big enough for the two small keys plus envelope overhead, far too
+    # small for the 2000-entry token list.
+    ann = build_source_metadata_annotation(
+        "urn:doc#ai_AIPackage-1",
+        "gguf",
+        metadata,
+        ci,
+        _DOC_NAME,
+        _DOC_UUID,
+        max_metadata_bytes=500,
+    )
+    assert ann is not None
+    assert ann.statement is not None
+    assert len(ann.statement.encode("utf-8")) <= 500
+    statement = json.loads(ann.statement)
+    assert statement["truncated"] is True
+    assert statement["truncatedKeys"] == ["tokenizer.ggml.tokens"]
+    assert statement["truncatedKeyCount"] == 1
+    assert statement["maxMetadataBytes"] == 500
+    assert statement["metadata"] == {
+        "general.architecture": "llama",
+        "block_count": 32,
+    }
+
+
+def test_budget_drops_every_key_but_envelope_still_fits(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    ci = _make_ci()
+    # Each key is large enough that keeping any of them exceeds the budget,
+    # but an empty metadata dict plus the truncatedKeys marker still fits.
+    metadata = {"k1": "x" * 40, "k2": "y" * 40, "k3": "z" * 40}
+    with caplog.at_level(logging.WARNING):
+        ann = build_source_metadata_annotation(
+            "urn:doc#ai_AIPackage-1",
+            "gguf",
+            metadata,
+            ci,
+            _DOC_NAME,
+            _DOC_UUID,
+            max_metadata_bytes=230,
+        )
+    assert ann is not None
+    assert ann.statement is not None
+    statement = json.loads(ann.statement)
+    assert statement["metadata"] == {}
+    assert sorted(statement["truncatedKeys"]) == sorted(metadata)
+    assert statement["truncatedKeyCount"] == len(metadata)
+    assert "all" in caplog.text and "dropped" in caplog.text
+
+
+def test_budget_too_small_for_empty_envelope_returns_none(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    ci = _make_ci()
+    with caplog.at_level(logging.WARNING):
+        ann = build_source_metadata_annotation(
+            "urn:doc#ai_AIPackage-1",
+            "gguf",
+            _small_metadata(),
+            ci,
+            _DOC_NAME,
+            _DOC_UUID,
+            max_metadata_bytes=8,
+        )
+    assert ann is None
+    assert "dropped entirely" in caplog.text
+
+
+def test_truncated_keys_sorted_alphabetically_regardless_of_drop_order() -> None:
+    ci = _make_ci()
+    # zzz_huge is larger than aaa_huge, so it's dropped *first* (largest
+    # first) -- the raw drop order is [zzz_huge, aaa_huge], the opposite of
+    # alphabetical, so this actually exercises the sort rather than
+    # coinciding with it.
+    metadata = {
+        "zzz_huge": "x" * 3000,
+        "aaa_huge": "y" * 2500,
+        "mmm_small": 5,
+    }
+    ann = build_source_metadata_annotation(
+        "urn:doc#ai_AIPackage-1",
+        "gguf",
+        metadata,
+        ci,
+        _DOC_NAME,
+        _DOC_UUID,
+        max_metadata_bytes=300,
+    )
+    assert ann is not None
+    assert ann.statement is not None
+    statement = json.loads(ann.statement)
+    assert statement["truncatedKeys"] == ["aaa_huge", "zzz_huge"]
+    assert statement["metadata"] == {"mmm_small": 5}
+
+
+def test_truncation_is_deterministic_regardless_of_dict_insertion_order() -> None:
+    ci = _make_ci()
+    metadata_a = _metadata_with_one_huge_key()
+    metadata_b = {k: metadata_a[k] for k in reversed(list(metadata_a))}
+
+    _clear_doc_counters(_DOC_UUID)
+    ann_a = build_source_metadata_annotation(
+        "urn:doc#ai_AIPackage-1",
+        "gguf",
+        metadata_a,
+        ci,
+        _DOC_NAME,
+        _DOC_UUID,
+        max_metadata_bytes=500,
+    )
+    ann_b = build_source_metadata_annotation(
+        "urn:doc#ai_AIPackage-1",
+        "gguf",
+        metadata_b,
+        ci,
+        _DOC_NAME,
+        _DOC_UUID,
+        max_metadata_bytes=500,
+    )
+    assert ann_a is not None and ann_b is not None
+    assert ann_a.statement == ann_b.statement
+
+
+@pytest.mark.parametrize("budget", [500, 1000, 5000, 50_000])
+def test_respects_the_real_byte_budget(budget: int) -> None:
+    ci = _make_ci()
+    metadata = _metadata_with_one_huge_key()
+    ann = build_source_metadata_annotation(
+        "urn:doc#ai_AIPackage-1",
+        "gguf",
+        metadata,
+        ci,
+        _DOC_NAME,
+        _DOC_UUID,
+        max_metadata_bytes=budget,
+    )
+    assert ann is not None
+    assert ann.statement is not None
+    assert len(ann.statement.encode("utf-8")) <= budget
+
+
+def test_negative_max_bytes_treated_as_unbounded() -> None:
+    ci = _make_ci()
+    metadata = _small_metadata()
+    ann = build_source_metadata_annotation(
+        "urn:doc#ai_AIPackage-1",
+        "gguf",
+        metadata,
+        ci,
+        _DOC_NAME,
+        _DOC_UUID,
+        max_metadata_bytes=-5,
+    )
+    assert ann is not None
+    assert ann.statement is not None
+    statement = json.loads(ann.statement)
+    assert "truncated" not in statement
+    assert statement["metadata"] == metadata

--- a/tests/assemble/test_annotation_provenance_annotations.py
+++ b/tests/assemble/test_annotation_provenance_annotations.py
@@ -312,3 +312,37 @@ def test_sanitize_for_json_orders_unsortable_elements_deterministically() -> Non
     set_a = {frozenset({1, 2}), frozenset({3, 4}), frozenset({5})}
     set_b = {frozenset({5}), frozenset({3, 4}), frozenset({1, 2})}
     assert _sanitize_for_json(set_a) == _sanitize_for_json(set_b)
+
+
+# ---------------------------------------------------------------------------
+# RFC 8785 (JCS) canonicalization of Annotation.statement
+# ---------------------------------------------------------------------------
+
+
+def test_build_json_annotation_uses_compact_rfc8785_separators() -> None:
+    """statement must have no insignificant whitespace (JCS, not plain
+    json.dumps' default ``': '``/``', '`` separators)."""
+    ci = _make_ci()
+    ann = build_unification_annotation(
+        "urn:doc#Package-1", "hash", ["urn:doc#a"], ["urn:doc#b"], ci, "urn:doc#Ann-1"
+    )
+    assert ann.statement is not None
+    assert ": " not in ann.statement
+    assert ", " not in ann.statement
+
+
+def test_sanitize_for_json_stringifies_unsupported_types() -> None:
+    """RFC 8785 has no default=str-style hook (unlike plain json.dumps) --
+    the sanitizer must stringify unrecognized types itself, matching the
+    previous default=str fallback's behavior."""
+    # pylint: disable=import-outside-toplevel
+    from decimal import Decimal
+
+    from pitloom.assemble.spdx3.provenance import _sanitize_for_json
+
+    class _Unrecognized:
+        def __str__(self) -> str:
+            return "unrecognized-value"
+
+    assert _sanitize_for_json(Decimal("1.5")) == "1.5"
+    assert _sanitize_for_json(_Unrecognized()) == "unrecognized-value"

--- a/tests/cli/test_cli_utils.py
+++ b/tests/cli/test_cli_utils.py
@@ -1,0 +1,63 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for pitloom.cli.commands.utils.resolve_effective_provenance()."""
+
+# pylint: disable=missing-function-docstring
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+import pytest
+
+from pitloom.cli.commands.utils import resolve_effective_provenance
+from pitloom.core.config import PitloomConfig
+
+
+def _args(max_source_metadata_bytes: int | None = None) -> argparse.Namespace:
+    return argparse.Namespace(max_source_metadata_bytes=max_source_metadata_bytes)
+
+
+def test_no_override_returns_config_provenance_unchanged() -> None:
+    cfg = PitloomConfig(provenance_max_source_metadata_bytes=1234)
+    provenance = resolve_effective_provenance(cfg, _args())
+    assert provenance.max_source_metadata_bytes == 1234
+
+
+def test_cli_override_replaces_config_value() -> None:
+    cfg = PitloomConfig(provenance_max_source_metadata_bytes=1234)
+    provenance = resolve_effective_provenance(
+        cfg, _args(max_source_metadata_bytes=9000)
+    )
+    assert provenance.max_source_metadata_bytes == 9000
+
+
+def test_cli_override_preserves_other_provenance_fields() -> None:
+    cfg = PitloomConfig(provenance_format="annotation", provenance_detail="full")
+    provenance = resolve_effective_provenance(
+        cfg, _args(max_source_metadata_bytes=9000)
+    )
+    assert provenance.format == "annotation"
+    assert provenance.detail == "full"
+
+
+def test_negative_cli_override_normalizes_to_zero(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    cfg = PitloomConfig()
+    with caplog.at_level(logging.WARNING):
+        provenance = resolve_effective_provenance(
+            cfg, _args(max_source_metadata_bytes=-5)
+        )
+    assert provenance.max_source_metadata_bytes == 0
+    assert "max-source-metadata-bytes" in caplog.text
+
+
+def test_missing_attribute_treated_as_no_override() -> None:
+    cfg = PitloomConfig(provenance_max_source_metadata_bytes=1234)
+    provenance = resolve_effective_provenance(cfg, argparse.Namespace())
+    assert provenance.max_source_metadata_bytes == 1234

--- a/tests/cli/test_cli_wheel.py
+++ b/tests/cli/test_cli_wheel.py
@@ -107,7 +107,8 @@ def test_wheel_command_wires_max_source_metadata_bytes(
 
     assert __main__.main() == 0
     assert captured["provenance"] is not None
-    assert captured["provenance"].max_source_metadata_bytes == 5000  # type: ignore[attr-defined]
+    provenance = captured["provenance"]
+    assert provenance.max_source_metadata_bytes == 5000  # type: ignore[attr-defined]
 
 
 def test_wheel_command_nonexistent_and_verbose(

--- a/tests/cli/test_cli_wheel.py
+++ b/tests/cli/test_cli_wheel.py
@@ -64,6 +64,52 @@ def test_analyze_wheel_dispatches_to_wheel_path(
     assert captured["wheel_path"] == wheel_path.resolve()
 
 
+def test_wheel_command_wires_max_source_metadata_bytes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`loom wheel --max-source-metadata-bytes N` must reach
+    generate_wheel_sbom() via resolve_effective_provenance() -- a
+    regression test for a call site that was missed when this flag was
+    added to every other generate-family command."""
+    monkeypatch.chdir(tmp_path)
+    wheel_path = _make_wheel(tmp_path, "pkg", "1.0.0")
+    captured: dict[str, object] = {}
+
+    def _fake_generate_analyzed_sbom(
+        wheel_path_arg: Path,
+        output_path: object = None,
+        creation_metadata: object = None,
+        pretty: bool = False,
+        describe_relationship: bool = False,
+        registry: object = None,
+        offline: bool = False,
+        provenance: object = None,
+        **kwargs: object,
+    ) -> str:
+        _ = (
+            wheel_path_arg,
+            output_path,
+            creation_metadata,
+            pretty,
+            describe_relationship,
+            registry,
+            offline,
+        )
+        captured["provenance"] = provenance
+        return "{}"
+
+    monkeypatch.setattr(mod_wheel, "generate_wheel_sbom", _fake_generate_analyzed_sbom)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["loom", "wheel", str(wheel_path), "--max-source-metadata-bytes", "5000"],
+    )
+
+    assert __main__.main() == 0
+    assert captured["provenance"] is not None
+    assert captured["provenance"].max_source_metadata_bytes == 5000  # type: ignore[attr-defined]
+
+
 def test_wheel_command_nonexistent_and_verbose(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
 ) -> None:

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -289,6 +289,7 @@ def test_pitloom_config_helper_properties() -> None:
         provenance_schema="spdx3",
         provenance_detail="full",
         provenance_preserve_source_metadata="always",
+        provenance_max_source_metadata_bytes=5000,
         content_type_enabled=True,
         content_type_method="magika",
         enrich_local=True,
@@ -303,6 +304,7 @@ def test_pitloom_config_helper_properties() -> None:
     assert prov.schema == "spdx3"
     assert prov.detail == "full"
     assert prov.preserve_source_metadata == "always"
+    assert prov.max_source_metadata_bytes == 5000
 
     ct = cfg.content_type
     assert ct.enabled is True

--- a/tests/core/test_generator_model_metadata_cap.py
+++ b/tests/core/test_generator_model_metadata_cap.py
@@ -1,0 +1,65 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end test for build()'s max_source_metadata_bytes cap on the P1
+artifact-metadata Annotation, through the real assembly pipeline.
+
+See also: tests/assemble/test_annotation_metadata_truncation.py, which
+unit-tests build_source_metadata_annotation() directly.
+"""
+
+from __future__ import annotations
+
+import json
+
+from pitloom.assemble.spdx3.document import build
+from pitloom.core.ai_metadata import AiModelFormat, AiModelFormatInfo, AiModelMetadata
+from pitloom.core.creation import CreationMetadata
+from pitloom.core.document import DocumentModel
+from pitloom.core.project import ProjectMetadata
+from pitloom.core.provenance import ProvenanceConfig
+
+
+def test_build_respects_max_source_metadata_bytes_end_to_end() -> None:
+    project = ProjectMetadata(name="ai-project", version="0.1.0")
+    ai_model = AiModelMetadata(
+        format_info=AiModelFormatInfo(model_format=AiModelFormat.GGUF),
+        name="tiny-llm",
+        version="1.0.0",
+        raw_metadata={
+            "general.architecture": "llama",
+            "tokenizer.ggml.tokens": [f"token_{i}" for i in range(5000)],
+        },
+    )
+    doc = DocumentModel(
+        project=project, creation_metadata=CreationMetadata(), ai_models=[ai_model]
+    )
+    provenance = ProvenanceConfig(
+        preserve_source_metadata="always", max_source_metadata_bytes=500
+    )
+
+    exporter = build(doc, provenance=provenance)
+    output = exporter.to_json(pretty=False)
+    data = json.loads(output)  # whole document must still be valid JSON
+    graph = data["@graph"]
+
+    annotations = [
+        e
+        for e in graph
+        if e.get("type") == "Annotation" and e.get("contentType") == "application/json"
+    ]
+    artifact_metadata_anns = [
+        a
+        for a in annotations
+        if json.loads(a["statement"]).get("kind") == "artifact-metadata"
+    ]
+    assert len(artifact_metadata_anns) == 1
+    ann = artifact_metadata_anns[0]
+
+    assert len(ann["statement"].encode("utf-8")) <= 500
+    statement = json.loads(ann["statement"])  # must parse cleanly
+    assert statement["truncated"] is True
+    assert "tokenizer.ggml.tokens" in statement["truncatedKeys"]
+    assert statement["metadata"] == {"general.architecture": "llama"}

--- a/tests/core/test_metadata.py
+++ b/tests/core/test_metadata.py
@@ -12,6 +12,7 @@ creator/tool shapes, dependency-name canonicalization, and license
 concluded (G2) tests.
 """
 
+import logging
 import tempfile
 from pathlib import Path
 
@@ -250,6 +251,7 @@ version = "1.0.0"
         assert config.provenance_schema == "pitloom/1"
         assert config.provenance_detail == "minimal"
         assert config.provenance_preserve_source_metadata == "auto"
+        assert config.provenance_max_source_metadata_bytes == 0
 
 
 def test_extract_pitloom_provenance_settings_explicit() -> None:
@@ -263,6 +265,7 @@ format = "annotation"
 schema = "custom/1"
 detail = "full"
 preserve-source-metadata = "always"
+max-source-metadata-bytes = 5000
 """
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -276,6 +279,86 @@ preserve-source-metadata = "always"
         assert config.provenance_schema == "custom/1"
         assert config.provenance_detail == "full"
         assert config.provenance_preserve_source_metadata == "always"
+        assert config.provenance_max_source_metadata_bytes == 5000
+
+
+def test_max_source_metadata_bytes_underscore_spelling_accepted() -> None:
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[tool.pitloom.provenance]
+max_source_metadata_bytes = 5000
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        _, config = read_pyproject(pyproject_path)
+
+        assert config.provenance_max_source_metadata_bytes == 5000
+
+
+@pytest.mark.parametrize("value", [-1, 1, 7])
+def test_max_source_metadata_bytes_too_small_collapses_to_zero(
+    value: int, caplog: pytest.LogCaptureFixture
+) -> None:
+    pyproject_content = f"""
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[tool.pitloom.provenance]
+max-source-metadata-bytes = {value}
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        with caplog.at_level(logging.WARNING):
+            _, config = read_pyproject(pyproject_path)
+
+        assert config.provenance_max_source_metadata_bytes == 0
+        assert "max-source-metadata-bytes" in caplog.text
+
+
+def test_max_source_metadata_bytes_bool_raises() -> None:
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[tool.pitloom.provenance]
+max-source-metadata-bytes = true
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        with pytest.raises(ValueError, match="must be an integer"):
+            read_pyproject(pyproject_path)
+
+
+def test_max_source_metadata_bytes_non_int_raises() -> None:
+    pyproject_content = """
+[project]
+name = "test-package"
+version = "1.0.0"
+
+[tool.pitloom.provenance]
+max-source-metadata-bytes = "5000"
+"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        pyproject_path = tmppath / "pyproject.toml"
+        pyproject_path.write_text(pyproject_content)
+
+        with pytest.raises(ValueError, match="must be an integer"):
+            read_pyproject(pyproject_path)
 
 
 def test_creator_empty_name_raises() -> None:

--- a/tests/core/test_provenance.py
+++ b/tests/core/test_provenance.py
@@ -1,0 +1,66 @@
+# SPDX-FileContributor: Arthit Suriyawongkul
+# SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for pitloom.core.provenance: ProvenanceConfig and
+normalize_max_source_metadata_bytes().
+"""
+
+# pylint: disable=missing-function-docstring
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from pitloom.core.provenance import (
+    _MIN_EFFECTIVE_MAX_SOURCE_METADATA_BYTES,
+    ProvenanceConfig,
+    normalize_max_source_metadata_bytes,
+)
+
+
+def test_min_effective_floor_is_eight_bytes() -> None:
+    # {"a":""} under RFC 8785 (JCS) compact separators -- no whitespace.
+    assert _MIN_EFFECTIVE_MAX_SOURCE_METADATA_BYTES == 8
+
+
+def test_normalize_zero_passes_through_unchanged() -> None:
+    assert normalize_max_source_metadata_bytes(0) == 0
+
+
+@pytest.mark.parametrize("value", [8, 9, 1000, 10**9])
+def test_normalize_valid_values_pass_through_unchanged(value: int) -> None:
+    assert normalize_max_source_metadata_bytes(value) == value
+
+
+@pytest.mark.parametrize("value", [1, 2, 7])
+def test_normalize_too_small_positive_collapses_to_zero(
+    value: int, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.WARNING):
+        assert normalize_max_source_metadata_bytes(value) == 0
+    assert "max-source-metadata-bytes" in caplog.text
+    assert str(value) in caplog.text
+
+
+@pytest.mark.parametrize("value", [-1, -1000])
+def test_normalize_negative_collapses_to_zero(
+    value: int, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.WARNING):
+        assert normalize_max_source_metadata_bytes(value) == 0
+    assert "max-source-metadata-bytes" in caplog.text
+
+
+def test_provenance_config_default_max_source_metadata_bytes_is_zero() -> None:
+    assert ProvenanceConfig().max_source_metadata_bytes == 0
+
+
+def test_provenance_config_max_source_metadata_bytes_round_trips() -> None:
+    assert (
+        ProvenanceConfig(max_source_metadata_bytes=5000).max_source_metadata_bytes
+        == 5000
+    )

--- a/working-docs/design/provenance-enrichment-vocabulary.md
+++ b/working-docs/design/provenance-enrichment-vocabulary.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-08-13
-Last-Modified: 2026-08-25
+Last-Modified: 2026-08-26
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -108,17 +108,19 @@ it). §1/§2 below and the drafted page content are updated to match.
    `working-docs/implementation/provenance/metadata-provenance.md`):
    record when third-party tools (e.g. the `enrich` skill) augmented the
    data; track validation steps and results. Neither is built.
-7. **Unbounded artifact-metadata-blob size** (same carry-over): artifact-
-   metadata preservation (`_source_metadata_blob()`/`_emit_source_metadata()`
-   in `src/pitloom/assemble/spdx3/ai.py`) embeds an AI model's raw
-   metadata verbatim, with no size cap, into a single `Annotation.statement`
-   -- fine for small test fixtures, but a real production model with a
-   large vocabulary (e.g. a GGUF LLM's 32K-128K+ token list) could inflate
-   a single Annotation into the multi-megabyte range. Not a spec
-   violation (SPDX 3.0.1's `statement` is plain `xsd:string`, no
-   spec-mandated limit), but an untested scalability gap. Whether to drop
-   oversized fields entirely, truncate with a marker, or move to an
-   external reference is still undecided.
+7. ~~**Unbounded artifact-metadata-blob size**~~ -- **Resolved
+   (2026-08-26):** `[tool.pitloom.provenance] max-source-metadata-bytes`
+   (default `0`, unbounded) caps the serialized `Annotation.statement`
+   byte length via dictionary-level, greedy-heaviest-key-first
+   truncation, marked with `truncated`/`truncatedKeys`/
+   `truncatedKeyCount`/`maxMetadataBytes` in the statement envelope when
+   it fires. Also gained a `--max-source-metadata-bytes` CLI flag /
+   `action.yml` input, a deliberate exception to this table's
+   config-only precedent. See
+   `working-docs/implementation/provenance/annotation-mechanism.md`'s
+   "Size-bounded artifact-metadata preservation" section for the shipped
+   design, and `docs/metadata-provenance.md`'s "Size-bounded
+   preservation" section for the user-facing explainer.
 8. **`Method` vs. `Role` as separate keys, flagged 2026-08-14 for
    dedicated human review**: the 2026-08-13 fix (see "Already applied"
    above) resolved the specific bug where `sbomAuthorSupplied` was

--- a/working-docs/design/roadmap.md
+++ b/working-docs/design/roadmap.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-04-14
-Last-Modified: 2026-08-25
+Last-Modified: 2026-08-27
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -118,6 +118,19 @@ full picture.
 - [ ] **Docker container action** (future) -- a `Dockerfile` +
   `action.yml` `using: docker` variant of the GitHub Action for hermetic
   or self-hosted-runner use.
+- [ ] **Surface `WARNING:`/`ERROR:` stderr as GitHub Actions annotations**
+  (future) -- `action.yml`'s composite "Generate SBOM" step captures
+  stdout only (`loom_stdout=$(loom "${loom_args[@]}" | tee /dev/stderr)`);
+  a `loom`-emitted `WARNING:`/`ERROR:` (e.g. artifact-metadata truncation,
+  see [metadata-provenance.md](../implementation/provenance/metadata-provenance.md))
+  goes to the raw job log only, not the workflow-run summary or PR
+  "Files changed" view (`::warning::`/`::error::` workflow commands).
+  A synchronous `2>`-redirect-to-file approach is race-free but drops
+  real-time log streaming; a `tee`-based approach needs a provably
+  race-free wait, not just bash's default process-substitution
+  behavior. Needs a design pass on that trade-off before implementing.
+  Already done for AI-agent Skills -- see
+  [agent-skill.md](../implementation/agent-skill.md#relaying-warningerror-stderr-to-the-user).
 
 ## Near-term
 

--- a/working-docs/implementation/agent-skill.md
+++ b/working-docs/implementation/agent-skill.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-07-05
-Last-Modified: 2026-08-14
+Last-Modified: 2026-08-27
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -125,6 +125,20 @@ See `skills/sbom-generate/references/examples.md`,
 `skills/sbom-enrich/references/examples.md`, and
 `skills/sbom-validate/references/examples.md` for the exact commands and
 a full worked fragment example.
+
+### Relaying `WARNING:`/`ERROR:` stderr to the user
+
+`sbom-generate` and `sbom-enrich` both run `loom` directly (`sbom-validate`
+only wraps the separate `spdx3-validate` CLI, so it is out of scope
+here). `loom` logs to stderr with a grep-able `WARNING:`/`ERROR:` prefix
+(e.g. artifact-metadata truncation -- see
+[metadata-provenance.md](provenance/metadata-provenance.md)) that doesn't
+always fail the command or show up in the output JSON. Both SKILL.md
+files instruct the agent to scan captured stderr for these prefixes
+after running `loom` and relay any hit to the user in plain language,
+rather than letting it pass by unmentioned just because the command
+exited 0. This is the AI-agent-Skill equivalent of the GitHub Actions
+gap tracked in [roadmap.md](../design/roadmap.md#adoption-surfaces).
 
 ## Also available as a Claude Code plugin
 

--- a/working-docs/implementation/provenance/annotation-mechanism.md
+++ b/working-docs/implementation/provenance/annotation-mechanism.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-08-25
-Last-Modified: 2026-08-25
+Last-Modified: 2026-08-26
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -88,8 +88,15 @@ PEP 508 `declared_constraint`.
 - `preserve-source-metadata = "auto" | "always" | "never"` — default
   `"auto"` (preserve an AI model's verbatim metadata only when the artifact is
   not shipped in the distribution and can't be re-extracted).
+- `max-source-metadata-bytes = <int>` — default `0` (unlimited). Byte
+  budget for the serialized artifact-metadata `Annotation.statement`
+  (2026-08-26); unlike its siblings, also has a `--max-source-metadata-bytes`
+  CLI flag / `action.yml` input, resolved at the CLI layer via
+  `cli/commands/utils.resolve_effective_provenance()` rather than a new
+  per-hop parameter — see "Size-bounded artifact-metadata preservation"
+  below.
 
-Both parsed/validated in `core/config.py` (`_read_provenance_settings`),
+All parsed/validated in `core/_config_parse.py` (`_read_provenance_settings`),
 threaded through `build`/`build_model` and the `generate_*` / hatch-hook
 entry points exactly as `provenance_format`/`schema` already were.
 
@@ -107,12 +114,71 @@ consumer can dispatch mechanically without pattern-matching prose:
 
 Compound JSON keys use `camelCase`, matching the surrounding SPDX 3
 JSON-LD style already used everywhere in the same document (`spdxId`,
-`creationInfo`, `annotationType`). None of the four current schemas ends
-up needing a compound key — G2's `candidates` list settled on flat,
+`creationInfo`, `annotationType`). G2's `candidates` list settled on flat,
 single-word fields (`value`/`role`/`source`/`ref`) once it moved to an
 open candidate-list design instead of fixed `declaredLicenseId`-style
-pairs — but the convention is stated explicitly so the next schema that
-*does* need one (E1/E2, whenever `enrich/` lands) doesn't have to
-re-derive it. Established retroactively across all four schemas this
-session (none had shipped in a release yet, so no compatibility
-constraint).
+pairs, so none of the original four schemas needed a compound key at
+first — but the convention was stated explicitly so the next schema that
+*does* need one doesn't have to re-derive it. P1 (artifact-metadata) is
+that schema: its optional truncation marker fields (`truncated`,
+`truncatedKeys`, `truncatedKeyCount`, `maxMetadataBytes`) are the first
+to use it, added 2026-08-26 — see below. Established retroactively
+across all four original schemas in an earlier session (none had shipped
+in a release yet, so no compatibility constraint).
+
+### Size-bounded artifact-metadata preservation (2026-08-26)
+
+P1's `Annotation.statement` embeds an AI model's raw metadata verbatim
+with no inherent size limit — a real GGUF model's tokenizer vocab array
+can inflate it into the multi-megabyte range (previously an open,
+unimplemented gap — `working-docs/design/provenance-enrichment-vocabulary.md`
+open question #7). `max-source-metadata-bytes` (`ProvenanceConfig` field
+`max_source_metadata_bytes`, default `0` = unlimited) caps this.
+
+Truncation happens at the dictionary level only — whole `metadata` keys
+are dropped, largest-serialized-size first, never a value cut
+mid-string (which would produce invalid JSON). This is implemented in
+`assemble/spdx3/provenance.py`'s `_truncate_metadata_for_budget()`,
+re-checking the real RFC 8785-serialized byte length of the candidate
+envelope after each drop rather than approximating it — cheap at the
+realistic key counts here (a model's own KV/metadata table: dozens of
+keys, not thousands). When triggered, the envelope gains
+`truncated: true`, `truncatedKeys` (sorted alphabetically, regardless of
+drop order), `truncatedKeyCount`, and `maxMetadataBytes` — an explicit,
+visible marker, never a silent size reduction. Two edge cases: if
+dropping every key still leaves the envelope's own fixed overhead
+(schema/kind/format/markers) over budget, no Annotation is emitted at
+all (`build_source_metadata_annotation()` returns `None`, same as
+today's "empty original metadata" case); if the overhead fits but every
+key had to go, the Annotation is emitted with `metadata: {}`. Both log a
+`WARNING`.
+
+A negative or too-small-to-hold-data value (below `_MIN_EFFECTIVE_
+MAX_SOURCE_METADATA_BYTES`, 8 bytes — the smallest possible JCS-encoded
+JSON object, e.g. `{"a":""}`) is normalized to `0` (unlimited) with a
+logged `WARNING`, via `core/provenance.normalize_max_source_metadata_bytes()`
+— called from both the TOML reader and the CLI-override path, so every
+construction route gets the same treatment.
+
+Unlike every other `[tool.pitloom.provenance]` key, this one also has a
+`--max-source-metadata-bytes` CLI flag and `action.yml` input — a byte
+cap is judged an operational knob worth overriding per-run, unlike the
+project-level policy choices the other keys represent. Resolved at the
+CLI layer (`cli/commands/utils.resolve_effective_provenance()`, composing
+a `dataclasses.replace()` onto the config-sourced `ProvenanceConfig`
+before it's ever passed into the assembly pipeline) rather than adding a
+new parameter at every hop the way `content_type_method` does — since
+`ProvenanceConfig` already flows through `generate_project_sbom()` →
+`build()` → `add_ai_models()` as one opaque object, no per-hop threading
+was needed.
+
+**Also 2026-08-26**: `_build_json_annotation()` (shared by all four
+schemas) switched from plain `json.dumps(..., sort_keys=True)` to true
+RFC 8785 (JCS) canonicalization (`rfc8785.dumps()`, already a project
+dependency, used for the outer document). Every `Annotation.statement`
+is now genuinely canonical, not just key-sorted — no insignificant
+whitespace, so every statement also shrank a little for free.
+`_sanitize_for_json()`'s fallback for unrecognized types (`np.float32`,
+`Decimal`, etc.) changed from relying on `json.dumps`'s `default=str`
+hook (which `rfc8785.dumps()` has no equivalent of) to stringifying them
+itself before the value ever reaches the serializer.

--- a/working-docs/implementation/provenance/metadata-provenance.md
+++ b/working-docs/implementation/provenance/metadata-provenance.md
@@ -1,6 +1,6 @@
 ---
 Created: 2026-02-07
-Last-Modified: 2026-08-14
+Last-Modified: 2026-08-26
 SPDX-FileCopyrightText: 2026-present Arthit Suriyawongkul
 SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: CC0-1.0
@@ -10,8 +10,9 @@ SPDX-License-Identifier: CC0-1.0
 
 See [annotation-provenance.md](annotation-provenance.md) for the full
 design history and [provenance-enrichment-vocabulary.md](../../design/provenance-enrichment-vocabulary.md)
-for still-open questions (CreationInfo future enhancements, the unbounded
-artifact-metadata-blob question). The user-facing explainer lives at
+for still-open questions (CreationInfo future enhancements; the
+unbounded artifact-metadata-blob question was resolved 2026-08-26 -- see
+below). The user-facing explainer lives at
 [docs/metadata-provenance.md](../../../docs/metadata-provenance.md) and
 [docs/creation-metadata.md](../../../docs/creation-metadata.md).
 
@@ -79,21 +80,24 @@ the model is not shipped and can't be re-extracted). See §10 of the
 implementation plan for the use-case catalog and the Phase 2 native-backfill
 checklist.
 
-**Known limitation, not yet fixed:** artifact-metadata preservation
-(`_source_metadata_blob()`/`_emit_source_metadata()` in
-`src/pitloom/assemble/spdx3/ai.py`) embeds an AI model's raw metadata
-**verbatim, with no size cap**, into a single `Annotation.statement`. For
-the small fixtures this repo tests against, that's a few KB at most; for
-a real production model with a large vocabulary (e.g. a GGUF LLM's
-32K-128K+ token list), the same field could inflate a single Annotation
-into the multi-megabyte range. SPDX 3.0.1's `statement` is plain
-`xsd:string` with no spec-mandated limit, so this isn't a spec
-violation, but it's an untested scalability gap for realistic models
-(found by independent review). The right behavior (drop oversized fields
-entirely? truncate with a marker? move to an external reference?) is
-still an open design question -- see
+**Size, bounded (2026-08-26):** artifact-metadata preservation
+(`_source_metadata_blob()` in `src/pitloom/assemble/spdx3/_ai_package.py`,
+`build_source_metadata_annotation()` in
+`src/pitloom/assemble/spdx3/provenance.py`) embeds an AI model's raw
+metadata verbatim into a single `Annotation.statement` -- for a real
+production model with a large vocabulary (e.g. a GGUF LLM's 32K-128K+
+token list), that field alone could inflate a single Annotation into the
+multi-megabyte range. `[tool.pitloom.provenance] max-source-metadata-bytes`
+(default `0`, unlimited -- unchanged behavior unless a project opts in)
+now caps the serialized statement's size: whole `metadata` keys are
+dropped, largest first, and the reduction is marked explicitly
+(`truncated`/`truncatedKeys`/`truncatedKeyCount`/`maxMetadataBytes`)
+rather than silently losing data. See
+[annotation-mechanism.md](annotation-mechanism.md)'s "Size-bounded
+artifact-metadata preservation" section for the full algorithm and edge
+cases. Previously an open design question (see
 [provenance-enrichment-vocabulary.md](../../design/provenance-enrichment-vocabulary.md)'s
-"Open questions" list.
+open question #7, now marked resolved).
 
 Controlled by `[tool.pitloom.provenance]` in `pyproject.toml`:
 

--- a/working-docs/implementation/provenance/use-case-catalog.md
+++ b/working-docs/implementation/provenance/use-case-catalog.md
@@ -71,22 +71,22 @@ checklist (N1-N6). G2's own implementation depth lives separately in
   which is itself evidence the role is "preserve what would otherwise be
   lost," not "hold a property."
 
-  **Known limitation (unbounded statement size):** the P1 blob embeds
-  `raw_metadata` verbatim with no size cap. Pitloom's own GGUF/safetensors
-  test fixtures are small ("vocab-only" stubs, ~4 KB statements), but a
-  production LLM's GGUF kv-store can carry a 32K–128K-entry tokenizer vocab
-  (plus parallel `scores`/`token_type` arrays) in the same field, which would
-  inflate a single `Annotation.statement` into the multi-megabyte range.
-  SPDX 3.0.1's `statement` is a plain `xsd:string` with no spec-mandated
-  limit, so this isn't a compliance violation, just a real scale gap not
-  exercised by the current test suite. No truncation heuristic is applied
-  here deliberately — silently cutting array data would make "verbatim
-  preservation" dishonest about what was actually preserved, which defeats
-  P1's purpose more than the size cost does. For large models, set
-  `preserve-source-metadata = "never"` (or leave the default `"auto"`, which
-  already skips preservation for any model that *is* shipped and thus
-  re-extractable). A future fix, if needed, should truncate with an explicit,
-  visible marker (e.g. `"_truncated": true`) rather than cutting silently.
+  **Statement size, bounded (2026-08-26, resolved):** the P1 blob embeds
+  `raw_metadata` verbatim, and a production LLM's GGUF kv-store can carry a
+  32K–128K-entry tokenizer vocab (plus parallel `scores`/`token_type`
+  arrays) in a single field — unbounded, that would inflate a single
+  `Annotation.statement` into the multi-megabyte range. SPDX 3.0.1's
+  `statement` is a plain `xsd:string` with no spec-mandated limit, so this
+  was never a compliance violation, just a real scale gap. `[tool.pitloom.
+  provenance] max-source-metadata-bytes` (default `0`, unlimited —
+  unchanged behavior for existing users) now caps it: whole `metadata`
+  keys are dropped, largest first, never a value cut mid-string, and the
+  result carries an explicit `truncated`/`truncatedKeys`/
+  `truncatedKeyCount`/`maxMetadataBytes` marker rather than silently
+  losing data — see [annotation-mechanism.md](annotation-mechanism.md)'s
+  "Size-bounded artifact-metadata preservation" section for the full
+  design. `preserve-source-metadata = "never"` (or the size cap set to a
+  small budget) both remain valid ways to keep a large model's SBOM small.
 
 ## Phase 2 (documented; built after this Annotation work): native-first backfill
 


### PR DESCRIPTION
## Summary

- Serialize every Annotation.statement via RFC 8785 (JCS), not plain JSON — smaller, spec-compliant output
- Add `max-source-metadata-bytes` config/CLI/Action cap on artifact-metadata blobs; truncates largest keys first, marks the result explicitly
- Default `0` (unlimited) — no behavior change unless opted in

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [x] Tests pass (`pytest`)
- [x] Code formatted (`ruff format`)
- [x] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [x] `CHANGELOG.md` updated (if user-facing)
- [x] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
