### PR TITLE
Only declare simpleLicensing when a real claim exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,10 @@ and this project adheres to
 ### Added
 
 - Serialize every Annotation's `statement` via RFC 8785 (JSON
-  Canonicalization Scheme) instead of plain JSON, shrinking the output
-  and closing a spec-compliance gap
+  Canonicalization Scheme) ([#189])
 - Cap artifact-metadata `Annotation.statement` size via
   `[tool.pitloom.provenance] max-source-metadata-bytes` /
-  `--max-source-metadata-bytes`; truncates by dropping the largest
-  metadata keys first and marks the result with
-  `truncated`/`truncatedKeys`/`maxMetadataBytes`
+  `--max-source-metadata-bytes` ([#189])
 
 ### Changed
 
@@ -39,9 +36,13 @@ and this project adheres to
 ### Fixed
 
 - Prune two unreachable branches in `_setuptools_cfg.py` ([#188])
+- Only declare the `simpleLicensing` profile when a real license claim was
+  made ([#190])
 
 [#187]: https://github.com/bact/pitloom/pull/187
 [#188]: https://github.com/bact/pitloom/pull/188
+[#189]: https://github.com/bact/pitloom/pull/189
+[#190]: https://github.com/bact/pitloom/pull/190
 
 ## [0.16.4] - 2026-08-21
 

--- a/src/pitloom/assemble/spdx3/document.py
+++ b/src/pitloom/assemble/spdx3/document.py
@@ -266,11 +266,11 @@ def build(
             provenance_config=prov_cfg,
             encoder=encoder,
         )
-    # TODO: appended unconditionally even when NOASSERTION was the only
-    # outcome above -- should only fire when a real license/copyright
-    # claim was actually made, matching the AI-models check below (see
-    # line 317).
-    spdx_doc.profileConformance.append(spdx3.ProfileIdentifierType.simpleLicensing)
+    # Only fires when a real license claim was made above, matching the
+    # AI-models check below (see line 316) -- NOASSERTION alone doesn't
+    # warrant declaring the simpleLicensing profile.
+    if metadata.license_name:
+        spdx_doc.profileConformance.append(spdx3.ProfileIdentifierType.simpleLicensing)
 
     # --- Dependencies ---
     add_dependencies(

--- a/src/pitloom/assemble/spdx3/document.py
+++ b/src/pitloom/assemble/spdx3/document.py
@@ -230,6 +230,7 @@ def build(
 
     # --- License ---
     if metadata.license_name:
+        spdx_doc.profileConformance.append(spdx3.ProfileIdentifierType.simpleLicensing)
         rel_declared, rel_concluded = build_license_elements(
             license_id=metadata.license_name,
             package_spdx_id=require_spdx_id(main_package),
@@ -266,11 +267,6 @@ def build(
             provenance_config=prov_cfg,
             encoder=encoder,
         )
-    # Only fires when a real license claim was made above, matching the
-    # AI-models check below (see line 316) -- NOASSERTION alone doesn't
-    # warrant declaring the simpleLicensing profile.
-    if metadata.license_name:
-        spdx_doc.profileConformance.append(spdx3.ProfileIdentifierType.simpleLicensing)
 
     # --- Dependencies ---
     add_dependencies(

--- a/tests/core/test_generator_project_structure.py
+++ b/tests/core/test_generator_project_structure.py
@@ -168,7 +168,7 @@ def test_build_main_package_noassertion_license_when_undeclared() -> None:
     assert license_rels[0]["to"] == [noassertion["spdxId"]]
 
     spdx_docs = [e for e in graph if e.get("type") == "SpdxDocument"]
-    assert "simpleLicensing" in spdx_docs[0]["profileConformance"]
+    assert "simpleLicensing" not in spdx_docs[0]["profileConformance"]
 
 
 def test_generate_project_sbom_with_fragments() -> None:


### PR DESCRIPTION
## Summary

`simpleLicensing` profile is now appended only when a real license was declared, not for NOASSERTION-only outcomes — matches the existing AI-models guard. Closes a coverage gap too.

## Related issue

<!-- Closes #... , or "N/A" -->

## Checklist

- [ ] Tests pass (`pytest`)
- [ ] Code formatted (`ruff format`)
- [ ] Lints pass
      (`ruff check src/ tests/`,
      `pylint src/ tests`,
      `mypy examples/ src/ tests/`,
      `pyright examples/ src/ tests/`,
      `pyrefly check examples/ src/ tests/`)
- [ ] `CHANGELOG.md` updated (if user-facing)
- [ ] Docs updated (`README.md` / `working-docs/` / `docs/`, if applicable)
- [x] Commits are signed off (`git commit -s`) -- see
      [CONTRIBUTING.md](../CONTRIBUTING.md#sign-off-dco)
